### PR TITLE
Dns prefetch to the Saleor API

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import "styles/globals.css";
 import { ApolloProvider } from "@apollo/client";
 import { NextPage } from "next";
 import { AppProps } from "next/app";
+import Head from "next/head";
 import React, { ReactElement, ReactNode } from "react";
 
 import RegionsProvider from "@/components/RegionsProvider";
@@ -21,13 +22,28 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   const getLayout = Component.getLayout ?? ((page: ReactElement) => page);
 
   return (
-    <RegionsProvider>
-      <ApolloProvider client={apolloClient}>
-        <SaleorProviderWithChannels>
-          {getLayout(<Component {...pageProps} />)}
-        </SaleorProviderWithChannels>
-      </ApolloProvider>
-    </RegionsProvider>
+    <>
+      <Head>
+        {/*
+          Adding preconnect/dns-prefetch allow us to not wait for dns resolving
+          when contacting the Saleor API for the first time.
+          https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
+        */}
+        <link
+          rel="preconnect"
+          href={process.env.NEXT_PUBLIC_API_URI}
+          crossOrigin="true"
+        />
+        <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_API_URI} />
+      </Head>
+      <RegionsProvider>
+        <ApolloProvider client={apolloClient}>
+          <SaleorProviderWithChannels>
+            {getLayout(<Component {...pageProps} />)}
+          </SaleorProviderWithChannels>
+        </ApolloProvider>
+      </RegionsProvider>
+    </>
   );
 };
 


### PR DESCRIPTION
Before the first Saleor API call dns needs to be resolved. Preconnect allow us to do that before JS will launch its queries.