### PR TITLE
Dev Command updated to work for Windows OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ npm run dev
 
 Storefront can be now accessed at http://localhost:3001/.
 
+(If you are using windows, change the "dev" command in package.json from "PORT=3001 next dev" to "next dev --port 3001")
+
 ## Development
 
 ### Configuration


### PR DESCRIPTION
I got an error while running the "dev" command on my windows machine. Making this simple change in "package.json" fixes the issue