### PR TITLE
Configurable homepage, changed variant selector, bugfixes

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URI=https://vercel.saleor.cloud/graphql/
 NEXT_PUBLIC_DEFAULT_CHANNEL=default-channel
+NEXT_PUBLIC_HOMEPAGE_MENU=homepage
 NEXT_PUBLIC_VERCEL_URL=https://localhost:3001
 NEXT_PUBLIC_DEMO_MODE=false

--- a/components/checkout/payments/DummyCreditCardSection.tsx
+++ b/components/checkout/payments/DummyCreditCardSection.tsx
@@ -5,6 +5,7 @@ import { useIntl } from "react-intl";
 
 import { useRegions } from "@/components/RegionsProvider";
 import { messages } from "@/components/translations";
+import { DEMO_MODE } from "@/lib/const";
 import { usePaths } from "@/lib/paths";
 import { useCheckout } from "@/lib/providers/CheckoutProvider";
 import {
@@ -42,6 +43,14 @@ export const DummyCreditCardSection = ({
   const payLabel = t.formatMessage(messages.paymentButton, {
     total: formatPrice(totalPrice),
   });
+
+  let defaultValues = DEMO_MODE
+    ? {
+        cardNumber: "4242 4242 4242 4242",
+        expDate: "12/34",
+        cvc: "123",
+      }
+    : {};
 
   const {
     register: registerCard,

--- a/components/checkout/payments/DummyCreditCardSection.tsx
+++ b/components/checkout/payments/DummyCreditCardSection.tsx
@@ -44,7 +44,7 @@ export const DummyCreditCardSection = ({
     total: formatPrice(totalPrice),
   });
 
-  let defaultValues = DEMO_MODE
+  const defaultValues = DEMO_MODE
     ? {
         cardNumber: "4242 4242 4242 4242",
         expDate: "12/34",

--- a/components/checkout/payments/DummyCreditCardSection.tsx
+++ b/components/checkout/payments/DummyCreditCardSection.tsx
@@ -57,12 +57,12 @@ export const DummyCreditCardSection = ({
     handleSubmit: handleSubmitCard,
     formState: { errors: errorsAddress },
     setError: setErrorCard,
-  } = useForm<CardForm>({});
+  } = useForm<CardForm>({ defaultValues });
 
-  const redirectToOrderDetailsPage = () => {
+  const redirectToOrderDetailsPage = async () => {
+    // without the `await` checkout data will be removed before the redirection which will cause issue with rendering checkout view
+    await router.push(paths.order.$url());
     resetCheckoutToken();
-
-    router.push(paths.order.$url());
   };
 
   const handleSubmit = handleSubmitCard(async (formData: CardForm) => {

--- a/components/checkout/payments/StripeCreditCardSection.tsx
+++ b/components/checkout/payments/StripeCreditCardSection.tsx
@@ -65,7 +65,7 @@ const StripeCardForm = ({ checkout }: StripeCardFormInterface) => {
       type: "card",
       card: cardElement,
       billing_details: {
-        email: checkout.email,
+        email: checkout.email!,
         phone: checkout.billingAddress?.phone || "",
         name: `${checkout.billingAddress?.firstName} ${checkout.billingAddress?.lastName}`,
         address: {

--- a/components/product/VariantSelector.tsx
+++ b/components/product/VariantSelector.tsx
@@ -27,8 +27,8 @@ export const VariantSelector = ({
     return null;
   }
 
-  const onChange = (event: React.FormEvent<HTMLSelectElement>) => {
-    const target = event.target as HTMLSelectElement;
+  const onChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const target = event.target;
     setValue(target.value);
     let query = {};
     if (target.value !== "None") {

--- a/components/product/VariantSelector.tsx
+++ b/components/product/VariantSelector.tsx
@@ -1,6 +1,5 @@
-import clsx from "clsx";
-import Link from "next/link";
-import React from "react";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
 
 import { usePaths } from "@/lib/paths";
 import { translate } from "@/lib/translations";
@@ -17,40 +16,47 @@ export const VariantSelector = ({
   selectedVariantID,
 }: VariantSelectorProps) => {
   const paths = usePaths();
+  const router = useRouter();
+
+  const [value, setValue] = useState(selectedVariantID);
 
   const variants = product.variants;
+
+  // Skip displaying selector when theres less than 2 variants
   if (!variants || variants.length === 1) {
     return null;
   }
+
+  const onChange = (event: React.FormEvent<HTMLSelectElement>) => {
+    const target = event.target as HTMLSelectElement;
+    setValue(target.value);
+    let query = {};
+    if (target.value !== "None") {
+      query = { variant: target.value };
+    }
+    router.replace(
+      paths.products._slug(product.slug).$url({ query }),
+      undefined,
+      { shallow: true }
+    );
+  };
+
   return (
-    <div className="grid grid-cols-8 gap-2">
+    <select onChange={onChange} value={value} className="w-full">
+      <option key="None" value="None">
+        -
+      </option>
       {variants.map((variant) => {
         if (!notNullable(variant)) {
           return null;
         }
-        const isSelected = variant.id === selectedVariantID;
         return (
-          <Link
-            key={translate(variant, "name")}
-            href={paths.products
-              ._slug(product.slug)
-              .$url({ query: { variant: variant.id } })}
-            replace
-            shallow
-          >
-            <a
-              className={clsx(
-                "flex justify-center  rounded-md p-3 font-semibold hover:border-blue-400 shadow-md",
-                isSelected && "border-2 border-blue-300 bg-blue-300",
-                !isSelected && "border-2 border-gray-300"
-              )}
-            >
-              {translate(variant, "name")}
-            </a>
-          </Link>
+          <option key={variant.id} value={variant.id}>
+            {translate(variant, "name")}
+          </option>
         );
       })}
-    </div>
+    </select>
   );
 };
 

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -35,7 +35,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "address",
@@ -118,7 +118,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "address",
@@ -201,7 +201,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "address",
@@ -284,7 +284,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -698,7 +698,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -789,11 +789,35 @@
             "deprecationReason": null
           },
           {
+            "name": "firstName",
+            "description": "Given name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "languageCode",
             "description": "User language code.",
             "type": {
               "kind": "ENUM",
               "name": "LanguageCodeEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": "Family name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -880,7 +904,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -939,7 +963,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -1010,7 +1034,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -1157,7 +1181,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1310,7 +1334,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "address",
@@ -1393,7 +1417,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "address",
@@ -1619,7 +1643,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -1713,7 +1737,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "address",
@@ -2023,7 +2047,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2171,6 +2195,30 @@
             "deprecationReason": null
           },
           {
+            "name": "extensions",
+            "description": "New in Saleor 3.1. App's dashboard extensions. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppExtension",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "homepageUrl",
             "description": "Homepage of the app.",
             "args": [],
@@ -2184,7 +2232,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2402,7 +2450,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -2579,7 +2627,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "authToken",
@@ -2662,7 +2710,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -2733,7 +2781,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -2792,7 +2840,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "appInstallation",
@@ -2998,6 +3046,388 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppExtension",
+        "description": "Represents app data.",
+        "fields": [
+          {
+            "name": "accessToken",
+            "description": "JWT token used to authenticate by thridparty app extension.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "Label of the extension to show in the dashboard.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mount",
+            "description": "Place where given extension will be mounted.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppExtensionMountEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissions",
+            "description": "List of the app extension's permissions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Permission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "target",
+            "description": "Type of way how app extension will be opened.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppExtensionTargetEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "URL of a view where extension's iframe is placed.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppExtensionCountableConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppExtensionCountableEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Pagination data for this connection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "A total count of items in the collection.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppExtensionCountableEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The item at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppExtension",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppExtensionFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "mount",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppExtensionMountEnum",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "target",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppExtensionTargetEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppExtensionMountEnum",
+        "description": "All places where app extension can be mounted.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "NAVIGATION_CATALOG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAVIGATION_CUSTOMERS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAVIGATION_DISCOUNTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAVIGATION_ORDERS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAVIGATION_PAGES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAVIGATION_TRANSLATIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_DETAILS_MORE_ACTIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_OVERVIEW_CREATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_OVERVIEW_MORE_ACTIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppExtensionTargetEnum",
+        "description": "All available ways of opening an app extension.\n\n    POPUP - app's extension will be mounted as a popup window\n    APP_PAGE - redirect to app's page\n    ",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "APP_PAGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POPUP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppFetchManifest",
         "description": "Fetch and validate manifest.",
         "fields": [
@@ -3023,7 +3453,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -3180,7 +3610,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "appInstallation",
@@ -3326,7 +3756,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3419,6 +3849,105 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppManifestExtension",
+        "description": null,
+        "fields": [
+          {
+            "name": "label",
+            "description": "Label of the extension to show in the dashboard.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mount",
+            "description": "Place where given extension will be mounted.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppExtensionMountEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissions",
+            "description": "List of the app extension's permissions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Permission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "target",
+            "description": "Type of way how app extension will be opened.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppExtensionTargetEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "URL of a view where extension's iframe is placed.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppRetryInstall",
         "description": "Retry failed installation of new app.",
         "fields": [
@@ -3444,7 +3973,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "appInstallation",
@@ -3573,7 +4102,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3638,7 +4167,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "appToken",
@@ -3721,7 +4250,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "appToken",
@@ -3831,7 +4360,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -3941,7 +4470,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -4083,7 +4612,50 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AssignedVariantAttribute",
+        "description": "New in Saleor 3.1. Represents assigned attribute to variant with variant selection attached.",
+        "fields": [
+          {
+            "name": "attribute",
+            "description": "Attribute assigned to variant.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Attribute",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variantSelection",
+            "description": "Determines, whether assigned attribute is allowed for variant selection. Supported variant types for variant selection are: ['dropdown', 'boolean', 'swatch', 'numeric']",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4243,7 +4815,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4327,7 +4899,7 @@
             "args": [
               {
                 "name": "after",
-                "description": null,
+                "description": "Return the elements in the list that come after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4339,7 +4911,7 @@
               },
               {
                 "name": "before",
-                "description": null,
+                "description": "Return the elements in the list that come before the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4351,7 +4923,7 @@
               },
               {
                 "name": "first",
-                "description": null,
+                "description": "Return the first n elements from the list.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4363,7 +4935,7 @@
               },
               {
                 "name": "last",
-                "description": null,
+                "description": "Return the last n elements from the list.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4392,7 +4964,7 @@
             "args": [
               {
                 "name": "after",
-                "description": null,
+                "description": "Return the elements in the list that come after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4404,7 +4976,7 @@
               },
               {
                 "name": "before",
-                "description": null,
+                "description": "Return the elements in the list that come before the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4416,7 +4988,7 @@
               },
               {
                 "name": "first",
-                "description": null,
+                "description": "Return the first n elements from the list.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4428,7 +5000,7 @@
               },
               {
                 "name": "last",
-                "description": null,
+                "description": "Return the last n elements from the list.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4624,7 +5196,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "count",
@@ -4883,7 +5455,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -5145,7 +5717,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -5318,7 +5890,7 @@
           },
           {
             "name": "channel",
-            "description": "Specifies the channel by which the data should be filtered. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel by which the data should be filtered. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -5625,6 +6197,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "SWATCH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -5668,7 +6246,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -5823,11 +6401,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5961,7 +6539,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -5976,7 +6554,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6096,7 +6674,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -6142,7 +6720,7 @@
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
-                "name": "AttributeValueCreateInput",
+                "name": "AttributeValueUpdateInput",
                 "ofType": null
               }
             },
@@ -6346,7 +6924,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6451,7 +7029,7 @@
           },
           {
             "name": "value",
-            "description": "Represents the value of the attribute value.",
+            "description": "Represent value of the attribute value (e.g. color values for swatch attributes).",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6500,7 +7078,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "count",
@@ -6693,7 +7271,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "attributeValue",
@@ -6744,6 +7322,30 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "contentType",
+            "description": "File content type.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileUrl",
+            "description": "URL of the file attribute. Every time, a new value is created.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": "Name of a value displayed in the interface.",
             "type": {
@@ -6773,7 +7375,7 @@
           },
           {
             "name": "value",
-            "description": "Represents the value of the attribute value.",
+            "description": "Represent value of the attribute value (e.g. color values for swatch attributes).",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6827,7 +7429,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "attributeValue",
@@ -7044,11 +7646,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7194,7 +7796,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -7209,7 +7811,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7353,7 +7955,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "attributeValue",
@@ -7394,6 +7996,77 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AttributeValueUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "contentType",
+            "description": "File content type.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileUrl",
+            "description": "URL of the file attribute. Every time, a new value is created.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Name of a value displayed in the interface.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "richText",
+            "description": "Represents the text (JSON) of the attribute value.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONString",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "Represent value of the attribute value (e.g. color values for swatch attributes).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -7819,7 +8492,7 @@
           },
           {
             "name": "variants",
-            "description": "Product variant related to the discount.",
+            "description": "New in Saleor 3.1. Product variant related to the discount.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -8012,11 +8685,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8340,7 +9013,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -8517,7 +9190,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -8588,7 +9261,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -8771,7 +9444,7 @@
         "inputFields": [
           {
             "name": "channel",
-            "description": "Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel in which to sort the data. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8833,7 +9506,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "description",
@@ -8857,11 +9530,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -9019,7 +9692,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -9054,11 +9727,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -9199,7 +9872,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -9230,7 +9903,7 @@
           },
           {
             "name": "defaultCountry",
-            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.",
+            "description": "New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -9262,7 +9935,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -9375,7 +10048,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -9446,7 +10119,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -9522,7 +10195,7 @@
           },
           {
             "name": "defaultCountry",
-            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.",
+            "description": "New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9624,7 +10297,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -9695,7 +10368,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -9929,7 +10602,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -9989,7 +10662,7 @@
           },
           {
             "name": "defaultCountry",
-            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.",
+            "description": "New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.",
             "type": {
               "kind": "ENUM",
               "name": "CountryCode",
@@ -10066,6 +10739,30 @@
         "description": "Checkout object.",
         "fields": [
           {
+            "name": "availableCollectionPoints",
+            "description": "New in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Warehouse",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "availablePaymentGateways",
             "description": "List of available payment gateways.",
             "args": [],
@@ -10107,7 +10804,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use `shippingMethods`, this field will be removed in 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `shippingMethods` instead."
           },
           {
             "name": "billingAddress",
@@ -10154,6 +10851,18 @@
             "deprecationReason": null
           },
           {
+            "name": "deliveryMethod",
+            "description": "New in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "DeliveryMethod",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "discount",
             "description": null,
             "args": [],
@@ -10182,13 +10891,9 @@
             "description": "Email of a customer.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -10211,7 +10916,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -10382,8 +11087,8 @@
               "name": "ShippingMethod",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `deliveryMethod` instead."
           },
           {
             "name": "shippingMethods",
@@ -10412,6 +11117,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "TaxedMoney",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stockReservationExpires",
+            "description": "New in Saleor 3.1. Date when oldest stock reservation for this checkout  expires or null if no stock is reserved.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,
@@ -10549,7 +11266,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -10620,7 +11337,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -10679,7 +11396,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "confirmationData",
@@ -10896,19 +11613,19 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "created",
-            "description": "Whether the checkout was created or the current active one was returned. Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart with an active checkout.DEPRECATED: Will be removed in Saleor 4.0. Always returns True.",
+            "description": "Whether the checkout was created or the current active one was returned. Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart with an active checkout.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Always returns `true`."
           },
           {
             "name": "errors",
@@ -11070,7 +11787,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -11141,7 +11858,54 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
+          },
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CheckoutError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CheckoutDeliveryMethodUpdate",
+        "description": "New in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "checkout",
+            "description": "An updated checkout.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Checkout",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "errors",
@@ -11212,7 +11976,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -11374,6 +12138,24 @@
             "deprecationReason": null
           },
           {
+            "name": "DELIVERY_METHOD_NOT_APPLICABLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EMAIL_NOT_SET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GIFT_CARD_NOT_APPLICABLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "GRAPHQL_ERROR",
             "description": null,
             "isDeprecated": false,
@@ -11503,6 +12285,85 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channels",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateRangeInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customer",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "MetadataFilter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "search",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "CheckoutLanguageCodeUpdate",
         "description": "Update language code in the existing checkout.",
@@ -11541,7 +12402,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -11580,7 +12441,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11807,7 +12668,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -11921,7 +12782,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -12039,7 +12900,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -12146,7 +13007,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -12193,7 +13054,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -12264,7 +13125,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -12335,7 +13196,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -12364,6 +13225,78 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CheckoutSortField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CREATION_DATE",
+            "description": "Sort checkouts by creation date.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOMER",
+            "description": "Sort checkouts by customer.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT",
+            "description": "Sort checkouts by payment.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutSortingInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": "Specifies the direction in which to sort products.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Sort checkouts by the selected field.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CheckoutSortField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -12486,11 +13419,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -12770,7 +13703,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -12829,7 +13762,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "count",
@@ -12900,7 +13833,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -13104,7 +14037,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -13332,7 +14265,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -13526,7 +14459,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -13690,7 +14623,7 @@
         "inputFields": [
           {
             "name": "channel",
-            "description": "Specifies the channel by which the data should be filtered. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel by which the data should be filtered. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13930,7 +14863,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -14001,7 +14934,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -14076,7 +15009,7 @@
         "inputFields": [
           {
             "name": "channel",
-            "description": "Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel in which to sort the data. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14138,7 +15071,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "description",
@@ -14162,11 +15095,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -14324,7 +15257,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -14359,11 +15292,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -14480,7 +15413,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -14706,7 +15639,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -14777,7 +15710,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -16437,7 +17370,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "csrfToken",
@@ -16623,7 +17556,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "count",
@@ -16698,7 +17631,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -16769,7 +17702,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -16856,7 +17789,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17100,6 +18033,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateTimeRangeInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -17240,7 +18185,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -17401,7 +18346,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -17496,7 +18441,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -17567,13 +18512,34 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "DeliveryMethod",
+        "description": "New in Saleor 3.1. Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as \"click and collect\" and `ShippingMethod` otherwise. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "ShippingMethod",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Warehouse",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "OBJECT",
@@ -17614,7 +18580,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17926,7 +18892,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "variant",
@@ -17997,7 +18963,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "variant",
@@ -18143,7 +19109,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "variant",
@@ -18297,7 +19263,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18414,7 +19380,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -18824,7 +19790,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -18895,7 +19861,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -18966,7 +19932,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -19184,7 +20150,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -19390,7 +20356,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -19461,12 +20427,746 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDelivery",
+        "description": "Event delivery.",
+        "fields": [
+          {
+            "name": "attempts",
+            "description": "Event delivery attempts.",
+            "args": [
+              {
+                "name": "after",
+                "description": "Return the elements in the list that come after the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Return the elements in the list that come before the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Return the first n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Return the last n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortBy",
+                "description": "Event delivery sorter",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EventDeliveryAttemptSortingInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EventDeliveryAttemptCountableConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventType",
+            "description": "Webhook event type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WebhookEventTypeEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payload",
+            "description": "Event payload.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "Event delivery status.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EventDeliveryStatusEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDeliveryAttempt",
+        "description": "Event delivery attempts.",
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": "Event delivery creation date and time.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "duration",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestHeaders",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "response",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "responseHeaders",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "Event delivery status.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EventDeliveryStatusEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "taskId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDeliveryAttemptCountableConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EventDeliveryAttemptCountableEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Pagination data for this connection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "A total count of items in the collection.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDeliveryAttemptCountableEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The item at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EventDeliveryAttempt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EventDeliveryAttemptSortField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CREATED_AT",
+            "description": "Sort event delivery attempts by created at.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EventDeliveryAttemptSortingInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": "Specifies the direction in which to sort products.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Sort attempts by the selected field.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EventDeliveryAttemptSortField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDeliveryCountableConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EventDeliveryCountableEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Pagination data for this connection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "A total count of items in the collection.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDeliveryCountableEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The item at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EventDelivery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EventDeliveryFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eventType",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WebhookEventTypeEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "EventDeliveryStatusEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventDeliveryRetry",
+        "description": "Retries event delivery.",
+        "fields": [
+          {
+            "name": "delivery",
+            "description": "Event delivery.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EventDelivery",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WebhookError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EventDeliverySortField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CREATED_AT",
+            "description": "Sort event deliveries by created at.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EventDeliverySortingInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": "Specifies the direction in which to sort products.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Sort deliveries by the selected field.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EventDeliverySortField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EventDeliveryStatusEnum",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "FAILED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUCCESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -19762,7 +21462,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -20048,19 +21748,25 @@
         "enumValues": [
           {
             "name": "CREATED_AT",
-            "description": "Sort export file by created at.",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LAST_MODIFIED_AT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "STATUS",
-            "description": "Sort export file by status.",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UPDATED_AT",
-            "description": "Sort export file by updated at.",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -20098,6 +21804,128 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "ExportFileSortField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExportGiftCards",
+        "description": "New in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ExportError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exportFile",
+            "description": "The newly created export file job which is responsible for export data.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExportFile",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ExportGiftCardsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "fileType",
+            "description": "Type of exported file.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "FileTypesEnum",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "filter",
+            "description": "Filtering options for gift cards.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "GiftCardFilterInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ids",
+            "description": "List of gift cards IDs to export.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scope",
+            "description": "Determine which gift cards should be exported.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ExportScope",
                 "ofType": null
               }
             },
@@ -20252,7 +22080,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "exportFile",
@@ -20320,7 +22148,7 @@
           },
           {
             "name": "ids",
-            "description": "List of products IDS to export.",
+            "description": "List of products IDs to export.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -20454,7 +22282,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "authenticationData",
@@ -20525,7 +22353,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -20571,6 +22399,186 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ExternalNotificationError",
+        "description": null,
+        "fields": [
+          {
+            "name": "code",
+            "description": "The error code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ExternalNotificationErrorCodes",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "The error message.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ExternalNotificationErrorCodes",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CHANNEL_INACTIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVALID_MODEL_TYPE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_FOUND",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REQUIRED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExternalNotificationTrigger",
+        "description": "New in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ExternalNotificationError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ExternalNotificationTriggerInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "externalEventType",
+            "description": "External event type. This field is passed to a plugin as an event type.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "extraPayload",
+            "description": "Additional payload that will be merged with the one based on the bussines object ID.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONString",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ids",
+            "description": "The list of customers or orders node IDs that will be serialized and included in the notification payload.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ExternalObtainAccessTokens",
         "description": "Obtain external access tokens for user by custom plugin.",
         "fields": [
@@ -20596,7 +22604,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "csrfToken",
@@ -20703,7 +22711,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "csrfToken",
@@ -20810,7 +22818,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -20995,7 +23003,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "uploadedFile",
@@ -21064,7 +23072,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21209,6 +23217,89 @@
       },
       {
         "kind": "OBJECT",
+        "name": "FulfillmentApprove",
+        "description": "New in Saleor 3.1. Approve existing fulfillment.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "OrderError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fulfillment",
+            "description": "An approved fulfillment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Fulfillment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "order",
+            "description": "Order which fulfillment was approved.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Order",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "OrderError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "FulfillmentCancel",
         "description": "Cancels existing fulfillment and optionally restocks items.",
         "fields": [
@@ -21282,7 +23373,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -21298,15 +23389,11 @@
         "inputFields": [
           {
             "name": "warehouseId",
-            "description": "ID of warehouse where items will be restock.",
+            "description": "ID of a warehouse where items will be restocked. Optional when fulfillment is in WAITING_FOR_APPROVAL state.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -21324,7 +23411,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21453,7 +23540,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -21524,7 +23611,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "replaceFulfillment",
@@ -21578,37 +23665,43 @@
         "enumValues": [
           {
             "name": "CANCELED",
-            "description": "Canceled",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "FULFILLED",
-            "description": "Fulfilled",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "REFUNDED",
-            "description": "Refunded",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "REFUNDED_AND_RETURNED",
-            "description": "Refunded and returned",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "REPLACED",
-            "description": "Replaced",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "RETURNED",
-            "description": "Returned",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WAITING_FOR_APPROVAL",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -21690,7 +23783,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -21788,13 +23881,41 @@
         "description": "A gift card is a prepaid electronic payment card accepted in stores. They can be used during checkout by providing a valid gift card codes.",
         "fields": [
           {
-            "name": "code",
-            "description": "Gift card code.",
+            "name": "app",
+            "description": "New in Saleor 3.1. App which created the gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "boughtInChannel",
+            "description": "New in Saleor 3.1. Slug of the channel where the gift card was bought. Note: this feature is in a preview state and can be subject to changes at later point.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "code",
+            "description": "Gift card code. Can be fetched by staff member with manage gift card permission when gift card wasn't used yet and by the gift card owner.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -21816,6 +23937,30 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": "New in Saleor 3.1. The user who bought or issued a gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdByEmail",
+            "description": "New in Saleor 3.1. Email address of the user who bought or issued gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currentBalance",
             "description": null,
             "args": [],
@@ -21832,15 +23977,68 @@
             "description": "Code in format which allows displaying in a user interface.",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "endDate",
+            "description": "End date of gift card.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `expiryDate` field instead."
+          },
+          {
+            "name": "events",
+            "description": "New in Saleor 3.1. List of events associated with the gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "filter",
+                "description": "Filtering options for gift card events.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GiftCardEventFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardEvent",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiryDate",
             "description": null,
             "args": [],
             "type": {
@@ -21853,7 +24051,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21896,6 +24094,22 @@
             "deprecationReason": null
           },
           {
+            "name": "last4CodeChars",
+            "description": "Last 4 characters of gift card code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "lastUsedOn",
             "description": null,
             "args": [],
@@ -21908,17 +24122,113 @@
             "deprecationReason": null
           },
           {
-            "name": "startDate",
-            "description": null,
+            "name": "metadata",
+            "description": "List of public metadata items. Can be accessed without permissions.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Date",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MetadataItem",
+                  "ofType": null
+                }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetadata",
+            "description": "List of private metadata items.Requires proper staff permissions to access.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MetadataItem",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "product",
+            "description": "New in Saleor 3.1. Related gift card product. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Product",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startDate",
+            "description": "Start date of gift card.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0."
+          },
+          {
+            "name": "tags",
+            "description": "New in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardTag",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "usedBy",
+            "description": "New in Saleor 3.1. The customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "usedByEmail",
+            "description": "New in Saleor 3.1. Email address of the customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -21932,8 +24242,8 @@
               "name": "User",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `createdBy` field instead."
           }
         ],
         "inputFields": null,
@@ -21941,6 +24251,11 @@
           {
             "kind": "INTERFACE",
             "name": "Node",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "ObjectWithMetadata",
             "ofType": null
           }
         ],
@@ -21978,7 +24293,7 @@
           },
           {
             "name": "giftCard",
-            "description": "A gift card to activate.",
+            "description": "Activated gift card.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -22010,7 +24325,412 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardAddNote",
+        "description": "New in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": "Gift card note created.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardEvent",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCard",
+            "description": "Gift card with the note added.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCard",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardAddNoteInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "message",
+            "description": "Note message.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardBulkActivate",
+        "description": "New in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "count",
+            "description": "Returns how many objects were affected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardBulkCreate",
+        "description": "New in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "count",
+            "description": "Returns how many objects were created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCards",
+            "description": "List of created gift cards.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCard",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardBulkCreateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "balance",
+            "description": "Balance of the gift card.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "PriceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": "The number of cards to issue.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiryDate",
+            "description": "The gift card expiry date.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": "Determine if gift card is active.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": "The gift card tags.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardBulkDeactivate",
+        "description": "New in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "count",
+            "description": "Returns how many objects were affected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardBulkDelete",
+        "description": "New in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "count",
+            "description": "Returns how many objects were affected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -22187,7 +24907,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -22202,11 +24922,47 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "addTags",
+            "description": "New in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "balance",
-            "description": "Value of the gift card.",
+            "description": "Balance of the gift card.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "PriceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "channel",
+            "description": "New in Saleor 3.1. Slug of a channel from which the email should be sent. Note: this feature is in a preview state and can be subject to changes at later point.",
             "type": {
               "kind": "SCALAR",
-              "name": "PositiveDecimal",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -22215,7 +24971,7 @@
           },
           {
             "name": "code",
-            "description": "Code to use the gift card.",
+            "description": "Code to use the gift card. \n\nDEPRECATED: this field will be removed in Saleor 4.0. The code is now auto generated.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -22227,7 +24983,7 @@
           },
           {
             "name": "endDate",
-            "description": "End date of the gift card in ISO 8601 format.",
+            "description": "End date of the gift card in ISO 8601 format. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` from `expirySettings` instead.",
             "type": {
               "kind": "SCALAR",
               "name": "Date",
@@ -22238,8 +24994,48 @@
             "deprecationReason": null
           },
           {
+            "name": "expiryDate",
+            "description": "New in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": "New in Saleor 3.1. Determine if gift card is active. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "note",
+            "description": "New in Saleor 3.1. The gift card note from the staff member. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "startDate",
-            "description": "Start date of the gift card in ISO 8601 format.",
+            "description": "Start date of the gift card in ISO 8601 format. \n\nDEPRECATED: this field will be removed in Saleor 4.0.",
             "type": {
               "kind": "SCALAR",
               "name": "Date",
@@ -22251,7 +25047,7 @@
           },
           {
             "name": "userEmail",
-            "description": "The customer's email of the gift card buyer.",
+            "description": "Email of the customer to whom gift card will be sent.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -22297,7 +25093,7 @@
           },
           {
             "name": "giftCard",
-            "description": "A gift card to deactivate.",
+            "description": "Deactivated gift card.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -22329,7 +25125,78 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardDelete",
+        "description": "New in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCard",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCard",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -22381,6 +25248,26 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": "List of tag values that cause the error.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -22398,6 +25285,18 @@
         "enumValues": [
           {
             "name": "ALREADY_EXISTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DUPLICATED_INPUT_ITEM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EXPIRED_GIFT_CARD",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -22433,6 +25332,1123 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardEvent",
+        "description": "New in Saleor 3.1. History log of the gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "app",
+            "description": "App that performed the action.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "balance",
+            "description": "The gift card balance.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardEventBalance",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "date",
+            "description": "Date when event happened at in ISO 8601 format.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": "Email of the customer.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiryDate",
+            "description": "The gift card expiry date.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "Content of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldExpiryDate",
+            "description": "Previous gift card expiry date.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldTags",
+            "description": "The list of old gift card tags.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderId",
+            "description": "The order ID where gift card was used or bought.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderNumber",
+            "description": "User-friendly number of an order where gift card was used or bought.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": "The list of gift card tags.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "Gift card event type.",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "GiftCardEventsEnum",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "User who performed the action.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardEventBalance",
+        "description": null,
+        "fields": [
+          {
+            "name": "currentBalance",
+            "description": "Current balance of the gift card.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialBalance",
+            "description": "Initial balance of the gift card.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Money",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldCurrentBalance",
+            "description": "Previous current balance of the gift card.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Money",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldInitialBalance",
+            "description": "Previous initial balance of the gift card.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Money",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardEventFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "orders",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "GiftCardEventsEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GiftCardEventsEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ACTIVATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BALANCE_RESET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BOUGHT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEACTIVATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EXPIRY_DATE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ISSUED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOTE_ADDED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SENT_TO_CUSTOMER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TAGS_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "USED_IN_ORDER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "code",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currency",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentBalance",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PriceRangeInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialBalance",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PriceRangeInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "MetadataFilter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "products",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "used",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "usedBy",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardResend",
+        "description": "New in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCard",
+            "description": "Gift card which has been sent.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCard",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardResendInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channel",
+            "description": "Slug of a channel from which the email should be sent.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": "Email to which gift card should be send.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "ID of a gift card to resend.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardSettings",
+        "description": "Gift card related settings from site settings.",
+        "fields": [
+          {
+            "name": "expiryPeriod",
+            "description": "The gift card expiry period settings.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "TimePeriod",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiryType",
+            "description": "The gift card expiry type settings.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GiftCardSettingsExpiryTypeEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardSettingsError",
+        "description": null,
+        "fields": [
+          {
+            "name": "code",
+            "description": "The error code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GiftCardSettingsErrorCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "The error message.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GiftCardSettingsErrorCode",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GRAPHQL_ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVALID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REQUIRED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GiftCardSettingsExpiryTypeEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EXPIRY_PERIOD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NEVER_EXPIRE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardSettingsUpdate",
+        "description": "Update gift card settings.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardSettingsError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardSettings",
+            "description": "Gift card settings.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardSettings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardSettingsUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "expiryPeriod",
+            "description": "Defines gift card expiry period.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimePeriodInputType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiryType",
+            "description": "Defines gift card default expiry settings.",
+            "type": {
+              "kind": "ENUM",
+              "name": "GiftCardSettingsExpiryTypeEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GiftCardSortField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CURRENT_BALANCE",
+            "description": "Sort orders by current balance.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT",
+            "description": "Sort orders by product.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "USED_BY",
+            "description": "Sort orders by used by.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardSortingInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": "Specifies the direction in which to sort products.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Sort gift cards by the selected field.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GiftCardSortField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardTag",
+        "description": "New in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardTagCountableConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GiftCardTagCountableEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Pagination data for this connection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "A total count of items in the collection.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCardTagCountableEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The item at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GiftCardTag",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GiftCardTagFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "search",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -22498,7 +26514,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -22513,8 +26529,28 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "balance",
-            "description": "Value of the gift card.",
+            "name": "addTags",
+            "description": "New in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "balanceAmount",
+            "description": "New in Saleor 3.1. The gift card balance amount. Note: this feature is in a preview state and can be subject to changes at later point.",
             "type": {
               "kind": "SCALAR",
               "name": "PositiveDecimal",
@@ -22526,11 +26562,43 @@
           },
           {
             "name": "endDate",
-            "description": "End date of the gift card in ISO 8601 format.",
+            "description": "End date of the gift card in ISO 8601 format. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` from `expirySettings` instead.",
             "type": {
               "kind": "SCALAR",
               "name": "Date",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiryDate",
+            "description": "New in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "removeTags",
+            "description": "New in Saleor 3.1. The gift card tags to remove. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -22538,22 +26606,10 @@
           },
           {
             "name": "startDate",
-            "description": "Start date of the gift card in ISO 8601 format.",
+            "description": "Start date of the gift card in ISO 8601 format. \n\nDEPRECATED: this field will be removed in Saleor 4.0.",
             "type": {
               "kind": "SCALAR",
               "name": "Date",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userEmail",
-            "description": "The customer's email of the gift card buyer.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -22572,7 +26628,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22869,7 +26925,7 @@
         "fields": [
           {
             "name": "createdAt",
-            "description": "Created date time of job in ISO 8601 format.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22913,7 +26969,7 @@
           },
           {
             "name": "message",
-            "description": "Job message.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22993,7 +27049,7 @@
           },
           {
             "name": "updatedAt",
-            "description": "Date time of job last update in ISO 8601 format.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23104,7 +27160,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -23218,7 +27274,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -23399,7 +27455,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "order",
@@ -23482,7 +27538,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -23553,7 +27609,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -23624,7 +27680,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -23635,7 +27691,7 @@
       {
         "kind": "SCALAR",
         "name": "JSONString",
-        "description": "Allows use of a JSON String for input / output from the GraphQL schema.\n\nUse of this type is *not recommended* as you lose the benefits of having a defined, static\nschema (one of the key benefits of GraphQL).",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -28672,6 +32728,30 @@
             "deprecationReason": null
           },
           {
+            "name": "extensions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppManifestExtension",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "homepageUrl",
             "description": null,
             "args": [],
@@ -29010,7 +33090,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -29196,7 +33276,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -29373,7 +33453,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -29499,7 +33579,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -29760,7 +33840,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -30011,7 +34091,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -30176,7 +34256,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "menuItem",
@@ -30350,7 +34430,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "menuItem",
@@ -30543,7 +34623,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -30652,7 +34732,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -30676,7 +34756,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "name",
@@ -30798,7 +34878,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -30813,7 +34893,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -30922,7 +35002,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "menuItem",
@@ -31088,7 +35168,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -32852,7 +36932,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
-                    "name": "AttributeValueCreateInput",
+                    "name": "AttributeValueUpdateInput",
                     "ofType": null
                   }
                 },
@@ -33257,7 +37337,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID. DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33326,7 +37406,7 @@
               },
               {
                 "name": "checkoutId",
-                "description": "ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33363,7 +37443,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33399,7 +37479,7 @@
               },
               {
                 "name": "storeSource",
-                "description": "Determines whether to store the payment source for future usage.",
+                "description": "Determines whether to store the payment source for future usage. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use checkoutPaymentCreate for this action.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -33465,7 +37545,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33514,7 +37594,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33546,12 +37626,49 @@
             "deprecationReason": null
           },
           {
+            "name": "checkoutDeliveryMethodUpdate",
+            "description": "New in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "deliveryMethodId",
+                "description": "Delivery Method ID (`Warehouse` ID or `ShippingMethod` ID).",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "token",
+                "description": "Checkout token.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "UUID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CheckoutDeliveryMethodUpdate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "checkoutEmailUpdate",
             "description": "Updates email address in the existing checkout object.",
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33604,7 +37721,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33657,7 +37774,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "The ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33706,7 +37823,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "The ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33812,7 +37929,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "The ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33869,7 +37986,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33922,7 +38039,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -33936,13 +38053,21 @@
                 "name": "promoCode",
                 "description": "Gift card code or voucher code.",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "promoCodeId",
+                "description": "Gift card or voucher ID.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -33975,7 +38100,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "ID of the checkout.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -34028,7 +38153,7 @@
             "args": [
               {
                 "name": "checkoutId",
-                "description": "Checkout ID.DEPRECATED: Will be removed in Saleor 4.0. Use token instead.",
+                "description": "The ID of the checkout. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use token instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -34072,8 +38197,8 @@
               "name": "CheckoutShippingMethodUpdate",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `checkoutDeliveryMethodUpdate` instead."
           },
           {
             "name": "collectionAddProducts",
@@ -35148,8 +39273,8 @@
               "name": "DraftOrderLinesBulkDelete",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0."
           },
           {
             "name": "draftOrderUpdate",
@@ -35197,12 +39322,70 @@
             "deprecationReason": null
           },
           {
+            "name": "eventDeliveryRetry",
+            "description": "Retries event delivery.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of the event delivery to retry.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EventDeliveryRetry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exportGiftCards",
+            "description": "New in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "input",
+                "description": "Fields required to export gift cards data.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ExportGiftCardsInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExportGiftCards",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "exportProducts",
             "description": "Export products to csv file.",
             "args": [
               {
                 "name": "input",
-                "description": "Fields required to export product data",
+                "description": "Fields required to export product data.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -35310,6 +39493,63 @@
             "type": {
               "kind": "OBJECT",
               "name": "ExternalLogout",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "externalNotificationTrigger",
+            "description": "New in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.",
+            "args": [
+              {
+                "name": "channel",
+                "description": "Channel slug. Saleor will send a notification within a provided channel. Please, make sure that necessary plugins are active.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "input",
+                "description": "Input for External Notification Trigger. ",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ExternalNotificationTriggerInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pluginId",
+                "description": "The ID of notification plugin.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExternalNotificationTrigger",
               "ofType": null
             },
             "isDeprecated": false,
@@ -35509,6 +39749,179 @@
             "deprecationReason": null
           },
           {
+            "name": "giftCardAddNote",
+            "description": "New in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of the gift card to add a note for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "input",
+                "description": "Fields required to create a note for the gift card.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GiftCardAddNoteInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardAddNote",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardBulkActivate",
+            "description": "New in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "ids",
+                "description": "List of gift card IDs to activate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardBulkActivate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardBulkCreate",
+            "description": "New in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "input",
+                "description": "Fields required to create gift cards.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GiftCardBulkCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardBulkCreate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardBulkDeactivate",
+            "description": "New in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "ids",
+                "description": "List of gift card IDs to deactivate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardBulkDeactivate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardBulkDelete",
+            "description": "New in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "ids",
+                "description": "List of gift card IDs to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardBulkDelete",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "giftCardCreate",
             "description": "Creates a new gift card.",
             "args": [
@@ -35561,6 +39974,93 @@
             "type": {
               "kind": "OBJECT",
               "name": "GiftCardDeactivate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardDelete",
+            "description": "New in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of the gift card to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardDelete",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardResend",
+            "description": "New in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "input",
+                "description": "Fields required to resend a gift card.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GiftCardResendInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardResend",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardSettingsUpdate",
+            "description": "Update gift card settings.",
+            "args": [
+              {
+                "name": "input",
+                "description": "Fields required to update gift card settings.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GiftCardSettingsUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardSettingsUpdate",
               "ofType": null
             },
             "isDeprecated": false,
@@ -36517,7 +41017,7 @@
             "args": [
               {
                 "name": "input",
-                "description": "Fields required to create an fulfillment.",
+                "description": "Fields required to create a fulfillment.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -36553,12 +41053,69 @@
             "deprecationReason": null
           },
           {
+            "name": "orderFulfillmentApprove",
+            "description": "New in Saleor 3.1. Approve existing fulfillment.",
+            "args": [
+              {
+                "name": "allowStockToBeExceeded",
+                "description": "True if stock could be exceeded.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "ID of a fulfillment to approve.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "notifyCustomer",
+                "description": "True if confirmation email should be send.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "FulfillmentApprove",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "orderFulfillmentCancel",
             "description": "Cancels existing fulfillment and optionally restocks items.",
             "args": [
               {
                 "name": "id",
-                "description": "ID of an fulfillment to cancel.",
+                "description": "ID of a fulfillment to cancel.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -36574,15 +41131,11 @@
               },
               {
                 "name": "input",
-                "description": "Fields required to cancel an fulfillment.",
+                "description": "Fields required to cancel a fulfillment.",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "FulfillmentCancelInput",
-                    "ofType": null
-                  }
+                  "kind": "INPUT_OBJECT",
+                  "name": "FulfillmentCancelInput",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -36693,7 +41246,7 @@
             "args": [
               {
                 "name": "id",
-                "description": "ID of an fulfillment to update.",
+                "description": "ID of a fulfillment to update.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -36709,7 +41262,7 @@
               },
               {
                 "name": "input",
-                "description": "Fields required to update an fulfillment.",
+                "description": "Fields required to update a fulfillment.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -37091,15 +41644,19 @@
           },
           {
             "name": "orderUpdateShipping",
-            "description": "Updates a shipping method of the order.",
+            "description": "Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed.",
             "args": [
               {
                 "name": "input",
                 "description": "Fields required to change shipping method of the order.",
                 "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "OrderUpdateShippingInput",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "OrderUpdateShippingInput",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -38213,6 +42770,55 @@
             "deprecationReason": null
           },
           {
+            "name": "productAttributeAssignmentUpdate",
+            "description": "New in Saleor 3.1. Update attributes assigned to product variant for given product type.",
+            "args": [
+              {
+                "name": "operations",
+                "description": "The operations to perform.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ProductAttributeAssignmentUpdateInput",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "productTypeId",
+                "description": "ID of the product type to assign the attributes into.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductAttributeAssignmentUpdate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "productAttributeUnassign",
             "description": "Un-assign attributes from a given product type.",
             "args": [
@@ -39058,7 +43664,7 @@
               },
               {
                 "name": "input",
-                "description": "('List of fields required to create or upgrade product variant channel listings.',)",
+                "description": "List of fields required to create or upgrade product variant channel listings.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -39142,6 +43748,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "ProductVariantDelete",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productVariantPreorderDeactivate",
+            "description": "New in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of a variant which preorder should be deactivated.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductVariantPreorderDeactivate",
               "ofType": null
             },
             "isDeprecated": false,
@@ -40326,7 +44961,7 @@
             "args": [
               {
                 "name": "id",
-                "description": "ShippingMethod ID or ShippingMethodTranslatableContent ID.",
+                "description": "('ShippingMethodType ID or ShippingMethodTranslatableContent ID.',)",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -41974,6 +46609,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "AppExtension",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "AppInstallation",
             "ofType": null
           },
@@ -42079,6 +46719,16 @@
           },
           {
             "kind": "OBJECT",
+            "name": "EventDelivery",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "EventDeliveryAttempt",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ExportEvent",
             "ofType": null
           },
@@ -42100,6 +46750,16 @@
           {
             "kind": "OBJECT",
             "name": "GiftCard",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "GiftCardEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "GiftCardTag",
             "ofType": null
           },
           {
@@ -42426,6 +47086,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "GiftCard",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Invoice",
             "ofType": null
           },
@@ -42452,6 +47117,11 @@
           {
             "kind": "OBJECT",
             "name": "PageType",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Payment",
             "ofType": null
           },
           {
@@ -42532,6 +47202,30 @@
             "deprecationReason": null
           },
           {
+            "name": "availableCollectionPoints",
+            "description": "New in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Warehouse",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "availableShippingMethods",
             "description": "Shipping methods that can be used with this order.",
             "args": [],
@@ -42592,6 +47286,18 @@
             "deprecationReason": null
           },
           {
+            "name": "collectionPointName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "created",
             "description": null,
             "args": [],
@@ -42624,6 +47330,18 @@
             "deprecationReason": null
           },
           {
+            "name": "deliveryMethod",
+            "description": "New in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "DeliveryMethod",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "discount",
             "description": "Returns applied discount.",
             "args": [],
@@ -42633,7 +47351,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Use discounts field. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `discounts` field instead."
           },
           {
             "name": "discountName",
@@ -42645,7 +47363,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Use discounts field. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `discounts` field instead."
           },
           {
             "name": "discounts",
@@ -42761,7 +47479,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -42837,7 +47555,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use the `languageCodeEnum` field to fetch the language code. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. "
           },
           {
             "name": "languageCodeEnum",
@@ -43036,8 +47754,8 @@
               "name": "ShippingMethod",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `deliveryMethod` instead."
           },
           {
             "name": "shippingMethodName",
@@ -43056,20 +47774,12 @@
             "description": "Shipping methods related to this order.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ShippingMethod",
-                    "ofType": null
-                  }
-                }
+                "kind": "OBJECT",
+                "name": "ShippingMethod",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -43257,7 +47967,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Use discounts field. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `discounts` field instead. "
           },
           {
             "name": "undiscountedTotal",
@@ -43269,6 +47979,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "TaxedMoney",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               }
             },
@@ -43450,7 +48176,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -43552,7 +48278,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -43623,7 +48349,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -43694,7 +48420,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -43765,7 +48491,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -43925,7 +48651,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -44098,7 +48824,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -44224,7 +48950,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -44242,13 +48968,13 @@
         "enumValues": [
           {
             "name": "MANUAL",
-            "description": "Manual",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "VOUCHER",
-            "description": "Voucher",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -44318,7 +49044,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -44559,6 +49285,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CANNOT_FULFILL_UNPAID_ORDER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CANNOT_REFUND",
             "description": null,
             "isDeprecated": false,
@@ -44584,6 +49316,12 @@
           },
           {
             "name": "FULFILL_ORDER_LINE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GIFT_CARD_LINE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -44812,7 +49550,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -45398,6 +50136,12 @@
             "deprecationReason": null
           },
           {
+            "name": "FULFILLMENT_AWAITS_APPROVAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "FULFILLMENT_CANCELED",
             "description": null,
             "isDeprecated": false,
@@ -45651,6 +50395,30 @@
             "deprecationReason": null
           },
           {
+            "name": "giftCardBought",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardUsed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ids",
             "description": null,
             "type": {
@@ -45661,6 +50429,30 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isClickAndCollect",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPreorder",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -45721,6 +50513,18 @@
                 "name": "OrderStatusFilter",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateTimeRangeInput",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -45810,7 +50614,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -46006,7 +50810,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -46057,13 +50861,21 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productVariantId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -46087,6 +50899,22 @@
           {
             "name": "quantityFulfilled",
             "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantityToFulfill",
+            "description": "New in Saleor 3.1. A quantity of items remaining to be fulfilled.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -46423,7 +51251,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "orderLine",
@@ -46506,7 +51334,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "orderLine",
@@ -46589,7 +51417,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "orderLine",
@@ -46699,7 +51527,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "orderLine",
@@ -46782,7 +51610,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "orderLines",
@@ -46873,7 +51701,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -46973,7 +51801,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -47359,6 +52187,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "automaticallyFulfillNonShippableGiftCard",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -47497,7 +52341,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -47515,13 +52359,21 @@
             "name": "automaticallyConfirmAllNewOrders",
             "description": "When disabled, all new orders from checkout will be marked as unconfirmed. When enabled orders from checkout will become unfulfilled immediately.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "automaticallyFulfillNonShippableGiftCard",
+            "description": "When enabled, all non-shippable gift card orders will be fulfilled automatically.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -47541,8 +52393,14 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "CREATED_AT",
+            "description": "Sort orders by creation date. \n\nDEPRECATED: this field will be removed in Saleor 4.0.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CREATION_DATE",
-            "description": "Sort orders by creation date.",
+            "description": "Sort orders by creation date. \n\nDEPRECATED: this field will be removed in Saleor 4.0.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -47555,6 +52413,12 @@
           {
             "name": "FULFILLMENT_STATUS",
             "description": "Sort orders by fulfillment status.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LAST_MODIFIED_AT",
+            "description": "Sort orders by last modified at.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -47626,49 +52490,49 @@
         "enumValues": [
           {
             "name": "CANCELED",
-            "description": "Canceled",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DRAFT",
-            "description": "Draft",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "FULFILLED",
-            "description": "Fulfilled",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PARTIALLY_FULFILLED",
-            "description": "Partially fulfilled",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PARTIALLY_RETURNED",
-            "description": "Partially returned",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "RETURNED",
-            "description": "Returned",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UNCONFIRMED",
-            "description": "Unconfirmed",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UNFULFILLED",
-            "description": "Unfulfilled",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -47791,7 +52655,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -47849,7 +52713,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderUpdateShipping",
-        "description": "Updates a shipping method of the order.",
+        "description": "Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed.",
         "fields": [
           {
             "name": "errors",
@@ -47909,7 +52773,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -47925,7 +52789,7 @@
         "inputFields": [
           {
             "name": "shippingMethod",
-            "description": "ID of the selected shipping method.",
+            "description": "ID of the selected shipping method, pass null to remove currently assigned shipping method.",
             "type": {
               "kind": "SCALAR",
               "name": "ID",
@@ -48003,7 +52867,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -48042,7 +52906,7 @@
           },
           {
             "name": "content",
-            "description": null,
+            "description": "Content of the page (JSON).",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -48066,7 +52930,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `content` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `content` field instead."
           },
           {
             "name": "created",
@@ -48086,7 +52950,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -48337,7 +53201,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "pageType",
@@ -48408,7 +53272,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "pageType",
@@ -48495,7 +53359,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -48570,7 +53434,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -48747,7 +53611,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -48937,7 +53801,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -49393,7 +54257,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -49536,11 +54400,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `content` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `content` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -49564,7 +54428,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "seoDescription",
@@ -49710,7 +54574,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -49745,11 +54609,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `content` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `content` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -49994,7 +54858,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -50164,7 +55028,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -50329,7 +55193,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "pageType",
@@ -50455,7 +55319,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "pageType",
@@ -50549,7 +55413,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "pageType",
@@ -50686,7 +55550,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "pageType",
@@ -50844,7 +55708,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -50879,7 +55743,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -51070,7 +55934,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -51095,6 +55959,26 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": "List of public metadata items. Can be accessed without permissions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MetadataItem",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -51139,6 +56023,26 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetadata",
+            "description": "List of private metadata items.Requires proper staff permissions to access.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MetadataItem",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -51194,6 +56098,11 @@
           {
             "kind": "INTERFACE",
             "name": "Node",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "ObjectWithMetadata",
             "ofType": null
           }
         ],
@@ -51263,7 +56172,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -51393,7 +56302,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -51680,6 +56589,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CHECKOUT_EMAIL_NOT_SET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "GRAPHQL_ERROR",
             "description": null,
             "isDeprecated": false,
@@ -51937,7 +56852,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -52035,11 +56950,43 @@
             "deprecationReason": null
           },
           {
+            "name": "metadata",
+            "description": "New in Saleor 3.1. User public metadata.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MetadataInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "returnUrl",
             "description": "URL of a storefront view where user should be redirected after requiring additional actions. Payment with additional actions will not be finished if this field is not provided.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storePaymentMethod",
+            "description": "New in Saleor 3.1. Payment store type.",
+            "type": {
+              "kind": "ENUM",
+              "name": "StorePaymentMethodEnum",
               "ofType": null
             },
             "defaultValue": null,
@@ -52126,7 +57073,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -52162,6 +57109,26 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": "New in Saleor 3.1. List of public metadata items. Can be accessed without permissions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MetadataItem",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -52248,7 +57215,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -52487,7 +57454,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -52625,7 +57592,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -52945,7 +57912,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -53660,7 +58627,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -53738,6 +58705,174 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PreorderData",
+        "description": "Represents preorder settings for product variant.",
+        "fields": [
+          {
+            "name": "endDate",
+            "description": "Preorder end date.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "globalSoldUnits",
+            "description": "Total number of sold product variant during preorder.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "globalThreshold",
+            "description": "The global preorder threshold for product variant.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PreorderSettingsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "endDate",
+            "description": "The end date for preorder.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "globalThreshold",
+            "description": "The global threshold for preorder variant.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PreorderThreshold",
+        "description": "Represents preorder variant data for channel.",
+        "fields": [
+          {
+            "name": "quantity",
+            "description": "Preorder threshold for product variant in this channel.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "soldUnits",
+            "description": "Number of sold product variant in this channel.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PriceInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "amount",
+            "description": "Amount of money.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "PositiveDecimal",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currency",
+            "description": "Currency code.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -53893,6 +59028,22 @@
             "deprecationReason": null
           },
           {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "defaultVariant",
             "description": null,
             "args": [],
@@ -53926,11 +59077,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -53967,7 +59118,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `mediaById` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `mediaById` field instead."
           },
           {
             "name": "images",
@@ -53983,7 +59134,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `media` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `media` field instead."
           },
           {
             "name": "isAvailable",
@@ -54287,9 +59438,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -54390,7 +59545,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productType",
@@ -54441,6 +59596,132 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "ProductAttributeType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variantSelection",
+            "description": "New in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductAttributeAssignmentUpdate",
+        "description": "New in Saleor 3.1. Update attributes assigned to product variant for given product type.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
+          },
+          {
+            "name": "productType",
+            "description": "The updated product type.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductAttributeAssignmentUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The ID of the attribute to assign.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variantSelection",
+            "description": "New in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -54527,7 +59808,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productType",
@@ -54614,7 +59895,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -54669,7 +59950,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -55121,7 +60402,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -55349,7 +60630,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -55595,7 +60876,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -55769,6 +61050,12 @@
             "deprecationReason": null
           },
           {
+            "name": "PREORDER_VARIANT_CANNOT_BE_DEACTIVATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PRODUCT_NOT_ASSIGNED_TO_CHANNEL",
             "description": null,
             "isDeprecated": false,
@@ -55864,6 +61151,12 @@
             "deprecationReason": null
           },
           {
+            "name": "VARIANT_ID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "VARIANT_MEDIA",
             "description": null,
             "isDeprecated": false,
@@ -55924,7 +61217,7 @@
           },
           {
             "name": "channel",
-            "description": "Specifies the channel by which the data should be filtered. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel by which the data should be filtered. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -55951,7 +61244,31 @@
             "deprecationReason": null
           },
           {
+            "name": "giftCard",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasCategory",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasPreorderedVariants",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -56076,6 +61393,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ProductStockFilterInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateTimeRangeInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -56349,7 +61678,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -56515,7 +61844,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -56598,7 +61927,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -56744,7 +62073,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -56835,7 +62164,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -56853,13 +62182,13 @@
         "enumValues": [
           {
             "name": "IMAGE",
-            "description": "An uploaded image or an URL to an image",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "VIDEO",
-            "description": "A URL to an external video",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -56941,7 +62270,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -56992,7 +62321,7 @@
           },
           {
             "name": "channel",
-            "description": "Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel in which to sort the data. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -57056,6 +62385,18 @@
             "deprecationReason": null
           },
           {
+            "name": "LAST_MODIFIED",
+            "description": "Sort products by update date.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LAST_MODIFIED_AT",
+            "description": "Sort products by update date.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "MINIMAL_PRICE",
             "description": "Sort products by a minimal price of a product's variant.",
             "isDeprecated": false,
@@ -57086,8 +62427,14 @@
             "deprecationReason": null
           },
           {
+            "name": "PUBLISHED_AT",
+            "description": "Sort products by publication date.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "RANK",
-            "description": "Sort products by rank. Note: This option is available only with the `search` filter.",
+            "description": "Sort products by name.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -57252,7 +62599,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -57354,11 +62701,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -57398,7 +62745,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "seoDescription",
@@ -57528,7 +62875,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -57563,11 +62910,11 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `description` field instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `description` field instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -57650,6 +62997,35 @@
         "name": "ProductType",
         "description": "Represents a type of product. It defines what attributes are available to products of this type.",
         "fields": [
+          {
+            "name": "assignedVariantAttributes",
+            "description": "New in Saleor 3.1. Variant attributes of that product type with attached variant selection.",
+            "args": [
+              {
+                "name": "variantSelection",
+                "description": "Define scope of returned attributes.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "VariantAttributeScope",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AssignedVariantAttribute",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "availableAttributes",
             "description": null,
@@ -57741,7 +63117,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -57781,6 +63157,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "The product type kind.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductTypeKindEnum",
                 "ofType": null
               }
             },
@@ -57930,7 +63322,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter."
           },
           {
             "name": "slug",
@@ -57986,8 +63378,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `assignedVariantAttributes` instead."
           },
           {
             "name": "weight",
@@ -58085,7 +63477,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -58273,7 +63665,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productType",
@@ -58344,7 +63736,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productType",
@@ -58416,6 +63808,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "ProductTypeKindEnum",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -58509,6 +63913,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "The product type kind.",
+            "type": {
+              "kind": "ENUM",
+              "name": "ProductTypeKindEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": "Name of the product type.",
             "type": {
@@ -58594,6 +64010,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "ProductTypeKindEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GIFT_CARD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NORMAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "ProductTypeReorderAttributes",
         "description": "Reorder the attributes of a product type.",
@@ -58644,7 +64083,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productType",
@@ -58787,7 +64226,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productType",
@@ -58870,7 +64309,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -58953,6 +64392,22 @@
             "deprecationReason": null
           },
           {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "digitalContent",
             "description": "Digital content for the product variant.",
             "args": [],
@@ -58966,7 +64421,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -58994,7 +64449,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `media` instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `media` field instead."
           },
           {
             "name": "margin",
@@ -59065,6 +64520,18 @@
             "deprecationReason": null
           },
           {
+            "name": "preorder",
+            "description": "New in Saleor 3.1. Preorder data for product variant. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PreorderData",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pricing",
             "description": "Lists the storefront variant's pricing, the current price and discounts, only meant for displaying.",
             "args": [
@@ -59127,7 +64594,7 @@
           },
           {
             "name": "quantityAvailable",
-            "description": "Quantity of a product available for sale in one checkout.",
+            "description": "Quantity of a product available for sale in one checkout. Field value will be `null` when no `limitQuantityPerCheckout` in global settings has been set, and `productVariant` stocks are not tracked.",
             "args": [
               {
                 "name": "address",
@@ -59143,7 +64610,7 @@
               },
               {
                 "name": "countryCode",
-                "description": "DEPRECATED: use `address` argument instead. This argument will be removed in Saleor 4.0.Two-letter ISO 3166-1 country code. When provided, the exact quantity from a warehouse operating in shipping zones that contain this country will be returned. Otherwise, it will return the maximum quantity from all shipping zones.",
+                "description": "Two-letter ISO 3166-1 country code. When provided, the exact quantity from a warehouse operating in shipping zones that contain this country will be returned. Otherwise, it will return the maximum quantity from all shipping zones. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `address` argument instead.",
                 "type": {
                   "kind": "ENUM",
                   "name": "CountryCode",
@@ -59155,13 +64622,21 @@
               }
             ],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantityLimitPerCustomer",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -59208,13 +64683,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -59237,7 +64708,7 @@
               },
               {
                 "name": "countryCode",
-                "description": "DEPRECATED: use `address` argument instead. This argument will be removed in Saleor 4.0. Two-letter ISO 3166-1 country code.",
+                "description": "Two-letter ISO 3166-1 country code. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `address` argument instead.",
                 "type": {
                   "kind": "ENUM",
                   "name": "CountryCode",
@@ -59306,6 +64777,22 @@
             "deprecationReason": null
           },
           {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "weight",
             "description": null,
             "args": [],
@@ -59361,7 +64848,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "count",
@@ -59484,16 +64971,36 @@
             "deprecationReason": null
           },
           {
+            "name": "preorder",
+            "description": "New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PreorderSettingsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantityLimitPerCustomer",
+            "description": "New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sku",
             "description": "Stock keeping unit.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -59615,7 +65122,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -59658,7 +65165,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -59679,6 +65186,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "preorderThreshold",
+            "description": "New in Saleor 3.1. Preorder variant data. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PreorderThreshold",
               "ofType": null
             },
             "isDeprecated": false,
@@ -59736,6 +65255,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "PositiveDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "preorderThreshold",
+            "description": "New in Saleor 3.1. The threshold for preorder variant in channel. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,
@@ -59814,7 +65345,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "variant",
@@ -59991,7 +65522,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productVariant",
@@ -60042,6 +65573,18 @@
             "deprecationReason": null
           },
           {
+            "name": "preorder",
+            "description": "New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PreorderSettingsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "product",
             "description": "Product ID of which type is the variant.",
             "type": {
@@ -60052,6 +65595,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantityLimitPerCustomer",
+            "description": "New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -60169,7 +65724,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productVariant",
@@ -60195,6 +65750,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "isPreorder",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "metadata",
             "description": null,
@@ -60238,6 +65805,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateTimeRangeInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -60265,6 +65844,30 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "preorder",
+            "description": "New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PreorderSettingsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantityLimitPerCustomer",
+            "description": "New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -60308,6 +65911,53 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductVariantPreorderDeactivate",
+        "description": "New in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "errors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductError",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productVariant",
+            "description": "Product variant with ended preorder.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductVariant",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -60374,7 +66024,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -60433,7 +66083,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productVariant",
@@ -60516,11 +66166,71 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProductVariantSortField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LAST_MODIFIED_AT",
+            "description": "Sort products variants by last modified at.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductVariantSortingInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": "Specifies the direction in which to sort products.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": "Sort productVariants by the selected field.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductVariantSortField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -60551,7 +66261,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -60658,7 +66368,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -60693,7 +66403,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -60768,7 +66478,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -60808,7 +66518,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "translation",
@@ -60914,7 +66624,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -60929,7 +66639,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -61038,7 +66748,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productVariant",
@@ -61273,6 +66983,108 @@
             "type": {
               "kind": "OBJECT",
               "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appExtension",
+            "description": "New in Saleor 3.1. Look up an app extension by ID. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of the app extension.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppExtension",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appExtensions",
+            "description": "New in Saleor 3.1. List of all extensions. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "after",
+                "description": "Return the elements in the list that come after the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Return the elements in the list that come before the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": "Filtering options for apps extensions.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppExtensionFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Return the first n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Return the last n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppExtensionCountableConnection",
               "ofType": null
             },
             "isDeprecated": false,
@@ -61827,6 +67639,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "filter",
+                "description": "New in Saleor 3.1. Filtering options for checkouts.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CheckoutFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "first",
                 "description": "Return the first n elements from the list.",
                 "type": {
@@ -61844,6 +67668,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortBy",
+                "description": "New in Saleor 3.1. Sort checkouts.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CheckoutSortingInput",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -62409,6 +68245,119 @@
             "deprecationReason": null
           },
           {
+            "name": "giftCardCurrencies",
+            "description": "New in Saleor 3.1. List of gift card currencies. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardSettings",
+            "description": "Gift card related settings from site settings.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GiftCardSettings",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "giftCardTags",
+            "description": "New in Saleor 3.1. List of gift card tags. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "after",
+                "description": "Return the elements in the list that come after the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Return the elements in the list that come before the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": "Filtering options for gift card tags.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GiftCardTagFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Return the first n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Return the last n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GiftCardTagCountableConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "giftCards",
             "description": "List of gift cards.",
             "args": [
@@ -62437,6 +68386,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "filter",
+                "description": "New in Saleor 3.1. Filtering options for gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GiftCardFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "first",
                 "description": "Return the first n elements from the list.",
                 "type": {
@@ -62454,6 +68415,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortBy",
+                "description": "New in Saleor 3.1. Sort gift cards. Note: this feature is in a preview state and can be subject to changes at later point.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GiftCardSortingInput",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -63911,6 +69884,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "sortBy",
+                "description": "Sort products variants.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProductVariantSortingInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -64230,7 +70215,7 @@
               },
               {
                 "name": "query",
-                "description": "Search sales by name, value or type. DEPRECATED: Will be removed in Saleor 4.0. Use `filter.search` input instead.",
+                "description": "Search sales by name, value or type. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `filter.search` input instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -64884,7 +70869,7 @@
               },
               {
                 "name": "query",
-                "description": "Search vouchers by name or code. DEPRECATED: Will be removed in Saleor 4.0. Use `filter.search` input instead.",
+                "description": "Search vouchers by name or code. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `filter.search` input instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -65071,8 +71056,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `WebhookEventTypeAsyncEnum` and `WebhookEventTypeSyncEnum` to get available event types."
           },
           {
             "name": "webhookSamplePayload",
@@ -65179,7 +71164,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -65324,7 +71309,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -65395,7 +71380,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -65575,6 +71560,22 @@
             "deprecationReason": null
           },
           {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currency",
             "description": "Currency code for sale.",
             "args": [],
@@ -65612,7 +71613,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -65805,8 +71806,24 @@
             "deprecationReason": null
           },
           {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "variants",
-            "description": "List of product variants this sale applies to.",
+            "description": "New in Saleor 3.1. List of product variants this sale applies to.",
             "args": [
               {
                 "name": "after",
@@ -65909,7 +71926,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -65996,7 +72013,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -66083,7 +72100,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -66230,7 +72247,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -66407,7 +72424,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -66478,7 +72495,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -66591,6 +72608,18 @@
                 "name": "DiscountStatusEnum",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateTimeRangeInput",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -66763,7 +72792,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -66816,8 +72845,20 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "CREATED_AT",
+            "description": "Sort sales by created at.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "END_DATE",
             "description": "Sort sales by end date.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LAST_MODIFIED_AT",
+            "description": "Sort sales by last modified at.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -66856,7 +72897,7 @@
         "inputFields": [
           {
             "name": "channel",
-            "description": "Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel in which to sort the data. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -66910,7 +72951,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -66950,7 +72991,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "translation",
@@ -67056,7 +73097,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -67071,7 +73112,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -67128,20 +73169,20 @@
       {
         "kind": "ENUM",
         "name": "SaleType",
-        "description": "An enumeration.",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "FIXED",
-            "description": "fixed",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PERCENTAGE",
-            "description": "%",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -67175,7 +73216,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -67328,7 +73369,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "csrfToken",
@@ -67561,7 +73602,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingMethod",
-        "description": "('Shipping methods that can be used as means of shippingfor orders and checkouts.',)",
+        "description": "Shipping methods that can be used as means of shipping for orders and checkouts.",
         "fields": [
           {
             "name": "active",
@@ -67844,7 +73885,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -68071,7 +74112,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingMethod",
@@ -68179,7 +74220,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -68219,7 +74260,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           },
           {
             "name": "translation",
@@ -68281,7 +74322,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -68362,7 +74403,7 @@
           },
           {
             "name": "description",
-            "description": null,
+            "description": "Shipping method description.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -68435,7 +74476,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": "Shipping method ID.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -68451,7 +74492,7 @@
           },
           {
             "name": "maximumDeliveryDays",
-            "description": null,
+            "description": "Maximum number of days for delivery.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -68462,8 +74503,20 @@
             "deprecationReason": null
           },
           {
+            "name": "maximumOrderPrice",
+            "description": "The price of the cheapest variant (including discounts).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Money",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "maximumOrderWeight",
-            "description": null,
+            "description": "Maximum order weight to use this shipping method.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -68495,7 +74548,7 @@
           },
           {
             "name": "minimumDeliveryDays",
-            "description": null,
+            "description": "Minimal number of days for delivery.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -68506,8 +74559,20 @@
             "deprecationReason": null
           },
           {
+            "name": "minimumOrderPrice",
+            "description": "The price of the cheapest variant (including discounts).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Money",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "minimumOrderWeight",
-            "description": null,
+            "description": "Minimum order weight to use this shipping method.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -68519,7 +74584,7 @@
           },
           {
             "name": "name",
-            "description": null,
+            "description": "Shipping method name.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -68756,7 +74821,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -68815,7 +74880,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingMethod",
@@ -68898,7 +74963,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingMethod",
@@ -68981,7 +75046,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingMethod",
@@ -69080,7 +75145,7 @@
           },
           {
             "name": "description",
-            "description": "Shipping method description (JSON).",
+            "description": "Shipping method description.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONString",
@@ -69242,7 +75307,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingMethod",
@@ -69325,7 +75390,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -69419,7 +75484,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingMethod",
@@ -69526,7 +75591,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -69732,7 +75797,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -69897,7 +75962,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingZone",
@@ -70067,7 +76132,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingZone",
@@ -70177,7 +76242,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "shippingZone",
@@ -70391,7 +76456,7 @@
               },
               {
                 "name": "currency",
-                "description": "DEPRECATED: use `channel` argument instead. This argument will be removed in Saleor 4.0.A currency for which gateways will be returned.",
+                "description": "A currency for which gateways will be returned. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `channel` argument instead.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -70468,6 +76533,30 @@
             "deprecationReason": null
           },
           {
+            "name": "channelCurrencies",
+            "description": "New in Saleor 3.1. List of all currencies supported by shop's channels.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "chargeTaxesOnShipping",
             "description": "Charge taxes on shipping.",
             "args": [],
@@ -70513,7 +76602,7 @@
               },
               {
                 "name": "languageCode",
-                "description": "DEPRECATED: This argument will be removed in Saleor 4.0. A language code to return the translation for.",
+                "description": "A language code to return the translation for. \n\nDEPRECATED: this field will be removed in Saleor 4.0.",
                 "type": {
                   "kind": "ENUM",
                   "name": "LanguageCodeEnum",
@@ -70673,6 +76762,38 @@
             "deprecationReason": null
           },
           {
+            "name": "fulfillmentAllowUnpaid",
+            "description": "New in Saleor 3.1. Allow to approve fulfillments which are unpaid.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fulfillmentAutoApprove",
+            "description": "New in Saleor 3.1. Automatically approve all new fulfillments.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "headerText",
             "description": "Header text.",
             "args": [],
@@ -70716,6 +76837,18 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limitQuantityPerCheckout",
+            "description": "New in Saleor 3.1. Default number of maximum line quantity in single checkout (per single checkout line). Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -70788,6 +76921,30 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reserveStockDurationAnonymousUser",
+            "description": "New in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout or null when stock reservation is disabled.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reserveStockDurationAuthenticatedUser",
+            "description": "New in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout or null when stock reservation is disabled.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -70934,7 +77091,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -71005,7 +77162,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -71180,7 +77337,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -71315,6 +77472,30 @@
             "deprecationReason": null
           },
           {
+            "name": "fulfillmentAllowUnpaid",
+            "description": "New in Saleor 3.1. Enable ability to approve fulfillments which are unpaid.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fulfillmentAutoApprove",
+            "description": "New in Saleor 3.1. Enable automatic approval of all new fulfillments.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "headerText",
             "description": "Header text.",
             "type": {
@@ -71332,6 +77513,42 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limitQuantityPerCheckout",
+            "description": "New in Saleor 3.1. Default number of maximum line quantity in single checkout. Minimum possible value is 1, default value is 50. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reserveStockDurationAnonymousUser",
+            "description": "New in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout. Enter 0 or null to disable.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reserveStockDurationAuthenticatedUser",
+            "description": "New in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout. Enter 0 or null to disable.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,
@@ -71418,7 +77635,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -71524,7 +77741,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -71571,7 +77788,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -71715,7 +77932,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -71774,7 +77991,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "user",
@@ -71948,7 +78165,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "user",
@@ -72145,7 +78362,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -72234,7 +78451,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "staffNotificationRecipient",
@@ -72305,7 +78522,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "staffNotificationRecipient",
@@ -72423,7 +78640,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "staffNotificationRecipient",
@@ -72494,7 +78711,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "user",
@@ -72683,7 +78900,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -72732,6 +78949,22 @@
           {
             "name": "quantityAllocated",
             "description": "Quantity allocated for orders",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantityReserved",
+            "description": "Quantity reserved for checkouts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -73079,6 +79312,35 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "StorePaymentMethodEnum",
+        "description": "Enum representing the type of a payment storage in a gateway.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "NONE",
+            "description": "Storage is disabled. The payment is not stored.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OFF_SESSION",
+            "description": "Off session storage type. The payment is stored to be reused even if the customer is absent.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ON_SESSION",
+            "description": "On session storage type. The payment is stored only to be reused when the customer is present in the checkout flow.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
@@ -73235,6 +79497,127 @@
       },
       {
         "kind": "OBJECT",
+        "name": "TimePeriod",
+        "description": null,
+        "fields": [
+          {
+            "name": "amount",
+            "description": "The length of the period.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of the period.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "TimePeriodTypeEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TimePeriodInputType",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "amount",
+            "description": "The length of the period.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of the period.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "TimePeriodTypeEnum",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "TimePeriodTypeEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DAY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MONTH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WEEK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "YEAR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Transaction",
         "description": "An object representing a single payment.",
         "fields": [
@@ -73296,7 +79679,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -73396,61 +79779,61 @@
         "enumValues": [
           {
             "name": "ACTION_TO_CONFIRM",
-            "description": "Action to confirm",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "AUTH",
-            "description": "Authorization",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "CANCEL",
-            "description": "Cancel",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "CAPTURE",
-            "description": "Capture",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "CONFIRM",
-            "description": "Confirm",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "EXTERNAL",
-            "description": "External reference",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PENDING",
-            "description": "Pending",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "REFUND",
-            "description": "Refund",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "REFUND_ONGOING",
-            "description": "Refund in progress",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "VOID",
-            "description": "Void",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -73772,6 +80155,12 @@
             "deprecationReason": null
           },
           {
+            "name": "INVALID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "NOT_FOUND",
             "description": null,
             "isDeprecated": false,
@@ -73953,7 +80342,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -74024,7 +80413,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -74166,7 +80555,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use the `checkoutTokens` field to fetch the user checkouts."
           },
           {
             "name": "checkoutTokens",
@@ -74368,7 +80757,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -74617,6 +81006,22 @@
             "deprecationReason": null
           },
           {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userPermissions",
             "description": "List of user's permissions.",
             "args": [],
@@ -74676,7 +81081,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -74747,7 +81152,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -74818,7 +81223,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "count",
@@ -75192,6 +81597,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "CREATED_AT",
+            "description": "Sort users by created at.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "EMAIL",
             "description": "Sort users by email.",
             "isDeprecated": false,
@@ -75200,6 +81611,12 @@
           {
             "name": "FIRST_NAME",
             "description": "Sort users by first name.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LAST_MODIFIED_AT",
+            "description": "Sort users by last modified at.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -75412,7 +81829,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productVariant",
@@ -75495,7 +81912,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "productVariant",
@@ -75625,7 +82042,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -76051,7 +82468,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -76309,7 +82726,7 @@
           },
           {
             "name": "variants",
-            "description": "List of product variants this voucher applies to.",
+            "description": "New in Saleor 3.1. List of product variants this voucher applies to.",
             "args": [
               {
                 "name": "after",
@@ -76412,7 +82829,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -76499,7 +82916,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -76586,7 +83003,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -76753,7 +83170,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -76930,7 +83347,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -77001,7 +83418,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -77373,7 +83790,7 @@
           },
           {
             "name": "variants",
-            "description": "Variants discounted by the voucher.",
+            "description": "New in Saleor 3.1. Variants discounted by the voucher.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -77419,7 +83836,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -77524,7 +83941,7 @@
         "inputFields": [
           {
             "name": "channel",
-            "description": "Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead.",
+            "description": "Specifies the channel in which to sort the data. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -77578,7 +83995,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -77643,7 +84060,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Will be removed in Saleor 4.0. Get model fields from the root level."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Get model fields from the root level queries."
           }
         ],
         "inputFields": null,
@@ -77708,7 +84125,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "voucher",
@@ -77735,7 +84152,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -77845,7 +84262,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           },
           {
             "name": "errors",
@@ -77911,6 +84328,22 @@
             "deprecationReason": null
           },
           {
+            "name": "clickAndCollectOption",
+            "description": "New in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WarehouseClickAndCollectOptionEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "companyName",
             "description": "Warehouse company name.",
             "args": [],
@@ -77924,7 +84357,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use address.CompanyName. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `Address.companyName` instead."
           },
           {
             "name": "email",
@@ -77944,7 +84377,7 @@
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -77952,6 +84385,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPrivate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -78020,7 +84469,7 @@
             "args": [
               {
                 "name": "after",
-                "description": null,
+                "description": "Return the elements in the list that come after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -78032,7 +84481,7 @@
               },
               {
                 "name": "before",
-                "description": null,
+                "description": "Return the elements in the list that come before the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -78044,7 +84493,7 @@
               },
               {
                 "name": "first",
-                "description": null,
+                "description": "Return the first n elements from the list.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -78056,7 +84505,7 @@
               },
               {
                 "name": "last",
-                "description": null,
+                "description": "Return the last n elements from the list.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -78110,6 +84559,35 @@
           }
         ],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WarehouseClickAndCollectOptionEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ALL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DISABLED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LOCAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -78281,7 +84759,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -78435,7 +84913,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -78548,6 +85026,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "clickAndCollectOption",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WarehouseClickAndCollectOptionEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ids",
             "description": null,
             "type": {
@@ -78558,6 +85048,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPrivate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -78643,7 +85145,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -78714,7 +85216,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -78845,7 +85347,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -78872,11 +85374,35 @@
             "deprecationReason": null
           },
           {
+            "name": "clickAndCollectOption",
+            "description": "New in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "ENUM",
+              "name": "WarehouseClickAndCollectOptionEnum",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "email",
             "description": "The email address of the warehouse.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPrivate",
+            "description": "New in Saleor 3.1. Visibility of warehouse stocks. Note: this feature is in a preview state and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -78934,6 +85460,115 @@
             "deprecationReason": null
           },
           {
+            "name": "asyncEvents",
+            "description": "List of asynchronous webhook events.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WebhookEventAsync",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventDeliveries",
+            "description": "Event deliveries.",
+            "args": [
+              {
+                "name": "after",
+                "description": "Return the elements in the list that come after the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Return the elements in the list that come before the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": "Event delivery filter options.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EventDeliveryFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Return the first n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Return the last n elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortBy",
+                "description": "Event delivery sorter.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EventDeliverySortingInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EventDeliveryCountableConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "events",
             "description": "List of webhook events.",
             "args": [],
@@ -78954,12 +85589,12 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead."
           },
           {
             "name": "id",
-            "description": "The ID of the object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -79013,6 +85648,30 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "syncEvents",
+            "description": "List of synchronous webhook events.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WebhookEventSync",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -79108,7 +85767,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -79135,8 +85794,28 @@
             "deprecationReason": null
           },
           {
+            "name": "asyncEvents",
+            "description": "The asynchronous events that webhook wants to subscribe.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WebhookEventTypeAsyncEnum",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "events",
-            "description": "The events that webhook wants to subscribe.",
+            "description": "The events that webhook wants to subscribe. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -79181,6 +85860,26 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "syncEvents",
+            "description": "The synchronous events that webhook wants to subscribe.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WebhookEventTypeSyncEnum",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -79266,7 +85965,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -79410,8 +86109,94 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "WebhookEventAsync",
+        "description": "Asynchronous webhook event.",
+        "fields": [
+          {
+            "name": "eventType",
+            "description": "Internal name of the event type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WebhookEventTypeAsyncEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Display name of the event.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WebhookEventSync",
+        "description": "Synchronous webhook event.",
+        "fields": [
+          {
+            "name": "eventType",
+            "description": "Internal name of the event type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WebhookEventTypeSyncEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Display name of the event.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
-        "name": "WebhookEventTypeEnum",
+        "name": "WebhookEventTypeAsyncEnum",
         "description": "Enum determining type of webhook.",
         "fields": null,
         "inputFields": null,
@@ -79430,14 +86215,26 @@
             "deprecationReason": null
           },
           {
-            "name": "CHECKOUT_FILTER_SHIPPING_METHODS",
-            "description": null,
+            "name": "CHECKOUT_UPDATED",
+            "description": "A checkout is updated. It also triggers all updates related to the checkout.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "CHECKOUT_UPDATED",
-            "description": "A checkout is updated. It also triggers all updates related to the checkout.",
+            "name": "COLLECTION_CREATED",
+            "description": "A new collection is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_DELETED",
+            "description": "A collection is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_UPDATED",
+            "description": "A collection is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -79468,6 +86265,12 @@
           {
             "name": "DRAFT_ORDER_UPDATED",
             "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FULFILLMENT_CANCELED",
+            "description": "A fulfillment is cancelled.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -79520,12 +86323,6 @@
             "deprecationReason": null
           },
           {
-            "name": "ORDER_FILTER_SHIPPING_METHODS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "ORDER_FULFILLED",
             "description": "An order is fulfilled.",
             "isDeprecated": false,
@@ -79562,48 +86359,6 @@
             "deprecationReason": null
           },
           {
-            "name": "PAYMENT_AUTHORIZE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PAYMENT_CAPTURE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PAYMENT_CONFIRM",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PAYMENT_LIST_GATEWAYS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PAYMENT_PROCESS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PAYMENT_REFUND",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PAYMENT_VOID",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "PRODUCT_CREATED",
             "description": "A new product is created.",
             "isDeprecated": false,
@@ -79622,6 +86377,12 @@
             "deprecationReason": null
           },
           {
+            "name": "PRODUCT_VARIANT_BACK_IN_STOCK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PRODUCT_VARIANT_CREATED",
             "description": "A new product variant is created.",
             "isDeprecated": false,
@@ -79634,8 +86395,32 @@
             "deprecationReason": null
           },
           {
+            "name": "PRODUCT_VARIANT_OUT_OF_STOCK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PRODUCT_VARIANT_UPDATED",
             "description": "A product variant is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_UPDATED",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -79656,12 +86441,18 @@
       },
       {
         "kind": "ENUM",
-        "name": "WebhookSampleEventTypeEnum",
-        "description": "An enumeration.",
+        "name": "WebhookEventTypeEnum",
+        "description": "Enum determining type of webhook.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
+          {
+            "name": "ANY_EVENTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "CHECKOUT_CREATED",
             "description": null,
@@ -79676,6 +86467,24 @@
           },
           {
             "name": "CHECKOUT_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_UPDATED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -79706,6 +86515,12 @@
           },
           {
             "name": "DRAFT_ORDER_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FULFILLMENT_CANCELED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -79861,6 +86676,12 @@
             "deprecationReason": null
           },
           {
+            "name": "PRODUCT_VARIANT_BACK_IN_STOCK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PRODUCT_VARIANT_CREATED",
             "description": null,
             "isDeprecated": false,
@@ -79873,7 +86694,347 @@
             "deprecationReason": null
           },
           {
+            "name": "PRODUCT_VARIANT_OUT_OF_STOCK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PRODUCT_VARIANT_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SHIPPING_LIST_METHODS_FOR_CHECKOUT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TRANSLATION_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TRANSLATION_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WebhookEventTypeSyncEnum",
+        "description": "Enum determining type of webhook.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CHECKOUT_FILTER_SHIPPING_METHODS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_FILTER_SHIPPING_METHODS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_AUTHORIZE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_CAPTURE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_CONFIRM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_LIST_GATEWAYS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_PROCESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_REFUND",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAYMENT_VOID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SHIPPING_LIST_METHODS_FOR_CHECKOUT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WebhookSampleEventTypeEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CHECKOUT_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CHECKOUT_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COLLECTION_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOMER_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOMER_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DRAFT_ORDER_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DRAFT_ORDER_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DRAFT_ORDER_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FULFILLMENT_CANCELED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FULFILLMENT_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVOICE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVOICE_REQUESTED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVOICE_SENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOTIFY_USER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_CANCELLED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_CONFIRMED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_FULFILLED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_FULLY_PAID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_VARIANT_BACK_IN_STOCK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_VARIANT_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_VARIANT_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_VARIANT_OUT_OF_STOCK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCT_VARIANT_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_UPDATED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -79956,7 +87117,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use errors field instead. This field will be removed in Saleor 4.0."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `errors` field instead."
           }
         ],
         "inputFields": null,
@@ -79983,8 +87144,28 @@
             "deprecationReason": null
           },
           {
+            "name": "asyncEvents",
+            "description": "The asynchronous events that webhook wants to subscribe.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WebhookEventTypeAsyncEnum",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "events",
-            "description": "The events that webhook wants to subscribe.",
+            "description": "The events that webhook wants to subscribe. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -80029,6 +87210,26 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "syncEvents",
+            "description": "The synchronous events that webhook wants to subscribe.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WebhookEventTypeSyncEnum",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -80148,7 +87349,7 @@
       {
         "kind": "SCALAR",
         "name": "_Any",
-        "description": "Anything",
+        "description": "_Any value scalar as defined by Federation spec.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -80158,7 +87359,7 @@
       {
         "kind": "UNION",
         "name": "_Entity",
-        "description": null,
+        "description": "_Entity union as defined by Federation spec.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -80224,7 +87425,7 @@
       {
         "kind": "OBJECT",
         "name": "_Service",
-        "description": null,
+        "description": "_Service manifest as defined by Federation spec.",
         "fields": [
           {
             "name": "sdl",

--- a/lib/const.ts
+++ b/lib/const.ts
@@ -1,3 +1,4 @@
 export const CHECKOUT_TOKEN = "checkoutToken";
 export const API_URI = process.env.NEXT_PUBLIC_API_URI || "";
 export const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
+export const HOMEPAGE_MENU = process.env.NEXT_PUBLIC_HOMEPAGE_MENU || "";

--- a/next.config.js
+++ b/next.config.js
@@ -2,11 +2,13 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
 
+const apiURL = new URL(process.env.NEXT_PUBLIC_API_URI);
+
 module.exports = withBundleAnalyzer({
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ["vercel.saleor.cloud", "img.youtube.com"],
+    domains: [apiURL.hostname, "img.youtube.com"],
     formats: ["image/avif", "image/webp"],
   },
   async redirects() {
@@ -21,6 +23,6 @@ module.exports = withBundleAnalyzer({
     ];
   },
   experimental: {
-    reactRoot: true
+    reactRoot: true,
   },
 });

--- a/pages/[channel]/[locale]/account/orders/[token].tsx
+++ b/pages/[channel]/[locale]/account/orders/[token].tsx
@@ -3,7 +3,7 @@ import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import Image from "next/image";
 import { ReactElement } from "react";
 
-import { Layout, Spinner } from "@/components";
+import { AccountLayout, Spinner } from "@/components";
 import AddressDisplay from "@/components/checkout/AddressDisplay";
 import { useRegions } from "@/components/RegionsProvider";
 import { useOrderDetailsByTokenQuery } from "@/saleor/api";
@@ -146,5 +146,5 @@ const OrderDetailsPage = ({
 export default OrderDetailsPage;
 
 OrderDetailsPage.getLayout = function getLayout(page: ReactElement) {
-  return <Layout>{page}</Layout>;
+  return <AccountLayout>{page}</AccountLayout>;
 };

--- a/pages/[channel]/[locale]/checkout.tsx
+++ b/pages/[channel]/[locale]/checkout.tsx
@@ -1,11 +1,22 @@
-import React, { ReactElement } from "react";
+import { useRouter } from "next/router";
+import React, { ReactElement, useEffect } from "react";
 
 import { CheckoutForm, CheckoutSidebar, Layout, Spinner } from "@/components";
 import BaseSeo from "@/components/seo/BaseSeo";
+import { usePaths } from "@/lib/paths";
 import { useCheckout } from "@/lib/providers/CheckoutProvider";
 
 const CheckoutPage = () => {
+  const router = useRouter();
+  const paths = usePaths();
   const { checkout, loading } = useCheckout();
+
+  useEffect(() => {
+    // Redirect to cart if theres no checkout data
+    if (!loading && (!checkout || !checkout.lines?.length)) {
+      router.push(paths.cart.$url());
+    }
+  });
 
   if (loading) {
     return (

--- a/pages/[channel]/[locale]/index.tsx
+++ b/pages/[channel]/[locale]/index.tsx
@@ -9,6 +9,7 @@ import { useIntl } from "react-intl";
 
 import { HomepageBlock, Layout } from "@/components";
 import BaseSeo from "@/components/seo/BaseSeo";
+import { HOMEPAGE_MENU } from "@/lib/const";
 import apolloClient from "@/lib/graphql";
 import { contextToRegionQuery } from "@/lib/regions";
 import { homepagePaths } from "@/lib/ssr/homepage";
@@ -54,7 +55,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
     await apolloClient.query<HomepageBlocksQuery, HomepageBlocksQueryVariables>(
       {
         query: HomepageBlocksQueryDocument,
-        variables: { slug: "homepage", ...contextToRegionQuery(context) },
+        variables: { slug: HOMEPAGE_MENU, ...contextToRegionQuery(context) },
       }
     );
   return {

--- a/pages/[channel]/[locale]/order.tsx
+++ b/pages/[channel]/[locale]/order.tsx
@@ -13,8 +13,7 @@ const OrderCompletedPage = () => {
       <CheckIcon className="text-green-700" />
       <div className="font-semibold text-3xl">Your order is completed!</div>
       <p className="mt-2">
-        To check your orders,
-        <Link href={paths.account.orders.$url()}> click here.</Link>
+        <Link href={paths.$url()}>Go back to homepage</Link>
       </p>
     </main>
   );

--- a/pages/[channel]/[locale]/products/[slug].tsx
+++ b/pages/[channel]/[locale]/products/[slug].tsx
@@ -189,7 +189,7 @@ const ProductPage = ({
             type="submit"
             disabled={isAddToCartButtonDisabled}
             className={clsx(
-              "max-w-xs w-full bg-blue-600 border border-transparent rounded-md py-3 px-8 flex items-center justify-center text-white hover:bg-blue-700 focus:outline-none",
+              "w-full bg-blue-600 border border-transparent rounded-md py-3 px-8 flex items-center justify-center text-white hover:bg-blue-700 focus:outline-none",
               isAddToCartButtonDisabled && "bg-gray-400 hover:bg-gray-400"
             )}
           >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,14 +51,14 @@ specifiers:
   typescript: 4.5.5
 
 dependencies:
-  '@apollo/client': 3.5.9_graphql@16.3.0+react@18.0.0-rc.0
+  '@apollo/client': 3.5.9_graphql@16.3.0+react@18.0.0-rc.2
   '@formatjs/swc-plugin': 1.3.2
   '@formatjs/ts-transformer': 3.9.2
   '@graphql-codegen/typescript-apollo-client-helpers': 2.1.12_graphql@16.3.0
-  '@headlessui/react': 1.5.0_757a802188413a36d4f24237d13b8e90
-  '@heroicons/react': 1.0.5_react@18.0.0-rc.0
-  '@saleor/sdk': 0.4.3_dbca4a5778fc64d751a22a2e45bb2641
-  '@stripe/react-stripe-js': 1.7.0_358c5e6d3e84eff3591273d9ac32b5df
+  '@headlessui/react': 1.5.0_bc22c48adf1a4e34a005159413cd72b5
+  '@heroicons/react': 1.0.5_react@18.0.0-rc.2
+  '@saleor/sdk': 0.4.3_20a7e8fe6898c896da7d8d5eb43b1d1b
+  '@stripe/react-stripe-js': 1.7.0_ea1d388c774a5d68c96a5549b0736d30
   '@stripe/stripe-js': 1.23.0
   '@tailwindcss/aspect-ratio': 0.4.0_tailwindcss@3.0.23
   '@tailwindcss/forms': 0.4.0_tailwindcss@3.0.23
@@ -66,16 +66,16 @@ dependencies:
   clsx: 1.1.1
   dotenv: 16.0.0
   dotenv-cli: 5.0.0
-  editorjs-blocks-react-renderer: 1.2.4_757a802188413a36d4f24237d13b8e90
+  editorjs-blocks-react-renderer: 1.2.4_bc22c48adf1a4e34a005159413cd72b5
   graphql: 16.3.0
-  next: 12.1.0_757a802188413a36d4f24237d13b8e90
-  next-seo: 5.1.0_ed58c1fe6c0bcbb0c2a343be17e9a4cb
+  next: 12.1.0_bc22c48adf1a4e34a005159413cd72b5
+  next-seo: 5.1.0_f9f209fbece82d217ff4e6481a2563a4
   next-sitemap: 2.4.3_next@12.1.0
-  next-usequerystate: 1.7.0_ed58c1fe6c0bcbb0c2a343be17e9a4cb
-  react: 18.0.0-rc.0
-  react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
-  react-hook-form: 7.27.1_react@18.0.0-rc.0
-  react-use: 17.3.2_757a802188413a36d4f24237d13b8e90
+  next-usequerystate: 1.7.0_f9f209fbece82d217ff4e6481a2563a4
+  react: 18.0.0-rc.2
+  react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
+  react-hook-form: 7.27.1_react@18.0.0-rc.2
+  react-use: 17.3.2_bc22c48adf1a4e34a005159413cd72b5
   tailwind-scrollbar-hide: 1.1.7
 
 devDependencies:
@@ -98,7 +98,7 @@ devDependencies:
   pathpida: 0.17.0
   postcss: 8.4.6
   prettier: 2.5.1
-  react-intl: 5.24.6_daf30299ea814298d69eb7ca356c7ed8
+  react-intl: 5.24.6_c0fd991a5970210ee3156d2bd7315866
   tailwindcss: 3.0.23_autoprefixer@10.4.2
   typescript: 4.5.5
 
@@ -110,7 +110,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.4
 
-  /@apollo/client/3.5.9_graphql@16.3.0+react@18.0.0-rc.0:
+  /@apollo/client/3.5.9_graphql@16.3.0+react@18.0.0-rc.2:
     resolution: {integrity: sha512-Qq3OE3GpyPG2fYXBzi1n4QXcKZ11c6jHdrXK2Kkn9SD+vUymSrllXsldqnKUK9tslxKqkKzNrkCXkLv7PxwfSQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -131,7 +131,7 @@ packages:
       hoist-non-react-statics: 3.3.2
       optimism: 0.16.1
       prop-types: 15.8.1
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
       symbol-observable: 4.0.0
       ts-invariant: 0.9.4
       tslib: 2.3.1
@@ -1287,23 +1287,23 @@ packages:
       graphql: 16.3.0
     dev: false
 
-  /@headlessui/react/1.5.0_757a802188413a36d4f24237d13b8e90:
+  /@headlessui/react/1.5.0_bc22c48adf1a4e34a005159413cd72b5:
     resolution: {integrity: sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16 || ^17 || ^18
       react-dom: ^16 || ^17 || ^18
     dependencies:
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
     dev: false
 
-  /@heroicons/react/1.0.5_react@18.0.0-rc.0:
+  /@heroicons/react/1.0.5_react@18.0.0-rc.2:
     resolution: {integrity: sha512-UDMyLM2KavIu2vlWfMspapw9yii7aoLwzI2Hudx4fyoPwfKfxU8r3cL8dEBXOjcLG0/oOONZzbT14M1HoNtEcg==}
     peerDependencies:
       react: '>= 16'
     dependencies:
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
     dev: false
 
   /@humanwhocodes/config-array/0.9.3:
@@ -1493,7 +1493,7 @@ packages:
     resolution: {integrity: sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==}
     dev: true
 
-  /@saleor/sdk/0.4.3_dbca4a5778fc64d751a22a2e45bb2641:
+  /@saleor/sdk/0.4.3_20a7e8fe6898c896da7d8d5eb43b1d1b:
     resolution: {integrity: sha512-gg/7e729PfT4t6SgpmOpNhzC9umytcci0pBUB+f8DxfluRgml0HJcZgKPDOH8AKap6taXZHR8o9kotT0FahOJw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -1501,11 +1501,11 @@ packages:
       graphql: ^15.5.0
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@apollo/client': 3.5.9_graphql@16.3.0+react@18.0.0-rc.0
+      '@apollo/client': 3.5.9_graphql@16.3.0+react@18.0.0-rc.2
       cross-fetch: 3.1.5
       graphql: 16.3.0
       jwt-decode: 3.1.2
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -1531,7 +1531,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /@stripe/react-stripe-js/1.7.0_358c5e6d3e84eff3591273d9ac32b5df:
+  /@stripe/react-stripe-js/1.7.0_ea1d388c774a5d68c96a5549b0736d30:
     resolution: {integrity: sha512-L20v8Jq0TDZFL2+y+uXD751t6q9SalSFkSYZpmZ2VWrGZGK7HAGfRQ804dzYSSr5fGenW6iz6y7U0YKfC/TK3g==}
     peerDependencies:
       '@stripe/stripe-js': ^1.20.3
@@ -1540,8 +1540,8 @@ packages:
     dependencies:
       '@stripe/stripe-js': 1.23.0
       prop-types: 15.8.1
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
     dev: false
 
   /@stripe/stripe-js/1.23.0:
@@ -2739,16 +2739,16 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /editorjs-blocks-react-renderer/1.2.4_757a802188413a36d4f24237d13b8e90:
+  /editorjs-blocks-react-renderer/1.2.4_bc22c48adf1a4e34a005159413cd72b5:
     resolution: {integrity: sha512-oplMOLKAgMBJ/URPXDOa5pm5XAoTTAn1p+NS9AdbH+Fr2fbnTZuiYIhQdmlkXQfH+DVtPztAFtz5G54z6aDq3w==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'
     dependencies:
-      html-react-parser: 1.4.8_react@18.0.0-rc.0
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
+      html-react-parser: 1.4.8_react@18.0.0-rc.2
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
     dev: false
 
   /electron-to-chromium/1.4.71:
@@ -2865,7 +2865,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.9.0
       eslint-plugin-react: 7.28.0_eslint@8.9.0
       eslint-plugin-react-hooks: 4.3.0_eslint@8.9.0
-      next: 12.1.0_757a802188413a36d4f24237d13b8e90
+      next: 12.1.0_bc22c48adf1a4e34a005159413cd72b5
       typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
@@ -3579,14 +3579,14 @@ packages:
       htmlparser2: 7.2.0
     dev: false
 
-  /html-react-parser/1.4.8_react@18.0.0-rc.0:
+  /html-react-parser/1.4.8_react@18.0.0-rc.2:
     resolution: {integrity: sha512-5XsBdFVhJLxdtRp7tWwZ6DwqOt6fJ+2lJc0lctwjX1yaxWNB41S5uzqii7vJcSCaabM+CK28U75e5f4wIMqdSg==}
     peerDependencies:
       react: 0.14 || 15 || 16 || 17
     dependencies:
       domhandler: 4.3.0
       html-dom-parser: 1.1.0
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
       react-property: 2.0.0
       style-to-js: 1.1.0
     dev: false
@@ -4397,7 +4397,7 @@ packages:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: true
 
-  /nano-css/5.3.4_757a802188413a36d4f24237d13b8e90:
+  /nano-css/5.3.4_bc22c48adf1a4e34a005159413cd72b5:
     resolution: {integrity: sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==}
     peerDependencies:
       react: '*'
@@ -4407,8 +4407,8 @@ packages:
       csstype: 3.0.10
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 6.0.1
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
       rtl-css-js: 1.15.0
       sourcemap-codec: 1.4.8
       stacktrace-js: 2.0.2
@@ -4424,16 +4424,16 @@ packages:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
 
-  /next-seo/5.1.0_ed58c1fe6c0bcbb0c2a343be17e9a4cb:
+  /next-seo/5.1.0_f9f209fbece82d217ff4e6481a2563a4:
     resolution: {integrity: sha512-ampuQfNTOi1x+xtRIb6CZGunIo6rQXtMo2Tyu861d5GjJFIwfOXsA4lzCa4+e2rLkyXDyVpavNNUZWa3US9ELw==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 12.1.0_757a802188413a36d4f24237d13b8e90
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
+      next: 12.1.0_bc22c48adf1a4e34a005159413cd72b5
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
     dev: false
 
   /next-sitemap/2.4.3_next@12.1.0:
@@ -4445,22 +4445,22 @@ packages:
     dependencies:
       '@corex/deepmerge': 2.6.148
       minimist: 1.2.5
-      next: 12.1.0_757a802188413a36d4f24237d13b8e90
+      next: 12.1.0_bc22c48adf1a4e34a005159413cd72b5
     dev: false
 
-  /next-usequerystate/1.7.0_ed58c1fe6c0bcbb0c2a343be17e9a4cb:
+  /next-usequerystate/1.7.0_f9f209fbece82d217ff4e6481a2563a4:
     resolution: {integrity: sha512-OAR+4zgWCz1P5XnrbCrhTBf/UfJIoj17mXRDB5daUq5yYZyYETWQnJFuqEFB9qEd8KrpjBNF2aSmrQpqVXdLUA==}
     peerDependencies:
       next: '*'
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 12.1.0_757a802188413a36d4f24237d13b8e90
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
+      next: 12.1.0_bc22c48adf1a4e34a005159413cd72b5
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
     dev: false
 
-  /next/12.1.0_757a802188413a36d4f24237d13b8e90:
+  /next/12.1.0_bc22c48adf1a4e34a005159413cd72b5:
     resolution: {integrity: sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -4481,10 +4481,10 @@ packages:
       '@next/env': 12.1.0
       caniuse-lite: 1.0.30001312
       postcss: 8.4.5
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
-      styled-jsx: 5.0.0_react@18.0.0-rc.0
-      use-subscription: 1.5.1_react@18.0.0-rc.0
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
+      styled-jsx: 5.0.0_react@18.0.0-rc.2
+      use-subscription: 1.5.1_react@18.0.0-rc.2
     optionalDependencies:
       '@next/swc-android-arm64': 12.1.0
       '@next/swc-darwin-arm64': 12.1.0
@@ -4963,27 +4963,26 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-dom/18.0.0-rc.0_react@18.0.0-rc.0:
-    resolution: {integrity: sha512-tdD1n0svTndHBQvVAq/f2Kx7FgQ30CpSLp87/neQKAHPW5WtdgW1sBSwmFAcMQOrmstTuP0M+zRlH86f9kMX/A==}
+  /react-dom/18.0.0-rc.2_react@18.0.0-rc.2:
+    resolution: {integrity: sha512-EvLlgtc/wAzAIXX5V1gnLgeK9B3wAdEGmmrXXKRoRzXM0RNNwGN+6OxQPBlACiGDUYYEOk+GT8f6u+gNWDnTtg==}
     peerDependencies:
-      react: ^18.0.0-rc.0
+      react: ^18.0.0-rc.2
     dependencies:
       loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
       scheduler: 0.21.0-rc.0-next-fe905f152-20220107
     dev: false
 
-  /react-hook-form/7.27.1_react@18.0.0-rc.0:
+  /react-hook-form/7.27.1_react@18.0.0-rc.2:
     resolution: {integrity: sha512-N3a7A6zIQ8DJeThisVZGtOUabTbJw+7DHJidmB9w8m3chckv2ZWKb5MHps9d2pPJqmCDoWe53Bos56bYmJms5w==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17
     dependencies:
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
     dev: false
 
-  /react-intl/5.24.6_daf30299ea814298d69eb7ca356c7ed8:
+  /react-intl/5.24.6_c0fd991a5970210ee3156d2bd7315866:
     resolution: {integrity: sha512-6gUhQwNAeAoRpN6F3N+bR66aot/mI6yduRwQS5ajfmXHX/YFvOfINkgMFTTrcbf3+qjBhACNU3ek4wFt6cn2ww==}
     peerDependencies:
       react: ^16.3.0 || 17
@@ -5001,7 +5000,7 @@ packages:
       '@types/react': 17.0.39
       hoist-non-react-statics: 3.3.2
       intl-messageformat: 9.11.4
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
       tslib: 2.3.1
       typescript: 4.5.5
     dev: true
@@ -5013,17 +5012,17 @@ packages:
     resolution: {integrity: sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==}
     dev: false
 
-  /react-universal-interface/0.6.2_react@18.0.0-rc.0+tslib@2.3.1:
+  /react-universal-interface/0.6.2_react@18.0.0-rc.2+tslib@2.3.1:
     resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
     peerDependencies:
       react: '*'
       tslib: '*'
     dependencies:
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
       tslib: 2.3.1
     dev: false
 
-  /react-use/17.3.2_757a802188413a36d4f24237d13b8e90:
+  /react-use/17.3.2_bc22c48adf1a4e34a005159413cd72b5:
     resolution: {integrity: sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==}
     peerDependencies:
       react: ^16.8.0  || ^17.0.0
@@ -5035,10 +5034,10 @@ packages:
       fast-deep-equal: 3.1.3
       fast-shallow-equal: 1.0.0
       js-cookie: 2.2.1
-      nano-css: 5.3.4_757a802188413a36d4f24237d13b8e90
-      react: 18.0.0-rc.0
-      react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
-      react-universal-interface: 0.6.2_react@18.0.0-rc.0+tslib@2.3.1
+      nano-css: 5.3.4_bc22c48adf1a4e34a005159413cd72b5
+      react: 18.0.0-rc.2
+      react-dom: 18.0.0-rc.2_react@18.0.0-rc.2
+      react-universal-interface: 0.6.2_react@18.0.0-rc.2+tslib@2.3.1
       resize-observer-polyfill: 1.5.1
       screenfull: 5.2.0
       set-harmonic-interval: 1.0.1
@@ -5047,12 +5046,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /react/18.0.0-rc.0:
-    resolution: {integrity: sha512-PawosMBgF8k5Nlc3++ibzjFqPvo1XKv80MNtVYqz3abHHB2w3IpU65sSdSmBd2ooCwVhcp9b1vkx/twqhakNtA==}
+  /react/18.0.0-rc.2:
+    resolution: {integrity: sha512-q32FWyA5HvqfRCN0ZOk0gUOpzJGPPh8fqbk8DYQuh4DyiGWiNgN/BxMq3/ScY0SlwDB1HOAMU1lUgtaOr5p2Ng==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-      object-assign: 4.1.1
     dev: false
 
   /readable-stream/3.6.0:
@@ -5534,7 +5532,7 @@ packages:
       inline-style-parser: 0.1.1
     dev: false
 
-  /styled-jsx/5.0.0_react@18.0.0-rc.0:
+  /styled-jsx/5.0.0_react@18.0.0-rc.2:
     resolution: {integrity: sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -5547,7 +5545,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
     dev: false
 
   /stylis/4.0.13:
@@ -5842,13 +5840,13 @@ packages:
       prepend-http: 2.0.0
     dev: true
 
-  /use-subscription/1.5.1_react@18.0.0-rc.0:
+  /use-subscription/1.5.1_react@18.0.0-rc.2:
     resolution: {integrity: sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       object-assign: 4.1.1
-      react: 18.0.0-rc.0
+      react: 18.0.0-rc.2
     dev: false
 
   /util-deprecate/1.0.2:

--- a/saleor/api.tsx
+++ b/saleor/api.tsx
@@ -34,12 +34,6 @@ export type Scalars = {
    * String, Boolean, Int, Float, List or Object.
    */
   GenericScalar: any;
-  /**
-   * Allows use of a JSON String for input / output from the GraphQL schema.
-   *
-   * Use of this type is *not recommended* as you lose the benefits of having a defined, static
-   * schema (one of the key benefits of GraphQL).
-   */
   JSONString: string;
   /**
    * Positive Decimal scalar implementation.
@@ -51,14 +45,14 @@ export type Scalars = {
   /** Variables of this type must be set to null in mutations. They will be replaced with a filename from a following multipart part containing a binary file. See: https://github.com/jaydenseric/graphql-multipart-request-spec. */
   Upload: any;
   WeightScalar: any;
-  /** Anything */
+  /** _Any value scalar as defined by Federation spec. */
   _Any: any;
 };
 
 /** Create a new address for the customer. */
 export type AccountAddressCreate = {
   __typename?: 'AccountAddressCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   address?: Maybe<Address>;
   errors: Array<AccountError>;
@@ -69,7 +63,7 @@ export type AccountAddressCreate = {
 /** Delete an address of the logged-in user. */
 export type AccountAddressDelete = {
   __typename?: 'AccountAddressDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   address?: Maybe<Address>;
   errors: Array<AccountError>;
@@ -80,7 +74,7 @@ export type AccountAddressDelete = {
 /** Updates an address of the logged-in user. */
 export type AccountAddressUpdate = {
   __typename?: 'AccountAddressUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   address?: Maybe<Address>;
   errors: Array<AccountError>;
@@ -91,7 +85,7 @@ export type AccountAddressUpdate = {
 /** Remove user account. */
 export type AccountDelete = {
   __typename?: 'AccountDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   user?: Maybe<User>;
@@ -161,7 +155,7 @@ export type AccountInput = {
 /** Register a new user. */
 export type AccountRegister = {
   __typename?: 'AccountRegister';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** Informs whether users need to confirm their email address. */
@@ -174,8 +168,12 @@ export type AccountRegisterInput = {
   channel?: InputMaybe<Scalars['String']>;
   /** The email address of the user. */
   email: Scalars['String'];
+  /** Given name. */
+  firstName?: InputMaybe<Scalars['String']>;
   /** User language code. */
   languageCode?: InputMaybe<LanguageCodeEnum>;
+  /** Family name. */
+  lastName?: InputMaybe<Scalars['String']>;
   /** User public metadata. */
   metadata?: InputMaybe<Array<MetadataInput>>;
   /** Password. */
@@ -187,7 +185,7 @@ export type AccountRegisterInput = {
 /** Sends an email with the account removal link for the logged-in user. */
 export type AccountRequestDeletion = {
   __typename?: 'AccountRequestDeletion';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
 };
@@ -195,7 +193,7 @@ export type AccountRequestDeletion = {
 /** Sets a default address for the authenticated user. */
 export type AccountSetDefaultAddress = {
   __typename?: 'AccountSetDefaultAddress';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** An updated user instance. */
@@ -205,7 +203,7 @@ export type AccountSetDefaultAddress = {
 /** Updates the account of the logged-in user. */
 export type AccountUpdate = {
   __typename?: 'AccountUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   user?: Maybe<User>;
@@ -221,7 +219,6 @@ export type Address = Node & {
   country: CountryDisplay;
   countryArea: Scalars['String'];
   firstName: Scalars['String'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Address is user's default billing address. */
   isDefaultBillingAddress?: Maybe<Scalars['Boolean']>;
@@ -237,7 +234,7 @@ export type Address = Node & {
 /** Creates user address. */
 export type AddressCreate = {
   __typename?: 'AddressCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   address?: Maybe<Address>;
   errors: Array<AccountError>;
@@ -248,7 +245,7 @@ export type AddressCreate = {
 /** Deletes an address. */
 export type AddressDelete = {
   __typename?: 'AddressDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   address?: Maybe<Address>;
   errors: Array<AccountError>;
@@ -284,7 +281,7 @@ export type AddressInput = {
 /** Sets a default address for the given user. */
 export type AddressSetDefault = {
   __typename?: 'AddressSetDefault';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** An updated user instance. */
@@ -299,7 +296,7 @@ export type AddressTypeEnum =
 /** Updates an address. */
 export type AddressUpdate = {
   __typename?: 'AddressUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   address?: Maybe<Address>;
   errors: Array<AccountError>;
@@ -331,7 +328,6 @@ export type AddressValidationData = {
 /** Represents allocation. */
 export type Allocation = Node & {
   __typename?: 'Allocation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Quantity allocated for orders. */
   quantity: Scalars['Int'];
@@ -356,9 +352,10 @@ export type App = Node & ObjectWithMetadata & {
   dataPrivacy?: Maybe<Scalars['String']>;
   /** Url to details about the privacy policy on the app owner page. */
   dataPrivacyUrl?: Maybe<Scalars['String']>;
+  /** New in Saleor 3.1. App's dashboard extensions. Note: this feature is in a preview state and can be subject to changes at later point. */
+  extensions: Array<AppExtension>;
   /** Homepage of the app. */
   homepageUrl?: Maybe<Scalars['String']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Determine if app will be set active or not. */
   isActive?: Maybe<Scalars['Boolean']>;
@@ -386,7 +383,7 @@ export type App = Node & ObjectWithMetadata & {
 export type AppActivate = {
   __typename?: 'AppActivate';
   app?: Maybe<App>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   errors: Array<AppError>;
 };
@@ -412,7 +409,7 @@ export type AppCountableEdge = {
 export type AppCreate = {
   __typename?: 'AppCreate';
   app?: Maybe<App>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   /** The newly created authentication token. */
   authToken?: Maybe<Scalars['String']>;
@@ -423,7 +420,7 @@ export type AppCreate = {
 export type AppDeactivate = {
   __typename?: 'AppDeactivate';
   app?: Maybe<App>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   errors: Array<AppError>;
 };
@@ -432,7 +429,7 @@ export type AppDeactivate = {
 export type AppDelete = {
   __typename?: 'AppDelete';
   app?: Maybe<App>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   errors: Array<AppError>;
 };
@@ -440,7 +437,7 @@ export type AppDelete = {
 /** Delete failed installation. */
 export type AppDeleteFailedInstallation = {
   __typename?: 'AppDeleteFailedInstallation';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   appInstallation?: Maybe<AppInstallation>;
   errors: Array<AppError>;
@@ -474,10 +471,74 @@ export type AppErrorCode =
   | 'REQUIRED'
   | 'UNIQUE';
 
+/** Represents app data. */
+export type AppExtension = Node & {
+  __typename?: 'AppExtension';
+  /** JWT token used to authenticate by thridparty app extension. */
+  accessToken?: Maybe<Scalars['String']>;
+  app: App;
+  id: Scalars['ID'];
+  /** Label of the extension to show in the dashboard. */
+  label: Scalars['String'];
+  /** Place where given extension will be mounted. */
+  mount: AppExtensionMountEnum;
+  /** List of the app extension's permissions. */
+  permissions: Array<Permission>;
+  /** Type of way how app extension will be opened. */
+  target: AppExtensionTargetEnum;
+  /** URL of a view where extension's iframe is placed. */
+  url: Scalars['String'];
+};
+
+export type AppExtensionCountableConnection = {
+  __typename?: 'AppExtensionCountableConnection';
+  edges: Array<AppExtensionCountableEdge>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  /** A total count of items in the collection. */
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type AppExtensionCountableEdge = {
+  __typename?: 'AppExtensionCountableEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node: AppExtension;
+};
+
+export type AppExtensionFilterInput = {
+  mount?: InputMaybe<Array<InputMaybe<AppExtensionMountEnum>>>;
+  target?: InputMaybe<AppExtensionTargetEnum>;
+};
+
+/** All places where app extension can be mounted. */
+export type AppExtensionMountEnum =
+  | 'NAVIGATION_CATALOG'
+  | 'NAVIGATION_CUSTOMERS'
+  | 'NAVIGATION_DISCOUNTS'
+  | 'NAVIGATION_ORDERS'
+  | 'NAVIGATION_PAGES'
+  | 'NAVIGATION_TRANSLATIONS'
+  | 'PRODUCT_DETAILS_MORE_ACTIONS'
+  | 'PRODUCT_OVERVIEW_CREATE'
+  | 'PRODUCT_OVERVIEW_MORE_ACTIONS';
+
+/**
+ * All available ways of opening an app extension.
+ *
+ *     POPUP - app's extension will be mounted as a popup window
+ *     APP_PAGE - redirect to app's page
+ *
+ */
+export type AppExtensionTargetEnum =
+  | 'APP_PAGE'
+  | 'POPUP';
+
 /** Fetch and validate manifest. */
 export type AppFetchManifest = {
   __typename?: 'AppFetchManifest';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   errors: Array<AppError>;
   manifest?: Maybe<Manifest>;
@@ -499,7 +560,7 @@ export type AppInput = {
 /** Install new app by using app manifest. */
 export type AppInstall = {
   __typename?: 'AppInstall';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   appInstallation?: Maybe<AppInstallation>;
   errors: Array<AppError>;
@@ -522,7 +583,6 @@ export type AppInstallation = Job & Node & {
   appName: Scalars['String'];
   /** Created date time of job in ISO 8601 format. */
   createdAt: Scalars['DateTime'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   manifestUrl: Scalars['String'];
   /** Job message. */
@@ -533,10 +593,24 @@ export type AppInstallation = Job & Node & {
   updatedAt: Scalars['DateTime'];
 };
 
+export type AppManifestExtension = {
+  __typename?: 'AppManifestExtension';
+  /** Label of the extension to show in the dashboard. */
+  label: Scalars['String'];
+  /** Place where given extension will be mounted. */
+  mount: AppExtensionMountEnum;
+  /** List of the app extension's permissions. */
+  permissions: Array<Permission>;
+  /** Type of way how app extension will be opened. */
+  target: AppExtensionTargetEnum;
+  /** URL of a view where extension's iframe is placed. */
+  url: Scalars['String'];
+};
+
 /** Retry failed installation of new app. */
 export type AppRetryInstall = {
   __typename?: 'AppRetryInstall';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   appInstallation?: Maybe<AppInstallation>;
   errors: Array<AppError>;
@@ -560,7 +634,6 @@ export type AppToken = Node & {
   __typename?: 'AppToken';
   /** Last 4 characters of the token. */
   authToken?: Maybe<Scalars['String']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Name of the authenticated token. */
   name?: Maybe<Scalars['String']>;
@@ -569,7 +642,7 @@ export type AppToken = Node & {
 /** Creates a new token. */
 export type AppTokenCreate = {
   __typename?: 'AppTokenCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   appToken?: Maybe<AppToken>;
   /** The newly created authentication token. */
@@ -580,7 +653,7 @@ export type AppTokenCreate = {
 /** Deletes an authentication token assigned to app. */
 export type AppTokenDelete = {
   __typename?: 'AppTokenDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   appToken?: Maybe<AppToken>;
   errors: Array<AppError>;
@@ -596,7 +669,7 @@ export type AppTokenInput = {
 /** Verify provided app token. */
 export type AppTokenVerify = {
   __typename?: 'AppTokenVerify';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   errors: Array<AppError>;
   /** Determine if token is valid or not. */
@@ -614,7 +687,7 @@ export type AppTypeEnum =
 export type AppUpdate = {
   __typename?: 'AppUpdate';
   app?: Maybe<App>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   appErrors: Array<AppError>;
   errors: Array<AppError>;
 };
@@ -634,8 +707,17 @@ export type AssignNavigation = {
   errors: Array<MenuError>;
   /** Assigned navigation menu. */
   menu?: Maybe<Menu>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
+};
+
+/** New in Saleor 3.1. Represents assigned attribute to variant with variant selection attached. */
+export type AssignedVariantAttribute = {
+  __typename?: 'AssignedVariantAttribute';
+  /** Attribute assigned to variant. */
+  attribute: Attribute;
+  /** Determines, whether assigned attribute is allowed for variant selection. Supported variant types for variant selection are: ['dropdown', 'boolean', 'swatch', 'numeric'] */
+  variantSelection: Scalars['Boolean'];
 };
 
 /** Custom attribute of a product. Attributes can be assigned to products and variants at the product type level. */
@@ -651,7 +733,6 @@ export type Attribute = Node & ObjectWithMetadata & {
   filterableInDashboard: Scalars['Boolean'];
   /** Whether the attribute can be filtered in storefront. */
   filterableInStorefront: Scalars['Boolean'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** The input type to use for entering attribute values in the dashboard. */
   inputType?: Maybe<AttributeInputTypeEnum>;
@@ -719,7 +800,7 @@ export type AttributeTranslationArgs = {
 /** Deletes attributes. */
 export type AttributeBulkDelete = {
   __typename?: 'AttributeBulkDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
@@ -760,7 +841,7 @@ export type AttributeCountableEdge = {
 export type AttributeCreate = {
   __typename?: 'AttributeCreate';
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   errors: Array<AttributeError>;
 };
@@ -800,7 +881,7 @@ export type AttributeCreateInput = {
 export type AttributeDelete = {
   __typename?: 'AttributeDelete';
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   errors: Array<AttributeError>;
 };
@@ -831,7 +912,11 @@ export type AttributeErrorCode =
 
 export type AttributeFilterInput = {
   availableInGrid?: InputMaybe<Scalars['Boolean']>;
-  /** Specifies the channel by which the data should be filtered. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel by which the data should be filtered.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   filterableInDashboard?: InputMaybe<Scalars['Boolean']>;
   filterableInStorefront?: InputMaybe<Scalars['Boolean']>;
@@ -871,14 +956,15 @@ export type AttributeInputTypeEnum =
   | 'MULTISELECT'
   | 'NUMERIC'
   | 'REFERENCE'
-  | 'RICH_TEXT';
+  | 'RICH_TEXT'
+  | 'SWATCH';
 
 /** Reorder the values of an attribute. */
 export type AttributeReorderValues = {
   __typename?: 'AttributeReorderValues';
   /** Attribute from which values are reordered. */
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   errors: Array<AttributeError>;
 };
@@ -914,10 +1000,9 @@ export type AttributeTranslatableContent = Node & {
   __typename?: 'AttributeTranslatableContent';
   /**
    * Custom attribute of a product.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   attribute?: Maybe<Attribute>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   /** Returns translated attribute fields for the given language code. */
@@ -934,13 +1019,12 @@ export type AttributeTranslate = {
   __typename?: 'AttributeTranslate';
   attribute?: Maybe<Attribute>;
   errors: Array<TranslationError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
 export type AttributeTranslation = Node & {
   __typename?: 'AttributeTranslation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -956,14 +1040,14 @@ export type AttributeTypeEnum =
 export type AttributeUpdate = {
   __typename?: 'AttributeUpdate';
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   errors: Array<AttributeError>;
 };
 
 export type AttributeUpdateInput = {
   /** New values to be created for this attribute. */
-  addValues?: InputMaybe<Array<InputMaybe<AttributeValueCreateInput>>>;
+  addValues?: InputMaybe<Array<InputMaybe<AttributeValueUpdateInput>>>;
   /** Whether the attribute can be displayed in the admin product list. */
   availableInGrid?: InputMaybe<Scalars['Boolean']>;
   /** Whether the attribute can be filtered in dashboard. */
@@ -999,7 +1083,6 @@ export type AttributeValue = Node & {
   dateTime?: Maybe<Scalars['DateTime']>;
   /** Represents file URL and content type (if attribute value is a file). */
   file?: Maybe<File>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** The input type to use for entering attribute values in the dashboard. */
   inputType?: Maybe<AttributeInputTypeEnum>;
@@ -1013,7 +1096,7 @@ export type AttributeValue = Node & {
   slug?: Maybe<Scalars['String']>;
   /** Returns translated attribute value fields for the given language code. */
   translation?: Maybe<AttributeValueTranslation>;
-  /** Represents the value of the attribute value. */
+  /** Represent value of the attribute value (e.g. color values for swatch attributes). */
   value?: Maybe<Scalars['String']>;
 };
 
@@ -1026,7 +1109,7 @@ export type AttributeValueTranslationArgs = {
 /** Deletes values of attributes. */
 export type AttributeValueBulkDelete = {
   __typename?: 'AttributeValueBulkDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
@@ -1055,18 +1138,22 @@ export type AttributeValueCreate = {
   __typename?: 'AttributeValueCreate';
   /** The updated attribute. */
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   attributeValue?: Maybe<AttributeValue>;
   errors: Array<AttributeError>;
 };
 
 export type AttributeValueCreateInput = {
+  /** File content type. */
+  contentType?: InputMaybe<Scalars['String']>;
+  /** URL of the file attribute. Every time, a new value is created. */
+  fileUrl?: InputMaybe<Scalars['String']>;
   /** Name of a value displayed in the interface. */
   name: Scalars['String'];
   /** Represents the text (JSON) of the attribute value. */
   richText?: InputMaybe<Scalars['JSONString']>;
-  /** Represents the value of the attribute value. */
+  /** Represent value of the attribute value (e.g. color values for swatch attributes). */
   value?: InputMaybe<Scalars['String']>;
 };
 
@@ -1075,7 +1162,7 @@ export type AttributeValueDelete = {
   __typename?: 'AttributeValueDelete';
   /** The updated attribute. */
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   attributeValue?: Maybe<AttributeValue>;
   errors: Array<AttributeError>;
@@ -1110,10 +1197,9 @@ export type AttributeValueTranslatableContent = Node & {
   __typename?: 'AttributeValueTranslatableContent';
   /**
    * Represents a value of an attribute.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   attributeValue?: Maybe<AttributeValue>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   richText?: Maybe<Scalars['JSONString']>;
@@ -1131,13 +1217,12 @@ export type AttributeValueTranslate = {
   __typename?: 'AttributeValueTranslate';
   attributeValue?: Maybe<AttributeValue>;
   errors: Array<TranslationError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
 export type AttributeValueTranslation = Node & {
   __typename?: 'AttributeValueTranslation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -1155,10 +1240,23 @@ export type AttributeValueUpdate = {
   __typename?: 'AttributeValueUpdate';
   /** The updated attribute. */
   attribute?: Maybe<Attribute>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   attributeValue?: Maybe<AttributeValue>;
   errors: Array<AttributeError>;
+};
+
+export type AttributeValueUpdateInput = {
+  /** File content type. */
+  contentType?: InputMaybe<Scalars['String']>;
+  /** URL of the file attribute. Every time, a new value is created. */
+  fileUrl?: InputMaybe<Scalars['String']>;
+  /** Name of a value displayed in the interface. */
+  name?: InputMaybe<Scalars['String']>;
+  /** Represents the text (JSON) of the attribute value. */
+  richText?: InputMaybe<Scalars['JSONString']>;
+  /** Represent value of the attribute value (e.g. color values for swatch attributes). */
+  value?: InputMaybe<Scalars['String']>;
 };
 
 export type BulkAttributeValueInput = {
@@ -1222,7 +1320,7 @@ export type CatalogueInput = {
   collections?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   /** Products related to the discount. */
   products?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  /** Product variant related to the discount. */
+  /** New in Saleor 3.1. Product variant related to the discount. */
   variants?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
 };
 
@@ -1237,10 +1335,9 @@ export type Category = Node & ObjectWithMetadata & {
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Description of the category (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   level: Scalars['Int'];
   /** List of public metadata items. Can be accessed without permissions. */
@@ -1304,7 +1401,7 @@ export type CategoryBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -1330,7 +1427,7 @@ export type CategoryCreate = {
   __typename?: 'CategoryCreate';
   category?: Maybe<Category>;
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -1339,7 +1436,7 @@ export type CategoryDelete = {
   __typename?: 'CategoryDelete';
   category?: Maybe<Category>;
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -1373,7 +1470,11 @@ export type CategorySortField =
   | 'SUBCATEGORY_COUNT';
 
 export type CategorySortingInput = {
-  /** Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel in which to sort the data.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   /** Specifies the direction in which to sort products. */
   direction: OrderDirection;
@@ -1385,16 +1486,15 @@ export type CategoryTranslatableContent = Node & {
   __typename?: 'CategoryTranslatableContent';
   /**
    * Represents a single category of products.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   category?: Maybe<Category>;
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Description of the category (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   seoDescription?: Maybe<Scalars['String']>;
@@ -1413,7 +1513,7 @@ export type CategoryTranslate = {
   __typename?: 'CategoryTranslate';
   category?: Maybe<Category>;
   errors: Array<TranslationError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
@@ -1422,10 +1522,9 @@ export type CategoryTranslation = Node & {
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Translated description of the product (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -1439,7 +1538,7 @@ export type CategoryUpdate = {
   __typename?: 'CategoryUpdate';
   category?: Maybe<Category>;
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -1447,11 +1546,10 @@ export type CategoryUpdate = {
 export type Channel = Node & {
   __typename?: 'Channel';
   currencyCode: Scalars['String'];
-  /** Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided. */
+  /** New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided. */
   defaultCountry: CountryDisplay;
   /** Whether a channel has associated orders. */
   hasOrders: Scalars['Boolean'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   isActive: Scalars['Boolean'];
   name: Scalars['String'];
@@ -1463,7 +1561,7 @@ export type ChannelActivate = {
   __typename?: 'ChannelActivate';
   /** Activated channel. */
   channel?: Maybe<Channel>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   channelErrors: Array<ChannelError>;
   errors: Array<ChannelError>;
 };
@@ -1472,7 +1570,7 @@ export type ChannelActivate = {
 export type ChannelCreate = {
   __typename?: 'ChannelCreate';
   channel?: Maybe<Channel>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   channelErrors: Array<ChannelError>;
   errors: Array<ChannelError>;
 };
@@ -1482,7 +1580,7 @@ export type ChannelCreateInput = {
   addShippingZones?: InputMaybe<Array<Scalars['ID']>>;
   /** Currency of the channel. */
   currencyCode: Scalars['String'];
-  /** Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided. */
+  /** New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided. */
   defaultCountry: CountryCode;
   /** isActive flag. */
   isActive?: InputMaybe<Scalars['Boolean']>;
@@ -1497,7 +1595,7 @@ export type ChannelDeactivate = {
   __typename?: 'ChannelDeactivate';
   /** Deactivated channel. */
   channel?: Maybe<Channel>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   channelErrors: Array<ChannelError>;
   errors: Array<ChannelError>;
 };
@@ -1506,7 +1604,7 @@ export type ChannelDeactivate = {
 export type ChannelDelete = {
   __typename?: 'ChannelDelete';
   channel?: Maybe<Channel>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   channelErrors: Array<ChannelError>;
   errors: Array<ChannelError>;
 };
@@ -1544,7 +1642,7 @@ export type ChannelErrorCode =
 export type ChannelUpdate = {
   __typename?: 'ChannelUpdate';
   channel?: Maybe<Channel>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   channelErrors: Array<ChannelError>;
   errors: Array<ChannelError>;
 };
@@ -1552,7 +1650,7 @@ export type ChannelUpdate = {
 export type ChannelUpdateInput = {
   /** List of shipping zones to assign to the channel. */
   addShippingZones?: InputMaybe<Array<Scalars['ID']>>;
-  /** Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided. */
+  /** New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided. */
   defaultCountry?: InputMaybe<CountryCode>;
   /** isActive flag. */
   isActive?: InputMaybe<Scalars['Boolean']>;
@@ -1567,23 +1665,26 @@ export type ChannelUpdateInput = {
 /** Checkout object. */
 export type Checkout = Node & ObjectWithMetadata & {
   __typename?: 'Checkout';
+  /** New in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point. */
+  availableCollectionPoints: Array<Warehouse>;
   /** List of available payment gateways. */
   availablePaymentGateways: Array<PaymentGateway>;
   /**
    * Shipping methods that can be used with this checkout.
-   * @deprecated Use `shippingMethods`, this field will be removed in 4.0.
+   * @deprecated This field will be removed in Saleor 4.0. Use `shippingMethods` instead.
    */
   availableShippingMethods: Array<Maybe<ShippingMethod>>;
   billingAddress?: Maybe<Address>;
   channel: Channel;
   created: Scalars['DateTime'];
+  /** New in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+  deliveryMethod?: Maybe<DeliveryMethod>;
   discount?: Maybe<Money>;
   discountName?: Maybe<Scalars['String']>;
   /** Email of a customer. */
-  email: Scalars['String'];
+  email?: Maybe<Scalars['String']>;
   /** List of gift cards associated with this checkout. */
   giftCards?: Maybe<Array<Maybe<GiftCard>>>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Returns True, if checkout requires shipping. */
   isShippingRequired: Scalars['Boolean'];
@@ -1600,12 +1701,17 @@ export type Checkout = Node & ObjectWithMetadata & {
   /** The number of items purchased. */
   quantity: Scalars['Int'];
   shippingAddress?: Maybe<Address>;
-  /** The shipping method related with checkout. */
+  /**
+   * The shipping method related with checkout.
+   * @deprecated This field will be removed in Saleor 4.0. Use `deliveryMethod` instead.
+   */
   shippingMethod?: Maybe<ShippingMethod>;
   /** Shipping methods that can be used with this checkout. */
   shippingMethods: Array<Maybe<ShippingMethod>>;
   /** The price of the shipping, with all the taxes included. */
   shippingPrice?: Maybe<TaxedMoney>;
+  /** New in Saleor 3.1. Date when oldest stock reservation for this checkout  expires or null if no stock is reserved. */
+  stockReservationExpires?: Maybe<Scalars['DateTime']>;
   /** The price of the checkout before shipping, with taxes included. */
   subtotalPrice?: Maybe<TaxedMoney>;
   /** The checkout's token. */
@@ -1622,7 +1728,7 @@ export type CheckoutAddPromoCode = {
   __typename?: 'CheckoutAddPromoCode';
   /** The checkout with the added gift card or voucher. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1632,7 +1738,7 @@ export type CheckoutBillingAddressUpdate = {
   __typename?: 'CheckoutBillingAddressUpdate';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1640,7 +1746,7 @@ export type CheckoutBillingAddressUpdate = {
 /** Completes the checkout. As a result a new order is created and a payment charge is made. This action requires a successful payment before it can be performed. In case additional confirmation step as 3D secure is required confirmationNeeded flag will be set to True and no order created until payment is confirmed with second call of this mutation. */
 export type CheckoutComplete = {
   __typename?: 'CheckoutComplete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   /** Confirmation data used to process additional authorization steps. */
   confirmationData?: Maybe<Scalars['JSONString']>;
@@ -1672,9 +1778,12 @@ export type CheckoutCountableEdge = {
 export type CheckoutCreate = {
   __typename?: 'CheckoutCreate';
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
-  /** Whether the checkout was created or the current active one was returned. Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart with an active checkout.DEPRECATED: Will be removed in Saleor 4.0. Always returns True. */
+  /**
+   * Whether the checkout was created or the current active one was returned. Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart with an active checkout.
+   * @deprecated This field will be removed in Saleor 4.0. Always returns `true`.
+   */
   created?: Maybe<Scalars['Boolean']>;
   errors: Array<CheckoutError>;
 };
@@ -1699,7 +1808,7 @@ export type CheckoutCustomerAttach = {
   __typename?: 'CheckoutCustomerAttach';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1709,8 +1818,16 @@ export type CheckoutCustomerDetach = {
   __typename?: 'CheckoutCustomerDetach';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
+  errors: Array<CheckoutError>;
+};
+
+/** New in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type CheckoutDeliveryMethodUpdate = {
+  __typename?: 'CheckoutDeliveryMethodUpdate';
+  /** An updated checkout. */
+  checkout?: Maybe<Checkout>;
   errors: Array<CheckoutError>;
 };
 
@@ -1719,7 +1836,7 @@ export type CheckoutEmailUpdate = {
   __typename?: 'CheckoutEmailUpdate';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1745,6 +1862,9 @@ export type CheckoutErrorCode =
   | 'BILLING_ADDRESS_NOT_SET'
   | 'CHANNEL_INACTIVE'
   | 'CHECKOUT_NOT_FULLY_PAID'
+  | 'DELIVERY_METHOD_NOT_APPLICABLE'
+  | 'EMAIL_NOT_SET'
+  | 'GIFT_CARD_NOT_APPLICABLE'
   | 'GRAPHQL_ERROR'
   | 'INSUFFICIENT_STOCK'
   | 'INVALID'
@@ -1767,12 +1887,20 @@ export type CheckoutErrorCode =
   | 'VOUCHER_NOT_APPLICABLE'
   | 'ZERO_QUANTITY';
 
+export type CheckoutFilterInput = {
+  channels?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  created?: InputMaybe<DateRangeInput>;
+  customer?: InputMaybe<Scalars['String']>;
+  metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
+  search?: InputMaybe<Scalars['String']>;
+};
+
 /** Update language code in the existing checkout. */
 export type CheckoutLanguageCodeUpdate = {
   __typename?: 'CheckoutLanguageCodeUpdate';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1780,7 +1908,6 @@ export type CheckoutLanguageCodeUpdate = {
 /** Represents an item in the checkout. */
 export type CheckoutLine = Node & {
   __typename?: 'CheckoutLine';
-  /** The ID of the object. */
   id: Scalars['ID'];
   quantity: Scalars['Int'];
   /** Indicates whether the item need to be delivered. */
@@ -1812,7 +1939,7 @@ export type CheckoutLineDelete = {
   __typename?: 'CheckoutLineDelete';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1829,7 +1956,7 @@ export type CheckoutLinesAdd = {
   __typename?: 'CheckoutLinesAdd';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1847,7 +1974,7 @@ export type CheckoutLinesUpdate = {
   __typename?: 'CheckoutLinesUpdate';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1860,7 +1987,7 @@ export type CheckoutPaymentCreate = {
   errors: Array<PaymentError>;
   /** A newly created payment. */
   payment?: Maybe<Payment>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
 };
 
@@ -1869,7 +1996,7 @@ export type CheckoutRemovePromoCode = {
   __typename?: 'CheckoutRemovePromoCode';
   /** The checkout with the removed gift card or voucher. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1879,7 +2006,7 @@ export type CheckoutShippingAddressUpdate = {
   __typename?: 'CheckoutShippingAddressUpdate';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
 };
@@ -1889,9 +2016,24 @@ export type CheckoutShippingMethodUpdate = {
   __typename?: 'CheckoutShippingMethodUpdate';
   /** An updated checkout. */
   checkout?: Maybe<Checkout>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   checkoutErrors: Array<CheckoutError>;
   errors: Array<CheckoutError>;
+};
+
+export type CheckoutSortField =
+  /** Sort checkouts by creation date. */
+  | 'CREATION_DATE'
+  /** Sort checkouts by customer. */
+  | 'CUSTOMER'
+  /** Sort checkouts by payment. */
+  | 'PAYMENT';
+
+export type CheckoutSortingInput = {
+  /** Specifies the direction in which to sort products. */
+  direction: OrderDirection;
+  /** Sort checkouts by the selected field. */
+  field: CheckoutSortField;
 };
 
 export type ChoiceValue = {
@@ -1911,10 +2053,9 @@ export type Collection = Node & ObjectWithMetadata & {
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Description of the collection (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
@@ -1958,7 +2099,7 @@ export type CollectionAddProducts = {
   __typename?: 'CollectionAddProducts';
   /** Collection to which products will be added. */
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   errors: Array<CollectionError>;
 };
@@ -1966,7 +2107,7 @@ export type CollectionAddProducts = {
 /** Deletes collections. */
 export type CollectionBulkDelete = {
   __typename?: 'CollectionBulkDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
@@ -1977,7 +2118,6 @@ export type CollectionBulkDelete = {
 export type CollectionChannelListing = Node & {
   __typename?: 'CollectionChannelListing';
   channel: Channel;
-  /** The ID of the object. */
   id: Scalars['ID'];
   isPublished: Scalars['Boolean'];
   publicationDate?: Maybe<Scalars['Date']>;
@@ -2004,7 +2144,7 @@ export type CollectionChannelListingUpdate = {
   __typename?: 'CollectionChannelListingUpdate';
   /** An updated collection instance. */
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionChannelListingErrors: Array<CollectionChannelListingError>;
   errors: Array<CollectionChannelListingError>;
 };
@@ -2037,7 +2177,7 @@ export type CollectionCountableEdge = {
 export type CollectionCreate = {
   __typename?: 'CollectionCreate';
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   errors: Array<CollectionError>;
 };
@@ -2067,7 +2207,7 @@ export type CollectionCreateInput = {
 export type CollectionDelete = {
   __typename?: 'CollectionDelete';
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   errors: Array<CollectionError>;
 };
@@ -2095,7 +2235,11 @@ export type CollectionErrorCode =
   | 'UNIQUE';
 
 export type CollectionFilterInput = {
-  /** Specifies the channel by which the data should be filtered. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel by which the data should be filtered.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
@@ -2131,7 +2275,7 @@ export type CollectionRemoveProducts = {
   __typename?: 'CollectionRemoveProducts';
   /** Collection from which products will be removed. */
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   errors: Array<CollectionError>;
 };
@@ -2141,7 +2285,7 @@ export type CollectionReorderProducts = {
   __typename?: 'CollectionReorderProducts';
   /** Collection from which products are reordered. */
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   errors: Array<CollectionError>;
 };
@@ -2157,7 +2301,11 @@ export type CollectionSortField =
   | 'PUBLICATION_DATE';
 
 export type CollectionSortingInput = {
-  /** Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel in which to sort the data.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   /** Specifies the direction in which to sort products. */
   direction: OrderDirection;
@@ -2169,16 +2317,15 @@ export type CollectionTranslatableContent = Node & {
   __typename?: 'CollectionTranslatableContent';
   /**
    * Represents a collection of products.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   collection?: Maybe<Collection>;
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Description of the collection (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   seoDescription?: Maybe<Scalars['String']>;
@@ -2197,7 +2344,7 @@ export type CollectionTranslate = {
   __typename?: 'CollectionTranslate';
   collection?: Maybe<Collection>;
   errors: Array<TranslationError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
@@ -2206,10 +2353,9 @@ export type CollectionTranslation = Node & {
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Translated description of the product (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -2222,7 +2368,7 @@ export type CollectionTranslation = Node & {
 export type CollectionUpdate = {
   __typename?: 'CollectionUpdate';
   collection?: Maybe<Collection>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   collectionErrors: Array<CollectionError>;
   errors: Array<CollectionError>;
 };
@@ -2262,7 +2408,7 @@ export type ConfigurationTypeFieldEnum =
 /** Confirm user account with token sent by email during registration. */
 export type ConfirmAccount = {
   __typename?: 'ConfirmAccount';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** An activated user account. */
@@ -2272,7 +2418,7 @@ export type ConfirmAccount = {
 /** Confirm the email change of the logged-in user. */
 export type ConfirmEmailChange = {
   __typename?: 'ConfirmEmailChange';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** A user instance with a new email. */
@@ -2550,7 +2696,7 @@ export type CountryFilterInput = {
 /** Create JWT token. */
 export type CreateToken = {
   __typename?: 'CreateToken';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** CSRF token required to re-generate access token. */
   csrfToken?: Maybe<Scalars['String']>;
@@ -2580,7 +2726,7 @@ export type CreditCard = {
 /** Deletes customers. */
 export type CustomerBulkDelete = {
   __typename?: 'CustomerBulkDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
@@ -2590,7 +2736,7 @@ export type CustomerBulkDelete = {
 /** Creates a new customer. */
 export type CustomerCreate = {
   __typename?: 'CustomerCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   user?: Maybe<User>;
@@ -2599,7 +2745,7 @@ export type CustomerCreate = {
 /** Deletes a customer. */
 export type CustomerDelete = {
   __typename?: 'CustomerDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   user?: Maybe<User>;
@@ -2614,7 +2760,6 @@ export type CustomerEvent = Node & {
   count?: Maybe<Scalars['Int']>;
   /** Date when event happened at in ISO 8601 format. */
   date?: Maybe<Scalars['DateTime']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Content of the event. */
   message?: Maybe<Scalars['String']>;
@@ -2650,6 +2795,7 @@ export type CustomerFilterInput = {
   numberOfOrders?: InputMaybe<IntRangeInput>;
   placedOrders?: InputMaybe<DateRangeInput>;
   search?: InputMaybe<Scalars['String']>;
+  updatedAt?: InputMaybe<DateTimeRangeInput>;
 };
 
 export type CustomerInput = {
@@ -2674,7 +2820,7 @@ export type CustomerInput = {
 /** Updates an existing customer. */
 export type CustomerUpdate = {
   __typename?: 'CustomerUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   user?: Maybe<User>;
@@ -2697,7 +2843,7 @@ export type DateTimeRangeInput = {
 /** Deactivate all JWT tokens of the currently authenticated user. */
 export type DeactivateAllUserTokens = {
   __typename?: 'DeactivateAllUserTokens';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
 };
@@ -2707,7 +2853,7 @@ export type DeleteMetadata = {
   __typename?: 'DeleteMetadata';
   errors: Array<MetadataError>;
   item?: Maybe<ObjectWithMetadata>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   metadataErrors: Array<MetadataError>;
 };
 
@@ -2716,15 +2862,17 @@ export type DeletePrivateMetadata = {
   __typename?: 'DeletePrivateMetadata';
   errors: Array<MetadataError>;
   item?: Maybe<ObjectWithMetadata>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   metadataErrors: Array<MetadataError>;
 };
+
+/** New in Saleor 3.1. Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as "click and collect" and `ShippingMethod` otherwise. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type DeliveryMethod = ShippingMethod | Warehouse;
 
 export type DigitalContent = Node & ObjectWithMetadata & {
   __typename?: 'DigitalContent';
   automaticFulfillment: Scalars['Boolean'];
   contentFile: Scalars['String'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   maxDownloads?: Maybe<Scalars['Int']>;
   /** List of public metadata items. Can be accessed without permissions. */
@@ -2761,7 +2909,7 @@ export type DigitalContentCreate = {
   __typename?: 'DigitalContentCreate';
   content?: Maybe<DigitalContent>;
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   variant?: Maybe<ProductVariant>;
 };
@@ -2770,7 +2918,7 @@ export type DigitalContentCreate = {
 export type DigitalContentDelete = {
   __typename?: 'DigitalContentDelete';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   variant?: Maybe<ProductVariant>;
 };
@@ -2791,7 +2939,7 @@ export type DigitalContentUpdate = {
   __typename?: 'DigitalContentUpdate';
   content?: Maybe<DigitalContent>;
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   variant?: Maybe<ProductVariant>;
 };
@@ -2814,7 +2962,6 @@ export type DigitalContentUrl = Node & {
   content: DigitalContent;
   created: Scalars['DateTime'];
   downloadNum: Scalars['Int'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** UUID of digital content. */
   token: Scalars['UUID'];
@@ -2827,7 +2974,7 @@ export type DigitalContentUrlCreate = {
   __typename?: 'DigitalContentUrlCreate';
   digitalContentUrl?: Maybe<DigitalContentUrl>;
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -2896,7 +3043,7 @@ export type DraftOrderBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<OrderError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -2906,7 +3053,7 @@ export type DraftOrderComplete = {
   errors: Array<OrderError>;
   /** Completed order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -2915,7 +3062,7 @@ export type DraftOrderCreate = {
   __typename?: 'DraftOrderCreate';
   errors: Array<OrderError>;
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -2949,7 +3096,7 @@ export type DraftOrderDelete = {
   __typename?: 'DraftOrderDelete';
   errors: Array<OrderError>;
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -2982,7 +3129,7 @@ export type DraftOrderLinesBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<OrderError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -2991,9 +3138,123 @@ export type DraftOrderUpdate = {
   __typename?: 'DraftOrderUpdate';
   errors: Array<OrderError>;
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
+
+/** Event delivery. */
+export type EventDelivery = Node & {
+  __typename?: 'EventDelivery';
+  /** Event delivery attempts. */
+  attempts?: Maybe<EventDeliveryAttemptCountableConnection>;
+  createdAt: Scalars['DateTime'];
+  /** Webhook event type. */
+  eventType: WebhookEventTypeEnum;
+  id: Scalars['ID'];
+  /** Event payload. */
+  payload?: Maybe<Scalars['String']>;
+  /** Event delivery status. */
+  status: EventDeliveryStatusEnum;
+};
+
+
+/** Event delivery. */
+export type EventDeliveryAttemptsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<EventDeliveryAttemptSortingInput>;
+};
+
+/** Event delivery attempts. */
+export type EventDeliveryAttempt = Node & {
+  __typename?: 'EventDeliveryAttempt';
+  /** Event delivery creation date and time. */
+  createdAt: Scalars['DateTime'];
+  duration?: Maybe<Scalars['Float']>;
+  id: Scalars['ID'];
+  requestHeaders?: Maybe<Scalars['String']>;
+  response?: Maybe<Scalars['String']>;
+  responseHeaders?: Maybe<Scalars['String']>;
+  /** Event delivery status. */
+  status: EventDeliveryStatusEnum;
+  taskId?: Maybe<Scalars['String']>;
+};
+
+export type EventDeliveryAttemptCountableConnection = {
+  __typename?: 'EventDeliveryAttemptCountableConnection';
+  edges: Array<EventDeliveryAttemptCountableEdge>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  /** A total count of items in the collection. */
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type EventDeliveryAttemptCountableEdge = {
+  __typename?: 'EventDeliveryAttemptCountableEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node: EventDeliveryAttempt;
+};
+
+export type EventDeliveryAttemptSortField =
+  /** Sort event delivery attempts by created at. */
+  | 'CREATED_AT';
+
+export type EventDeliveryAttemptSortingInput = {
+  /** Specifies the direction in which to sort products. */
+  direction: OrderDirection;
+  /** Sort attempts by the selected field. */
+  field: EventDeliveryAttemptSortField;
+};
+
+export type EventDeliveryCountableConnection = {
+  __typename?: 'EventDeliveryCountableConnection';
+  edges: Array<EventDeliveryCountableEdge>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  /** A total count of items in the collection. */
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type EventDeliveryCountableEdge = {
+  __typename?: 'EventDeliveryCountableEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node: EventDelivery;
+};
+
+export type EventDeliveryFilterInput = {
+  eventType?: InputMaybe<WebhookEventTypeEnum>;
+  status?: InputMaybe<EventDeliveryStatusEnum>;
+};
+
+/** Retries event delivery. */
+export type EventDeliveryRetry = {
+  __typename?: 'EventDeliveryRetry';
+  /** Event delivery. */
+  delivery?: Maybe<EventDelivery>;
+  errors: Array<WebhookError>;
+};
+
+export type EventDeliverySortField =
+  /** Sort event deliveries by created at. */
+  | 'CREATED_AT';
+
+export type EventDeliverySortingInput = {
+  /** Specifies the direction in which to sort products. */
+  direction: OrderDirection;
+  /** Sort deliveries by the selected field. */
+  field: EventDeliverySortField;
+};
+
+export type EventDeliveryStatusEnum =
+  | 'FAILED'
+  | 'PENDING'
+  | 'SUCCESS';
 
 export type ExportError = {
   __typename?: 'ExportError';
@@ -3046,7 +3307,6 @@ export type ExportFile = Job & Node & {
   createdAt: Scalars['DateTime'];
   /** List of events associated with the export. */
   events?: Maybe<Array<ExportEvent>>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Job message. */
   message?: Maybe<Scalars['String']>;
@@ -3085,11 +3345,9 @@ export type ExportFileFilterInput = {
 };
 
 export type ExportFileSortField =
-  /** Sort export file by created at. */
   | 'CREATED_AT'
-  /** Sort export file by status. */
+  | 'LAST_MODIFIED_AT'
   | 'STATUS'
-  /** Sort export file by updated at. */
   | 'UPDATED_AT';
 
 export type ExportFileSortingInput = {
@@ -3097,6 +3355,25 @@ export type ExportFileSortingInput = {
   direction: OrderDirection;
   /** Sort export file by the selected field. */
   field: ExportFileSortField;
+};
+
+/** New in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type ExportGiftCards = {
+  __typename?: 'ExportGiftCards';
+  errors: Array<ExportError>;
+  /** The newly created export file job which is responsible for export data. */
+  exportFile?: Maybe<ExportFile>;
+};
+
+export type ExportGiftCardsInput = {
+  /** Type of exported file. */
+  fileType: FileTypesEnum;
+  /** Filtering options for gift cards. */
+  filter?: InputMaybe<GiftCardFilterInput>;
+  /** List of gift cards IDs to export. */
+  ids?: InputMaybe<Array<Scalars['ID']>>;
+  /** Determine which gift cards should be exported. */
+  scope: ExportScope;
 };
 
 export type ExportInfoInput = {
@@ -3114,7 +3391,7 @@ export type ExportInfoInput = {
 export type ExportProducts = {
   __typename?: 'ExportProducts';
   errors: Array<ExportError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   exportErrors: Array<ExportError>;
   /** The newly created export file job which is responsible for export data. */
   exportFile?: Maybe<ExportFile>;
@@ -3127,7 +3404,7 @@ export type ExportProductsInput = {
   fileType: FileTypesEnum;
   /** Filtering options for products. */
   filter?: InputMaybe<ProductFilterInput>;
-  /** List of products IDS to export. */
+  /** List of products IDs to export. */
   ids?: InputMaybe<Array<Scalars['ID']>>;
   /** Determine which products should be exported. */
   scope: ExportScope;
@@ -3152,7 +3429,7 @@ export type ExternalAuthentication = {
 /** Prepare external authentication url for user by custom plugin. */
 export type ExternalAuthenticationUrl = {
   __typename?: 'ExternalAuthenticationUrl';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** The data returned by authentication plugin. */
   authenticationData?: Maybe<Scalars['JSONString']>;
@@ -3162,17 +3439,49 @@ export type ExternalAuthenticationUrl = {
 /** Logout user by custom plugin. */
 export type ExternalLogout = {
   __typename?: 'ExternalLogout';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** The data returned by authentication plugin. */
   logoutData?: Maybe<Scalars['JSONString']>;
 };
 
+export type ExternalNotificationError = {
+  __typename?: 'ExternalNotificationError';
+  /** The error code. */
+  code: ExternalNotificationErrorCodes;
+  /** Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field. */
+  field?: Maybe<Scalars['String']>;
+  /** The error message. */
+  message?: Maybe<Scalars['String']>;
+};
+
+/** An enumeration. */
+export type ExternalNotificationErrorCodes =
+  | 'CHANNEL_INACTIVE'
+  | 'INVALID_MODEL_TYPE'
+  | 'NOT_FOUND'
+  | 'REQUIRED';
+
+/** New in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload. */
+export type ExternalNotificationTrigger = {
+  __typename?: 'ExternalNotificationTrigger';
+  errors: Array<ExternalNotificationError>;
+};
+
+export type ExternalNotificationTriggerInput = {
+  /** External event type. This field is passed to a plugin as an event type. */
+  externalEventType: Scalars['String'];
+  /** Additional payload that will be merged with the one based on the bussines object ID. */
+  extraPayload?: InputMaybe<Scalars['JSONString']>;
+  /** The list of customers or orders node IDs that will be serialized and included in the notification payload. */
+  ids: Array<InputMaybe<Scalars['ID']>>;
+};
+
 /** Obtain external access tokens for user by custom plugin. */
 export type ExternalObtainAccessTokens = {
   __typename?: 'ExternalObtainAccessTokens';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** CSRF token required to re-generate external access token. */
   csrfToken?: Maybe<Scalars['String']>;
@@ -3188,7 +3497,7 @@ export type ExternalObtainAccessTokens = {
 /** Refresh user's access by custom plugin. */
 export type ExternalRefresh = {
   __typename?: 'ExternalRefresh';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** CSRF token required to re-generate external access token. */
   csrfToken?: Maybe<Scalars['String']>;
@@ -3204,7 +3513,7 @@ export type ExternalRefresh = {
 /** Verify external authentication data by plugin. */
 export type ExternalVerify = {
   __typename?: 'ExternalVerify';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** Determine if authentication data is valid or not. */
@@ -3232,7 +3541,7 @@ export type FileTypesEnum =
 export type FileUpload = {
   __typename?: 'FileUpload';
   errors: Array<UploadError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   uploadErrors: Array<UploadError>;
   uploadedFile?: Maybe<File>;
 };
@@ -3242,7 +3551,6 @@ export type Fulfillment = Node & ObjectWithMetadata & {
   __typename?: 'Fulfillment';
   created: Scalars['DateTime'];
   fulfillmentOrder: Scalars['Int'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of lines for the fulfillment. */
   lines?: Maybe<Array<Maybe<FulfillmentLine>>>;
@@ -3258,6 +3566,18 @@ export type Fulfillment = Node & ObjectWithMetadata & {
   warehouse?: Maybe<Warehouse>;
 };
 
+/** New in Saleor 3.1. Approve existing fulfillment. */
+export type FulfillmentApprove = {
+  __typename?: 'FulfillmentApprove';
+  errors: Array<OrderError>;
+  /** An approved fulfillment. */
+  fulfillment?: Maybe<Fulfillment>;
+  /** Order which fulfillment was approved. */
+  order?: Maybe<Order>;
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
+  orderErrors: Array<OrderError>;
+};
+
 /** Cancels existing fulfillment and optionally restocks items. */
 export type FulfillmentCancel = {
   __typename?: 'FulfillmentCancel';
@@ -3266,19 +3586,18 @@ export type FulfillmentCancel = {
   fulfillment?: Maybe<Fulfillment>;
   /** Order which fulfillment was cancelled. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
 export type FulfillmentCancelInput = {
-  /** ID of warehouse where items will be restock. */
-  warehouseId: Scalars['ID'];
+  /** ID of a warehouse where items will be restocked. Optional when fulfillment is in WAITING_FOR_APPROVAL state. */
+  warehouseId?: InputMaybe<Scalars['ID']>;
 };
 
 /** Represents line of the fulfillment. */
 export type FulfillmentLine = Node & {
   __typename?: 'FulfillmentLine';
-  /** The ID of the object. */
   id: Scalars['ID'];
   orderLine?: Maybe<OrderLine>;
   quantity: Scalars['Int'];
@@ -3292,7 +3611,7 @@ export type FulfillmentRefundProducts = {
   fulfillment?: Maybe<Fulfillment>;
   /** Order which fulfillment was refunded. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -3302,7 +3621,7 @@ export type FulfillmentReturnProducts = {
   errors: Array<OrderError>;
   /** Order which fulfillment was returned. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
   /** A replace fulfillment. */
   replaceFulfillment?: Maybe<Fulfillment>;
@@ -3314,18 +3633,13 @@ export type FulfillmentReturnProducts = {
 
 /** An enumeration. */
 export type FulfillmentStatus =
-  /** Canceled */
   | 'CANCELED'
-  /** Fulfilled */
   | 'FULFILLED'
-  /** Refunded */
   | 'REFUNDED'
-  /** Refunded and returned */
   | 'REFUNDED_AND_RETURNED'
-  /** Replaced */
   | 'REPLACED'
-  /** Returned */
-  | 'RETURNED';
+  | 'RETURNED'
+  | 'WAITING_FOR_APPROVAL';
 
 /** Updates a fulfillment for an order. */
 export type FulfillmentUpdateTracking = {
@@ -3335,7 +3649,7 @@ export type FulfillmentUpdateTracking = {
   fulfillment?: Maybe<Fulfillment>;
   /** Order for which fulfillment was updated. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -3356,33 +3670,136 @@ export type GatewayConfigLine = {
 };
 
 /** A gift card is a prepaid electronic payment card accepted in stores. They can be used during checkout by providing a valid gift card codes. */
-export type GiftCard = Node & {
+export type GiftCard = Node & ObjectWithMetadata & {
   __typename?: 'GiftCard';
-  /** Gift card code. */
-  code?: Maybe<Scalars['String']>;
+  /** New in Saleor 3.1. App which created the gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  app?: Maybe<App>;
+  /** New in Saleor 3.1. Slug of the channel where the gift card was bought. Note: this feature is in a preview state and can be subject to changes at later point. */
+  boughtInChannel?: Maybe<Scalars['String']>;
+  /** Gift card code. Can be fetched by staff member with manage gift card permission when gift card wasn't used yet and by the gift card owner. */
+  code: Scalars['String'];
   created: Scalars['DateTime'];
+  /** New in Saleor 3.1. The user who bought or issued a gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  createdBy?: Maybe<User>;
+  /** New in Saleor 3.1. Email address of the user who bought or issued gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  createdByEmail?: Maybe<Scalars['String']>;
   currentBalance?: Maybe<Money>;
   /** Code in format which allows displaying in a user interface. */
-  displayCode?: Maybe<Scalars['String']>;
-  endDate?: Maybe<Scalars['Date']>;
-  /** The ID of the object. */
+  displayCode: Scalars['String'];
+  /**
+   * End date of gift card.
+   * @deprecated This field will be removed in Saleor 4.0. Use `expiryDate` field instead.
+   */
+  endDate?: Maybe<Scalars['DateTime']>;
+  /** New in Saleor 3.1. List of events associated with the gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  events: Array<GiftCardEvent>;
+  expiryDate?: Maybe<Scalars['Date']>;
   id: Scalars['ID'];
   initialBalance?: Maybe<Money>;
   isActive: Scalars['Boolean'];
+  /** Last 4 characters of gift card code. */
+  last4CodeChars: Scalars['String'];
   lastUsedOn?: Maybe<Scalars['DateTime']>;
-  startDate: Scalars['Date'];
-  /** The customer who bought a gift card. */
+  /** List of public metadata items. Can be accessed without permissions. */
+  metadata: Array<Maybe<MetadataItem>>;
+  /** List of private metadata items.Requires proper staff permissions to access. */
+  privateMetadata: Array<Maybe<MetadataItem>>;
+  /** New in Saleor 3.1. Related gift card product. Note: this feature is in a preview state and can be subject to changes at later point. */
+  product?: Maybe<Product>;
+  /**
+   * Start date of gift card.
+   * @deprecated This field will be removed in Saleor 4.0.
+   */
+  startDate?: Maybe<Scalars['DateTime']>;
+  /** New in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point. */
+  tags: Array<GiftCardTag>;
+  /** New in Saleor 3.1. The customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  usedBy?: Maybe<User>;
+  /** New in Saleor 3.1. Email address of the customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  usedByEmail?: Maybe<Scalars['String']>;
+  /**
+   * The customer who bought a gift card.
+   * @deprecated This field will be removed in Saleor 4.0. Use `createdBy` field instead.
+   */
   user?: Maybe<User>;
+};
+
+
+/** A gift card is a prepaid electronic payment card accepted in stores. They can be used during checkout by providing a valid gift card codes. */
+export type GiftCardEventsArgs = {
+  filter?: InputMaybe<GiftCardEventFilterInput>;
 };
 
 /** Activate a gift card. */
 export type GiftCardActivate = {
   __typename?: 'GiftCardActivate';
   errors: Array<GiftCardError>;
-  /** A gift card to activate. */
+  /** Activated gift card. */
   giftCard?: Maybe<GiftCard>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   giftCardErrors: Array<GiftCardError>;
+};
+
+/** New in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardAddNote = {
+  __typename?: 'GiftCardAddNote';
+  errors: Array<GiftCardError>;
+  /** Gift card note created. */
+  event?: Maybe<GiftCardEvent>;
+  /** Gift card with the note added. */
+  giftCard?: Maybe<GiftCard>;
+};
+
+export type GiftCardAddNoteInput = {
+  /** Note message. */
+  message: Scalars['String'];
+};
+
+/** New in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardBulkActivate = {
+  __typename?: 'GiftCardBulkActivate';
+  /** Returns how many objects were affected. */
+  count: Scalars['Int'];
+  errors: Array<GiftCardError>;
+};
+
+/** New in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardBulkCreate = {
+  __typename?: 'GiftCardBulkCreate';
+  /** Returns how many objects were created. */
+  count: Scalars['Int'];
+  errors: Array<GiftCardError>;
+  /** List of created gift cards. */
+  giftCards: Array<GiftCard>;
+};
+
+export type GiftCardBulkCreateInput = {
+  /** Balance of the gift card. */
+  balance: PriceInput;
+  /** The number of cards to issue. */
+  count: Scalars['Int'];
+  /** The gift card expiry date. */
+  expiryDate?: InputMaybe<Scalars['Date']>;
+  /** Determine if gift card is active. */
+  isActive: Scalars['Boolean'];
+  /** The gift card tags. */
+  tags?: InputMaybe<Array<Scalars['String']>>;
+};
+
+/** New in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardBulkDeactivate = {
+  __typename?: 'GiftCardBulkDeactivate';
+  /** Returns how many objects were affected. */
+  count: Scalars['Int'];
+  errors: Array<GiftCardError>;
+};
+
+/** New in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardBulkDelete = {
+  __typename?: 'GiftCardBulkDelete';
+  /** Returns how many objects were affected. */
+  count: Scalars['Int'];
+  errors: Array<GiftCardError>;
 };
 
 export type GiftCardCountableConnection = {
@@ -3407,20 +3824,42 @@ export type GiftCardCreate = {
   __typename?: 'GiftCardCreate';
   errors: Array<GiftCardError>;
   giftCard?: Maybe<GiftCard>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   giftCardErrors: Array<GiftCardError>;
 };
 
 export type GiftCardCreateInput = {
-  /** Value of the gift card. */
-  balance?: InputMaybe<Scalars['PositiveDecimal']>;
-  /** Code to use the gift card. */
+  /** New in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point. */
+  addTags?: InputMaybe<Array<Scalars['String']>>;
+  /** Balance of the gift card. */
+  balance: PriceInput;
+  /** New in Saleor 3.1. Slug of a channel from which the email should be sent. Note: this feature is in a preview state and can be subject to changes at later point. */
+  channel?: InputMaybe<Scalars['String']>;
+  /**
+   * Code to use the gift card.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. The code is now auto generated.
+   */
   code?: InputMaybe<Scalars['String']>;
-  /** End date of the gift card in ISO 8601 format. */
+  /**
+   * End date of the gift card in ISO 8601 format.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` from `expirySettings` instead.
+   */
   endDate?: InputMaybe<Scalars['Date']>;
-  /** Start date of the gift card in ISO 8601 format. */
+  /** New in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point. */
+  expiryDate?: InputMaybe<Scalars['Date']>;
+  /** New in Saleor 3.1. Determine if gift card is active. Note: this feature is in a preview state and can be subject to changes at later point. */
+  isActive: Scalars['Boolean'];
+  /** New in Saleor 3.1. The gift card note from the staff member. Note: this feature is in a preview state and can be subject to changes at later point. */
+  note?: InputMaybe<Scalars['String']>;
+  /**
+   * Start date of the gift card in ISO 8601 format.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0.
+   */
   startDate?: InputMaybe<Scalars['Date']>;
-  /** The customer's email of the gift card buyer. */
+  /** Email of the customer to whom gift card will be sent. */
   userEmail?: InputMaybe<Scalars['String']>;
 };
 
@@ -3428,9 +3867,18 @@ export type GiftCardCreateInput = {
 export type GiftCardDeactivate = {
   __typename?: 'GiftCardDeactivate';
   errors: Array<GiftCardError>;
-  /** A gift card to deactivate. */
+  /** Deactivated gift card. */
   giftCard?: Maybe<GiftCard>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
+  giftCardErrors: Array<GiftCardError>;
+};
+
+/** New in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardDelete = {
+  __typename?: 'GiftCardDelete';
+  errors: Array<GiftCardError>;
+  giftCard?: Maybe<GiftCard>;
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   giftCardErrors: Array<GiftCardError>;
 };
 
@@ -3442,41 +3890,238 @@ export type GiftCardError = {
   field?: Maybe<Scalars['String']>;
   /** The error message. */
   message?: Maybe<Scalars['String']>;
+  /** List of tag values that cause the error. */
+  tags?: Maybe<Array<Scalars['String']>>;
 };
 
 /** An enumeration. */
 export type GiftCardErrorCode =
   | 'ALREADY_EXISTS'
+  | 'DUPLICATED_INPUT_ITEM'
+  | 'EXPIRED_GIFT_CARD'
   | 'GRAPHQL_ERROR'
   | 'INVALID'
   | 'NOT_FOUND'
   | 'REQUIRED'
   | 'UNIQUE';
 
+/** New in Saleor 3.1. History log of the gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardEvent = Node & {
+  __typename?: 'GiftCardEvent';
+  /** App that performed the action. */
+  app?: Maybe<App>;
+  /** The gift card balance. */
+  balance?: Maybe<GiftCardEventBalance>;
+  /** Date when event happened at in ISO 8601 format. */
+  date?: Maybe<Scalars['DateTime']>;
+  /** Email of the customer. */
+  email?: Maybe<Scalars['String']>;
+  /** The gift card expiry date. */
+  expiryDate?: Maybe<Scalars['Date']>;
+  id: Scalars['ID'];
+  /** Content of the event. */
+  message?: Maybe<Scalars['String']>;
+  /** Previous gift card expiry date. */
+  oldExpiryDate?: Maybe<Scalars['Date']>;
+  /** The list of old gift card tags. */
+  oldTags?: Maybe<Array<Scalars['String']>>;
+  /** The order ID where gift card was used or bought. */
+  orderId?: Maybe<Scalars['ID']>;
+  /** User-friendly number of an order where gift card was used or bought. */
+  orderNumber?: Maybe<Scalars['String']>;
+  /** The list of gift card tags. */
+  tags?: Maybe<Array<Scalars['String']>>;
+  /** Gift card event type. */
+  type?: Maybe<GiftCardEventsEnum>;
+  /** User who performed the action. */
+  user?: Maybe<User>;
+};
+
+export type GiftCardEventBalance = {
+  __typename?: 'GiftCardEventBalance';
+  /** Current balance of the gift card. */
+  currentBalance: Money;
+  /** Initial balance of the gift card. */
+  initialBalance?: Maybe<Money>;
+  /** Previous current balance of the gift card. */
+  oldCurrentBalance?: Maybe<Money>;
+  /** Previous initial balance of the gift card. */
+  oldInitialBalance?: Maybe<Money>;
+};
+
+export type GiftCardEventFilterInput = {
+  orders?: InputMaybe<Array<Scalars['ID']>>;
+  type?: InputMaybe<GiftCardEventsEnum>;
+};
+
+/** An enumeration. */
+export type GiftCardEventsEnum =
+  | 'ACTIVATED'
+  | 'BALANCE_RESET'
+  | 'BOUGHT'
+  | 'DEACTIVATED'
+  | 'EXPIRY_DATE_UPDATED'
+  | 'ISSUED'
+  | 'NOTE_ADDED'
+  | 'RESENT'
+  | 'SENT_TO_CUSTOMER'
+  | 'TAGS_UPDATED'
+  | 'UPDATED'
+  | 'USED_IN_ORDER';
+
+export type GiftCardFilterInput = {
+  code?: InputMaybe<Scalars['String']>;
+  currency?: InputMaybe<Scalars['String']>;
+  currentBalance?: InputMaybe<PriceRangeInput>;
+  initialBalance?: InputMaybe<PriceRangeInput>;
+  isActive?: InputMaybe<Scalars['Boolean']>;
+  metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
+  products?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tags?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  used?: InputMaybe<Scalars['Boolean']>;
+  usedBy?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+};
+
+/** New in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardResend = {
+  __typename?: 'GiftCardResend';
+  errors: Array<GiftCardError>;
+  /** Gift card which has been sent. */
+  giftCard?: Maybe<GiftCard>;
+};
+
+export type GiftCardResendInput = {
+  /** Slug of a channel from which the email should be sent. */
+  channel: Scalars['String'];
+  /** Email to which gift card should be send. */
+  email?: InputMaybe<Scalars['String']>;
+  /** ID of a gift card to resend. */
+  id: Scalars['ID'];
+};
+
+/** Gift card related settings from site settings. */
+export type GiftCardSettings = {
+  __typename?: 'GiftCardSettings';
+  /** The gift card expiry period settings. */
+  expiryPeriod?: Maybe<TimePeriod>;
+  /** The gift card expiry type settings. */
+  expiryType: GiftCardSettingsExpiryTypeEnum;
+};
+
+export type GiftCardSettingsError = {
+  __typename?: 'GiftCardSettingsError';
+  /** The error code. */
+  code: GiftCardSettingsErrorCode;
+  /** Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field. */
+  field?: Maybe<Scalars['String']>;
+  /** The error message. */
+  message?: Maybe<Scalars['String']>;
+};
+
+/** An enumeration. */
+export type GiftCardSettingsErrorCode =
+  | 'GRAPHQL_ERROR'
+  | 'INVALID'
+  | 'REQUIRED';
+
+/** An enumeration. */
+export type GiftCardSettingsExpiryTypeEnum =
+  | 'EXPIRY_PERIOD'
+  | 'NEVER_EXPIRE';
+
+/** Update gift card settings. */
+export type GiftCardSettingsUpdate = {
+  __typename?: 'GiftCardSettingsUpdate';
+  errors: Array<GiftCardSettingsError>;
+  /** Gift card settings. */
+  giftCardSettings?: Maybe<GiftCardSettings>;
+};
+
+export type GiftCardSettingsUpdateInput = {
+  /** Defines gift card expiry period. */
+  expiryPeriod?: InputMaybe<TimePeriodInputType>;
+  /** Defines gift card default expiry settings. */
+  expiryType?: InputMaybe<GiftCardSettingsExpiryTypeEnum>;
+};
+
+export type GiftCardSortField =
+  /** Sort orders by current balance. */
+  | 'CURRENT_BALANCE'
+  /** Sort orders by product. */
+  | 'PRODUCT'
+  /** Sort orders by used by. */
+  | 'USED_BY';
+
+export type GiftCardSortingInput = {
+  /** Specifies the direction in which to sort products. */
+  direction: OrderDirection;
+  /** Sort gift cards by the selected field. */
+  field: GiftCardSortField;
+};
+
+/** New in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type GiftCardTag = Node & {
+  __typename?: 'GiftCardTag';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
+export type GiftCardTagCountableConnection = {
+  __typename?: 'GiftCardTagCountableConnection';
+  edges: Array<GiftCardTagCountableEdge>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  /** A total count of items in the collection. */
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type GiftCardTagCountableEdge = {
+  __typename?: 'GiftCardTagCountableEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node: GiftCardTag;
+};
+
+export type GiftCardTagFilterInput = {
+  search?: InputMaybe<Scalars['String']>;
+};
+
 /** Update a gift card. */
 export type GiftCardUpdate = {
   __typename?: 'GiftCardUpdate';
   errors: Array<GiftCardError>;
   giftCard?: Maybe<GiftCard>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   giftCardErrors: Array<GiftCardError>;
 };
 
 export type GiftCardUpdateInput = {
-  /** Value of the gift card. */
-  balance?: InputMaybe<Scalars['PositiveDecimal']>;
-  /** End date of the gift card in ISO 8601 format. */
+  /** New in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point. */
+  addTags?: InputMaybe<Array<Scalars['String']>>;
+  /** New in Saleor 3.1. The gift card balance amount. Note: this feature is in a preview state and can be subject to changes at later point. */
+  balanceAmount?: InputMaybe<Scalars['PositiveDecimal']>;
+  /**
+   * End date of the gift card in ISO 8601 format.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` from `expirySettings` instead.
+   */
   endDate?: InputMaybe<Scalars['Date']>;
-  /** Start date of the gift card in ISO 8601 format. */
+  /** New in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point. */
+  expiryDate?: InputMaybe<Scalars['Date']>;
+  /** New in Saleor 3.1. The gift card tags to remove. Note: this feature is in a preview state and can be subject to changes at later point. */
+  removeTags?: InputMaybe<Array<Scalars['String']>>;
+  /**
+   * Start date of the gift card in ISO 8601 format.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0.
+   */
   startDate?: InputMaybe<Scalars['Date']>;
-  /** The customer's email of the gift card buyer. */
-  userEmail?: InputMaybe<Scalars['String']>;
 };
 
 /** Represents permission group data. */
 export type Group = Node & {
   __typename?: 'Group';
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   /** List of group permissions */
@@ -3523,12 +4168,10 @@ export type IntRangeInput = {
 /** Represents an Invoice. */
 export type Invoice = Job & Node & ObjectWithMetadata & {
   __typename?: 'Invoice';
-  /** Created date time of job in ISO 8601 format. */
   createdAt: Scalars['DateTime'];
   externalUrl?: Maybe<Scalars['String']>;
   /** The ID of the object. */
   id: Scalars['ID'];
-  /** Job message. */
   message?: Maybe<Scalars['String']>;
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
@@ -3537,7 +4180,6 @@ export type Invoice = Job & Node & ObjectWithMetadata & {
   privateMetadata: Array<Maybe<MetadataItem>>;
   /** Job status. */
   status: JobStatusEnum;
-  /** Date time of job last update in ISO 8601 format. */
   updatedAt: Scalars['DateTime'];
   /** URL to download an invoice. */
   url?: Maybe<Scalars['String']>;
@@ -3548,7 +4190,7 @@ export type InvoiceCreate = {
   __typename?: 'InvoiceCreate';
   errors: Array<InvoiceError>;
   invoice?: Maybe<Invoice>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   invoiceErrors: Array<InvoiceError>;
 };
 
@@ -3564,7 +4206,7 @@ export type InvoiceDelete = {
   __typename?: 'InvoiceDelete';
   errors: Array<InvoiceError>;
   invoice?: Maybe<Invoice>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   invoiceErrors: Array<InvoiceError>;
 };
 
@@ -3594,7 +4236,7 @@ export type InvoiceRequest = {
   __typename?: 'InvoiceRequest';
   errors: Array<InvoiceError>;
   invoice?: Maybe<Invoice>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   invoiceErrors: Array<InvoiceError>;
   /** Order related to an invoice. */
   order?: Maybe<Order>;
@@ -3605,7 +4247,7 @@ export type InvoiceRequestDelete = {
   __typename?: 'InvoiceRequestDelete';
   errors: Array<InvoiceError>;
   invoice?: Maybe<Invoice>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   invoiceErrors: Array<InvoiceError>;
 };
 
@@ -3614,7 +4256,7 @@ export type InvoiceSendNotification = {
   __typename?: 'InvoiceSendNotification';
   errors: Array<InvoiceError>;
   invoice?: Maybe<Invoice>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   invoiceErrors: Array<InvoiceError>;
 };
 
@@ -3623,7 +4265,7 @@ export type InvoiceUpdate = {
   __typename?: 'InvoiceUpdate';
   errors: Array<InvoiceError>;
   invoice?: Maybe<Invoice>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   invoiceErrors: Array<InvoiceError>;
 };
 
@@ -4460,6 +5102,7 @@ export type Manifest = {
   configurationUrl?: Maybe<Scalars['String']>;
   dataPrivacy?: Maybe<Scalars['String']>;
   dataPrivacyUrl?: Maybe<Scalars['String']>;
+  extensions: Array<AppManifestExtension>;
   homepageUrl?: Maybe<Scalars['String']>;
   identifier: Scalars['String'];
   name: Scalars['String'];
@@ -4511,7 +5154,6 @@ export type MeasurementUnitsEnum =
 /** Represents a single menu - an object that is used to help navigate through the store. */
 export type Menu = Node & ObjectWithMetadata & {
   __typename?: 'Menu';
-  /** The ID of the object. */
   id: Scalars['ID'];
   items?: Maybe<Array<Maybe<MenuItem>>>;
   /** List of public metadata items. Can be accessed without permissions. */
@@ -4528,7 +5170,7 @@ export type MenuBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<MenuError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
 };
 
@@ -4554,7 +5196,7 @@ export type MenuCreate = {
   __typename?: 'MenuCreate';
   errors: Array<MenuError>;
   menu?: Maybe<Menu>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
 };
 
@@ -4572,7 +5214,7 @@ export type MenuDelete = {
   __typename?: 'MenuDelete';
   errors: Array<MenuError>;
   menu?: Maybe<Menu>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
 };
 
@@ -4617,7 +5259,6 @@ export type MenuItem = Node & ObjectWithMetadata & {
   category?: Maybe<Category>;
   children?: Maybe<Array<Maybe<MenuItem>>>;
   collection?: Maybe<Collection>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   level: Scalars['Int'];
   menu: Menu;
@@ -4646,7 +5287,7 @@ export type MenuItemBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<MenuError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
 };
 
@@ -4671,7 +5312,7 @@ export type MenuItemCountableEdge = {
 export type MenuItemCreate = {
   __typename?: 'MenuItemCreate';
   errors: Array<MenuError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
   menuItem?: Maybe<MenuItem>;
 };
@@ -4697,7 +5338,7 @@ export type MenuItemCreateInput = {
 export type MenuItemDelete = {
   __typename?: 'MenuItemDelete';
   errors: Array<MenuError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
   menuItem?: Maybe<MenuItem>;
 };
@@ -4726,7 +5367,7 @@ export type MenuItemMove = {
   errors: Array<MenuError>;
   /** Assigned menu to move within. */
   menu?: Maybe<Menu>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
 };
 
@@ -4748,11 +5389,10 @@ export type MenuItemSortingInput = {
 
 export type MenuItemTranslatableContent = Node & {
   __typename?: 'MenuItemTranslatableContent';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /**
    * Represents a single item of the related menu. Can store categories, collection or pages.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   menuItem?: Maybe<MenuItem>;
   name: Scalars['String'];
@@ -4770,13 +5410,12 @@ export type MenuItemTranslate = {
   __typename?: 'MenuItemTranslate';
   errors: Array<TranslationError>;
   menuItem?: Maybe<MenuItem>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
 export type MenuItemTranslation = Node & {
   __typename?: 'MenuItemTranslation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -4787,7 +5426,7 @@ export type MenuItemTranslation = Node & {
 export type MenuItemUpdate = {
   __typename?: 'MenuItemUpdate';
   errors: Array<MenuError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
   menuItem?: Maybe<MenuItem>;
 };
@@ -4814,7 +5453,7 @@ export type MenuUpdate = {
   __typename?: 'MenuUpdate';
   errors: Array<MenuError>;
   menu?: Maybe<Menu>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   menuErrors: Array<MenuError>;
 };
 
@@ -4997,6 +5636,8 @@ export type Mutation = {
   checkoutCustomerAttach?: Maybe<CheckoutCustomerAttach>;
   /** Removes the user assigned as the owner of the checkout. */
   checkoutCustomerDetach?: Maybe<CheckoutCustomerDetach>;
+  /** New in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+  checkoutDeliveryMethodUpdate?: Maybe<CheckoutDeliveryMethodUpdate>;
   /** Updates email address in the existing checkout object. */
   checkoutEmailUpdate?: Maybe<CheckoutEmailUpdate>;
   /** Update language code in the existing checkout. */
@@ -5018,7 +5659,10 @@ export type Mutation = {
   checkoutRemovePromoCode?: Maybe<CheckoutRemovePromoCode>;
   /** Update shipping address in the existing checkout. */
   checkoutShippingAddressUpdate?: Maybe<CheckoutShippingAddressUpdate>;
-  /** Updates the shipping method of the checkout. */
+  /**
+   * Updates the shipping method of the checkout.
+   * @deprecated This field will be removed in Saleor 4.0. Use `checkoutDeliveryMethodUpdate` instead.
+   */
   checkoutShippingMethodUpdate?: Maybe<CheckoutShippingMethodUpdate>;
   /** Adds products to a collection. */
   collectionAddProducts?: Maybe<CollectionAddProducts>;
@@ -5074,16 +5718,25 @@ export type Mutation = {
   draftOrderCreate?: Maybe<DraftOrderCreate>;
   /** Deletes a draft order. */
   draftOrderDelete?: Maybe<DraftOrderDelete>;
-  /** Deletes order lines. */
+  /**
+   * Deletes order lines.
+   * @deprecated This field will be removed in Saleor 4.0.
+   */
   draftOrderLinesBulkDelete?: Maybe<DraftOrderLinesBulkDelete>;
   /** Updates a draft order. */
   draftOrderUpdate?: Maybe<DraftOrderUpdate>;
+  /** Retries event delivery. */
+  eventDeliveryRetry?: Maybe<EventDeliveryRetry>;
+  /** New in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point. */
+  exportGiftCards?: Maybe<ExportGiftCards>;
   /** Export products to csv file. */
   exportProducts?: Maybe<ExportProducts>;
   /** Prepare external authentication url for user by custom plugin. */
   externalAuthenticationUrl?: Maybe<ExternalAuthenticationUrl>;
   /** Logout user by custom plugin. */
   externalLogout?: Maybe<ExternalLogout>;
+  /** New in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload. */
+  externalNotificationTrigger?: Maybe<ExternalNotificationTrigger>;
   /** Obtain external access tokens for user by custom plugin. */
   externalObtainAccessTokens?: Maybe<ExternalObtainAccessTokens>;
   /** Refresh user's access by custom plugin. */
@@ -5094,10 +5747,26 @@ export type Mutation = {
   fileUpload?: Maybe<FileUpload>;
   /** Activate a gift card. */
   giftCardActivate?: Maybe<GiftCardActivate>;
+  /** New in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardAddNote?: Maybe<GiftCardAddNote>;
+  /** New in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardBulkActivate?: Maybe<GiftCardBulkActivate>;
+  /** New in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardBulkCreate?: Maybe<GiftCardBulkCreate>;
+  /** New in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardBulkDeactivate?: Maybe<GiftCardBulkDeactivate>;
+  /** New in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardBulkDelete?: Maybe<GiftCardBulkDelete>;
   /** Creates a new gift card. */
   giftCardCreate?: Maybe<GiftCardCreate>;
   /** Deactivate a gift card. */
   giftCardDeactivate?: Maybe<GiftCardDeactivate>;
+  /** New in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardDelete?: Maybe<GiftCardDelete>;
+  /** New in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardResend?: Maybe<GiftCardResend>;
+  /** Update gift card settings. */
+  giftCardSettingsUpdate?: Maybe<GiftCardSettingsUpdate>;
   /** Update a gift card. */
   giftCardUpdate?: Maybe<GiftCardUpdate>;
   /** Creates a ready to send invoice. */
@@ -5150,6 +5819,8 @@ export type Mutation = {
   orderDiscountUpdate?: Maybe<OrderDiscountUpdate>;
   /** Creates new fulfillments for an order. */
   orderFulfill?: Maybe<OrderFulfill>;
+  /** New in Saleor 3.1. Approve existing fulfillment. */
+  orderFulfillmentApprove?: Maybe<FulfillmentApprove>;
   /** Cancels existing fulfillment and optionally restocks items. */
   orderFulfillmentCancel?: Maybe<FulfillmentCancel>;
   /** Refund products. */
@@ -5176,7 +5847,7 @@ export type Mutation = {
   orderSettingsUpdate?: Maybe<OrderSettingsUpdate>;
   /** Updates an order. */
   orderUpdate?: Maybe<OrderUpdate>;
-  /** Updates a shipping method of the order. */
+  /** Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed. */
   orderUpdateShipping?: Maybe<OrderUpdateShipping>;
   /** Void an order. */
   orderVoid?: Maybe<OrderVoid>;
@@ -5230,6 +5901,8 @@ export type Mutation = {
   pluginUpdate?: Maybe<PluginUpdate>;
   /** Assign attributes to a given product type. */
   productAttributeAssign?: Maybe<ProductAttributeAssign>;
+  /** New in Saleor 3.1. Update attributes assigned to product variant for given product type. */
+  productAttributeAssignmentUpdate?: Maybe<ProductAttributeAssignmentUpdate>;
   /** Un-assign attributes from a given product type. */
   productAttributeUnassign?: Maybe<ProductAttributeUnassign>;
   /** Deletes products. */
@@ -5276,6 +5949,8 @@ export type Mutation = {
   productVariantCreate?: Maybe<ProductVariantCreate>;
   /** Deletes a product variant. */
   productVariantDelete?: Maybe<ProductVariantDelete>;
+  /** New in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point. */
+  productVariantPreorderDeactivate?: Maybe<ProductVariantPreorderDeactivate>;
   /** Reorder the variants of a product. Mutation updates updated_at on product and triggers PRODUCT_UPDATED webhook. */
   productVariantReorder?: Maybe<ProductVariantReorder>;
   /** Reorder product variant attribute values. */
@@ -5614,7 +6289,7 @@ export type MutationAttributeValueTranslateArgs = {
 
 export type MutationAttributeValueUpdateArgs = {
   id: Scalars['ID'];
-  input: AttributeValueCreateInput;
+  input: AttributeValueUpdateInput;
 };
 
 
@@ -5715,6 +6390,12 @@ export type MutationCheckoutCustomerDetachArgs = {
 };
 
 
+export type MutationCheckoutDeliveryMethodUpdateArgs = {
+  deliveryMethodId?: InputMaybe<Scalars['ID']>;
+  token?: InputMaybe<Scalars['UUID']>;
+};
+
+
 export type MutationCheckoutEmailUpdateArgs = {
   checkoutId?: InputMaybe<Scalars['ID']>;
   email: Scalars['String'];
@@ -5765,7 +6446,8 @@ export type MutationCheckoutPaymentCreateArgs = {
 
 export type MutationCheckoutRemovePromoCodeArgs = {
   checkoutId?: InputMaybe<Scalars['ID']>;
-  promoCode: Scalars['String'];
+  promoCode?: InputMaybe<Scalars['String']>;
+  promoCodeId?: InputMaybe<Scalars['ID']>;
   token?: InputMaybe<Scalars['UUID']>;
 };
 
@@ -5944,6 +6626,16 @@ export type MutationDraftOrderUpdateArgs = {
 };
 
 
+export type MutationEventDeliveryRetryArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationExportGiftCardsArgs = {
+  input: ExportGiftCardsInput;
+};
+
+
 export type MutationExportProductsArgs = {
   input: ExportProductsInput;
 };
@@ -5958,6 +6650,13 @@ export type MutationExternalAuthenticationUrlArgs = {
 export type MutationExternalLogoutArgs = {
   input: Scalars['JSONString'];
   pluginId: Scalars['String'];
+};
+
+
+export type MutationExternalNotificationTriggerArgs = {
+  channel: Scalars['String'];
+  input: ExternalNotificationTriggerInput;
+  pluginId?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -5989,6 +6688,32 @@ export type MutationGiftCardActivateArgs = {
 };
 
 
+export type MutationGiftCardAddNoteArgs = {
+  id: Scalars['ID'];
+  input: GiftCardAddNoteInput;
+};
+
+
+export type MutationGiftCardBulkActivateArgs = {
+  ids: Array<InputMaybe<Scalars['ID']>>;
+};
+
+
+export type MutationGiftCardBulkCreateArgs = {
+  input: GiftCardBulkCreateInput;
+};
+
+
+export type MutationGiftCardBulkDeactivateArgs = {
+  ids: Array<InputMaybe<Scalars['ID']>>;
+};
+
+
+export type MutationGiftCardBulkDeleteArgs = {
+  ids: Array<InputMaybe<Scalars['ID']>>;
+};
+
+
 export type MutationGiftCardCreateArgs = {
   input: GiftCardCreateInput;
 };
@@ -5996,6 +6721,21 @@ export type MutationGiftCardCreateArgs = {
 
 export type MutationGiftCardDeactivateArgs = {
   id: Scalars['ID'];
+};
+
+
+export type MutationGiftCardDeleteArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationGiftCardResendArgs = {
+  input: GiftCardResendInput;
+};
+
+
+export type MutationGiftCardSettingsUpdateArgs = {
+  input: GiftCardSettingsUpdateInput;
 };
 
 
@@ -6143,9 +6883,16 @@ export type MutationOrderFulfillArgs = {
 };
 
 
+export type MutationOrderFulfillmentApproveArgs = {
+  allowStockToBeExceeded?: InputMaybe<Scalars['Boolean']>;
+  id: Scalars['ID'];
+  notifyCustomer: Scalars['Boolean'];
+};
+
+
 export type MutationOrderFulfillmentCancelArgs = {
   id: Scalars['ID'];
-  input: FulfillmentCancelInput;
+  input?: InputMaybe<FulfillmentCancelInput>;
 };
 
 
@@ -6219,7 +6966,7 @@ export type MutationOrderUpdateArgs = {
 
 
 export type MutationOrderUpdateShippingArgs = {
-  input?: InputMaybe<OrderUpdateShippingInput>;
+  input: OrderUpdateShippingInput;
   order: Scalars['ID'];
 };
 
@@ -6373,6 +7120,12 @@ export type MutationProductAttributeAssignArgs = {
 };
 
 
+export type MutationProductAttributeAssignmentUpdateArgs = {
+  operations: Array<InputMaybe<ProductAttributeAssignmentUpdateInput>>;
+  productTypeId: Scalars['ID'];
+};
+
+
 export type MutationProductAttributeUnassignArgs = {
   attributeIds: Array<InputMaybe<Scalars['ID']>>;
   productTypeId: Scalars['ID'];
@@ -6498,6 +7251,11 @@ export type MutationProductVariantCreateArgs = {
 
 
 export type MutationProductVariantDeleteArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationProductVariantPreorderDeactivateArgs = {
   id: Scalars['ID'];
 };
 
@@ -6898,6 +7656,8 @@ export type Order = Node & ObjectWithMetadata & {
   __typename?: 'Order';
   /** List of actions that can be performed in the current state of an order. */
   actions: Array<Maybe<OrderAction>>;
+  /** New in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point. */
+  availableCollectionPoints: Array<Warehouse>;
   /**
    * Shipping methods that can be used with this order.
    * @deprecated Use `shippingMethods`, this field will be removed in 4.0
@@ -6907,16 +7667,19 @@ export type Order = Node & ObjectWithMetadata & {
   /** Informs whether a draft order can be finalized(turned into a regular order). */
   canFinalize: Scalars['Boolean'];
   channel: Channel;
+  collectionPointName?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
   customerNote: Scalars['String'];
+  /** New in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+  deliveryMethod?: Maybe<DeliveryMethod>;
   /**
    * Returns applied discount.
-   * @deprecated Use discounts field. This field will be removed in Saleor 4.0.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `discounts` field instead.
    */
   discount?: Maybe<Money>;
   /**
    * Discount name.
-   * @deprecated Use discounts field. This field will be removed in Saleor 4.0.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `discounts` field instead.
    */
   discountName?: Maybe<Scalars['String']>;
   /** List of all discounts assigned to the order. */
@@ -6930,7 +7693,6 @@ export type Order = Node & ObjectWithMetadata & {
   fulfillments: Array<Maybe<Fulfillment>>;
   /** List of user gift cards. */
   giftCards?: Maybe<Array<Maybe<GiftCard>>>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of order invoices. */
   invoices?: Maybe<Array<Maybe<Invoice>>>;
@@ -6938,7 +7700,7 @@ export type Order = Node & ObjectWithMetadata & {
   isPaid: Scalars['Boolean'];
   /** Returns True, if order requires shipping. */
   isShippingRequired: Scalars['Boolean'];
-  /** @deprecated Use the `languageCodeEnum` field to fetch the language code. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code.  */
   languageCode: Scalars['String'];
   /** Order language code. */
   languageCodeEnum: LanguageCodeEnum;
@@ -6962,11 +7724,14 @@ export type Order = Node & ObjectWithMetadata & {
   privateMetadata: Array<Maybe<MetadataItem>>;
   redirectUrl?: Maybe<Scalars['String']>;
   shippingAddress?: Maybe<Address>;
-  /** Shipping method for this order. */
+  /**
+   * Shipping method for this order.
+   * @deprecated This field will be removed in Saleor 4.0. Use `deliveryMethod` instead.
+   */
   shippingMethod?: Maybe<ShippingMethod>;
   shippingMethodName?: Maybe<Scalars['String']>;
   /** Shipping methods related to this order. */
-  shippingMethods: Array<ShippingMethod>;
+  shippingMethods?: Maybe<Array<Maybe<ShippingMethod>>>;
   /** Total price of shipping. */
   shippingPrice: TaxedMoney;
   shippingTaxRate: Scalars['Float'];
@@ -6987,11 +7752,12 @@ export type Order = Node & ObjectWithMetadata & {
   trackingClientId: Scalars['String'];
   /**
    * Translated discount name.
-   * @deprecated Use discounts field. This field will be removed in Saleor 4.0.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `discounts` field instead.
    */
   translatedDiscountName?: Maybe<Scalars['String']>;
   /** Undiscounted total amount of the order. */
   undiscountedTotal: TaxedMoney;
+  updatedAt: Scalars['DateTime'];
   user?: Maybe<User>;
   /** Email address of the customer. */
   userEmail?: Maybe<Scalars['String']>;
@@ -7017,7 +7783,7 @@ export type OrderAddNote = {
   event?: Maybe<OrderEvent>;
   /** Order with the note added. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7032,7 +7798,7 @@ export type OrderBulkCancel = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<OrderError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7042,7 +7808,7 @@ export type OrderCancel = {
   errors: Array<OrderError>;
   /** Canceled order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7052,7 +7818,7 @@ export type OrderCapture = {
   errors: Array<OrderError>;
   /** Captured order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7061,7 +7827,7 @@ export type OrderConfirm = {
   __typename?: 'OrderConfirm';
   errors: Array<OrderError>;
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7093,7 +7859,6 @@ export type OrderDiscount = Node & {
   __typename?: 'OrderDiscount';
   /** Returns amount of discount. */
   amount: Money;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name?: Maybe<Scalars['String']>;
   /** Explanation for the applied discount. */
@@ -7112,7 +7877,7 @@ export type OrderDiscountAdd = {
   errors: Array<OrderError>;
   /** Order which has been discounted. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7131,15 +7896,13 @@ export type OrderDiscountDelete = {
   errors: Array<OrderError>;
   /** Order which has removed discount. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
 /** An enumeration. */
 export type OrderDiscountType =
-  /** Manual */
   | 'MANUAL'
-  /** Voucher */
   | 'VOUCHER';
 
 /** Update discount for the order. */
@@ -7148,7 +7911,7 @@ export type OrderDiscountUpdate = {
   errors: Array<OrderError>;
   /** Order which has been discounted. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7185,11 +7948,13 @@ export type OrderErrorCode =
   | 'CANNOT_CANCEL_ORDER'
   | 'CANNOT_DELETE'
   | 'CANNOT_DISCOUNT'
+  | 'CANNOT_FULFILL_UNPAID_ORDER'
   | 'CANNOT_REFUND'
   | 'CAPTURE_INACTIVE_PAYMENT'
   | 'CHANNEL_INACTIVE'
   | 'DUPLICATED_INPUT_ITEM'
   | 'FULFILL_ORDER_LINE'
+  | 'GIFT_CARD_LINE'
   | 'GRAPHQL_ERROR'
   | 'INSUFFICIENT_STOCK'
   | 'INVALID'
@@ -7229,7 +7994,6 @@ export type OrderEvent = Node & {
   emailType?: Maybe<OrderEventsEmailsEnum>;
   /** The lines fulfilled. */
   fulfilledItems?: Maybe<Array<Maybe<FulfillmentLine>>>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Number of an invoice related to the order. */
   invoiceNumber?: Maybe<Scalars['String']>;
@@ -7329,6 +8093,7 @@ export type OrderEventsEnum =
   | 'DRAFT_CREATED_FROM_REPLACE'
   | 'EMAIL_SENT'
   | 'EXTERNAL_SERVICE_NOTIFICATION'
+  | 'FULFILLMENT_AWAITS_APPROVAL'
   | 'FULFILLMENT_CANCELED'
   | 'FULFILLMENT_FULFILLED_ITEMS'
   | 'FULFILLMENT_REFUNDED'
@@ -7368,11 +8133,16 @@ export type OrderFilterInput = {
   channels?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   created?: InputMaybe<DateRangeInput>;
   customer?: InputMaybe<Scalars['String']>;
+  giftCardBought?: InputMaybe<Scalars['Boolean']>;
+  giftCardUsed?: InputMaybe<Scalars['Boolean']>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  isClickAndCollect?: InputMaybe<Scalars['Boolean']>;
+  isPreorder?: InputMaybe<Scalars['Boolean']>;
   metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
   paymentStatus?: InputMaybe<Array<InputMaybe<PaymentChargeStatusEnum>>>;
   search?: InputMaybe<Scalars['String']>;
   status?: InputMaybe<Array<InputMaybe<OrderStatusFilter>>>;
+  updatedAt?: InputMaybe<DateTimeRangeInput>;
 };
 
 /** Creates new fulfillments for an order. */
@@ -7383,7 +8153,7 @@ export type OrderFulfill = {
   fulfillments?: Maybe<Array<Maybe<Fulfillment>>>;
   /** Fulfilled order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7416,13 +8186,15 @@ export type OrderLine = Node & {
   /** List of allocations across warehouses. */
   allocations?: Maybe<Array<Allocation>>;
   digitalContentUrl?: Maybe<DigitalContentUrl>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   isShippingRequired: Scalars['Boolean'];
   productName: Scalars['String'];
-  productSku: Scalars['String'];
+  productSku?: Maybe<Scalars['String']>;
+  productVariantId?: Maybe<Scalars['String']>;
   quantity: Scalars['Int'];
   quantityFulfilled: Scalars['Int'];
+  /** New in Saleor 3.1. A quantity of items remaining to be fulfilled. */
+  quantityToFulfill: Scalars['Int'];
   taxRate: Scalars['Float'];
   /** The main thumbnail for the ordered product. */
   thumbnail?: Maybe<Image>;
@@ -7467,7 +8239,7 @@ export type OrderLineDelete = {
   errors: Array<OrderError>;
   /** A related order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
   /** An order line that was deleted. */
   orderLine?: Maybe<OrderLine>;
@@ -7479,7 +8251,7 @@ export type OrderLineDiscountRemove = {
   errors: Array<OrderError>;
   /** Order which is related to line which has removed discount. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
   /** Order line which has removed discount. */
   orderLine?: Maybe<OrderLine>;
@@ -7491,7 +8263,7 @@ export type OrderLineDiscountUpdate = {
   errors: Array<OrderError>;
   /** Order which is related to the discounted line. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
   /** Order line which has been discounted. */
   orderLine?: Maybe<OrderLine>;
@@ -7508,7 +8280,7 @@ export type OrderLineUpdate = {
   errors: Array<OrderError>;
   /** Related order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
   orderLine?: Maybe<OrderLine>;
 };
@@ -7519,7 +8291,7 @@ export type OrderLinesCreate = {
   errors: Array<OrderError>;
   /** Related order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
   /** List of added order lines. */
   orderLines?: Maybe<Array<OrderLine>>;
@@ -7531,7 +8303,7 @@ export type OrderMarkAsPaid = {
   errors: Array<OrderError>;
   /** Order marked as paid. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7547,7 +8319,7 @@ export type OrderRefund = {
   errors: Array<OrderError>;
   /** A refunded order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7611,6 +8383,7 @@ export type OrderReturnProductsInput = {
 export type OrderSettings = {
   __typename?: 'OrderSettings';
   automaticallyConfirmAllNewOrders: Scalars['Boolean'];
+  automaticallyFulfillNonShippableGiftCard: Scalars['Boolean'];
 };
 
 export type OrderSettingsError = {
@@ -7633,22 +8406,36 @@ export type OrderSettingsUpdate = {
   errors: Array<OrderSettingsError>;
   /** Order settings. */
   orderSettings?: Maybe<OrderSettings>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderSettingsErrors: Array<OrderSettingsError>;
 };
 
 export type OrderSettingsUpdateInput = {
   /** When disabled, all new orders from checkout will be marked as unconfirmed. When enabled orders from checkout will become unfulfilled immediately. */
-  automaticallyConfirmAllNewOrders: Scalars['Boolean'];
+  automaticallyConfirmAllNewOrders?: InputMaybe<Scalars['Boolean']>;
+  /** When enabled, all non-shippable gift card orders will be fulfilled automatically. */
+  automaticallyFulfillNonShippableGiftCard?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type OrderSortField =
-  /** Sort orders by creation date. */
+  /**
+   * Sort orders by creation date.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0.
+   */
+  | 'CREATED_AT'
+  /**
+   * Sort orders by creation date.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0.
+   */
   | 'CREATION_DATE'
   /** Sort orders by customer. */
   | 'CUSTOMER'
   /** Sort orders by fulfillment status. */
   | 'FULFILLMENT_STATUS'
+  /** Sort orders by last modified at. */
+  | 'LAST_MODIFIED_AT'
   /** Sort orders by number. */
   | 'NUMBER'
   /** Sort orders by payment. */
@@ -7663,21 +8450,13 @@ export type OrderSortingInput = {
 
 /** An enumeration. */
 export type OrderStatus =
-  /** Canceled */
   | 'CANCELED'
-  /** Draft */
   | 'DRAFT'
-  /** Fulfilled */
   | 'FULFILLED'
-  /** Partially fulfilled */
   | 'PARTIALLY_FULFILLED'
-  /** Partially returned */
   | 'PARTIALLY_RETURNED'
-  /** Returned */
   | 'RETURNED'
-  /** Unconfirmed */
   | 'UNCONFIRMED'
-  /** Unfulfilled */
   | 'UNFULFILLED';
 
 export type OrderStatusFilter =
@@ -7694,7 +8473,7 @@ export type OrderUpdate = {
   __typename?: 'OrderUpdate';
   errors: Array<OrderError>;
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7707,18 +8486,18 @@ export type OrderUpdateInput = {
   userEmail?: InputMaybe<Scalars['String']>;
 };
 
-/** Updates a shipping method of the order. */
+/** Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed. */
 export type OrderUpdateShipping = {
   __typename?: 'OrderUpdateShipping';
   errors: Array<OrderError>;
   /** Order with updated shipping method. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
 export type OrderUpdateShippingInput = {
-  /** ID of the selected shipping method. */
+  /** ID of the selected shipping method, pass null to remove currently assigned shipping method. */
   shippingMethod?: InputMaybe<Scalars['ID']>;
 };
 
@@ -7728,7 +8507,7 @@ export type OrderVoid = {
   errors: Array<OrderError>;
   /** A voided order. */
   order?: Maybe<Order>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   orderErrors: Array<OrderError>;
 };
 
@@ -7737,14 +8516,14 @@ export type Page = Node & ObjectWithMetadata & {
   __typename?: 'Page';
   /** List of attributes assigned to this product. */
   attributes: Array<SelectedAttribute>;
+  /** Content of the page (JSON). */
   content?: Maybe<Scalars['JSONString']>;
   /**
    * Content of the page (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `content` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `content` field instead.
    */
   contentJson: Scalars['JSONString'];
   created: Scalars['DateTime'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   isPublished: Scalars['Boolean'];
   /** List of public metadata items. Can be accessed without permissions. */
@@ -7771,7 +8550,7 @@ export type PageTranslationArgs = {
 export type PageAttributeAssign = {
   __typename?: 'PageAttributeAssign';
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   /** The updated page type. */
   pageType?: Maybe<PageType>;
@@ -7781,7 +8560,7 @@ export type PageAttributeAssign = {
 export type PageAttributeUnassign = {
   __typename?: 'PageAttributeUnassign';
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   /** The updated page type. */
   pageType?: Maybe<PageType>;
@@ -7793,7 +8572,7 @@ export type PageBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
@@ -7803,7 +8582,7 @@ export type PageBulkPublish = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
@@ -7829,7 +8608,7 @@ export type PageCreate = {
   __typename?: 'PageCreate';
   errors: Array<PageError>;
   page?: Maybe<Page>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
@@ -7857,7 +8636,7 @@ export type PageDelete = {
   __typename?: 'PageDelete';
   errors: Array<PageError>;
   page?: Maybe<Page>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
@@ -7928,7 +8707,7 @@ export type PageReorderAttributeValues = {
   errors: Array<PageError>;
   /** Page from which attribute values are reordered. */
   page?: Maybe<Page>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
@@ -7958,14 +8737,13 @@ export type PageTranslatableContent = Node & {
   content?: Maybe<Scalars['JSONString']>;
   /**
    * Content of the page (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `content` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `content` field instead.
    */
   contentJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /**
    * ('A static page that can be manually added by a shop operator ', 'through the dashboard.')
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   page?: Maybe<Page>;
   seoDescription?: Maybe<Scalars['String']>;
@@ -7985,7 +8763,7 @@ export type PageTranslate = {
   __typename?: 'PageTranslate';
   errors: Array<TranslationError>;
   page?: Maybe<PageTranslatableContent>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
@@ -7994,10 +8772,9 @@ export type PageTranslation = Node & {
   content?: Maybe<Scalars['JSONString']>;
   /**
    * Translated description of the page (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `content` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `content` field instead.
    */
   contentJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -8022,7 +8799,6 @@ export type PageType = Node & ObjectWithMetadata & {
   availableAttributes?: Maybe<AttributeCountableConnection>;
   /** Whether page type has pages assigned. */
   hasPages?: Maybe<Scalars['Boolean']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
@@ -8048,7 +8824,7 @@ export type PageTypeBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
@@ -8073,7 +8849,7 @@ export type PageTypeCountableEdge = {
 export type PageTypeCreate = {
   __typename?: 'PageTypeCreate';
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   pageType?: Maybe<PageType>;
 };
@@ -8091,7 +8867,7 @@ export type PageTypeCreateInput = {
 export type PageTypeDelete = {
   __typename?: 'PageTypeDelete';
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   pageType?: Maybe<PageType>;
 };
@@ -8104,7 +8880,7 @@ export type PageTypeFilterInput = {
 export type PageTypeReorderAttributes = {
   __typename?: 'PageTypeReorderAttributes';
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   /** Page type from which attributes are reordered. */
   pageType?: Maybe<PageType>;
@@ -8127,7 +8903,7 @@ export type PageTypeSortingInput = {
 export type PageTypeUpdate = {
   __typename?: 'PageTypeUpdate';
   errors: Array<PageError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   pageType?: Maybe<PageType>;
 };
@@ -8148,14 +8924,14 @@ export type PageUpdate = {
   __typename?: 'PageUpdate';
   errors: Array<PageError>;
   page?: Maybe<Page>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
 };
 
 /** Change the password of the logged in user. */
 export type PasswordChange = {
   __typename?: 'PasswordChange';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** A user instance with a new password. */
@@ -8163,7 +8939,7 @@ export type PasswordChange = {
 };
 
 /** Represents a payment of a given type. */
-export type Payment = Node & {
+export type Payment = Node & ObjectWithMetadata & {
   __typename?: 'Payment';
   /** List of actions that can be performed in the current state of a payment. */
   actions: Array<Maybe<OrderAction>>;
@@ -8181,12 +8957,15 @@ export type Payment = Node & {
   creditCard?: Maybe<CreditCard>;
   customerIpAddress?: Maybe<Scalars['String']>;
   gateway: Scalars['String'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   isActive: Scalars['Boolean'];
+  /** List of public metadata items. Can be accessed without permissions. */
+  metadata: Array<Maybe<MetadataItem>>;
   modified: Scalars['DateTime'];
   order?: Maybe<Order>;
   paymentMethodType: Scalars['String'];
+  /** List of private metadata items.Requires proper staff permissions to access. */
+  privateMetadata: Array<Maybe<MetadataItem>>;
   token: Scalars['String'];
   /** Total amount of the payment. */
   total?: Maybe<Money>;
@@ -8200,7 +8979,7 @@ export type PaymentCapture = {
   errors: Array<PaymentError>;
   /** Updated payment. */
   payment?: Maybe<Payment>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
 };
 
@@ -8221,7 +9000,7 @@ export type PaymentCheckBalance = {
   /** Response from the gateway. */
   data?: Maybe<Scalars['JSONString']>;
   errors: Array<PaymentError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
 };
 
@@ -8270,6 +9049,7 @@ export type PaymentErrorCode =
   | 'BALANCE_CHECK_ERROR'
   | 'BILLING_ADDRESS_NOT_SET'
   | 'CHANNEL_INACTIVE'
+  | 'CHECKOUT_EMAIL_NOT_SET'
   | 'GRAPHQL_ERROR'
   | 'INVALID'
   | 'INVALID_SHIPPING_METHOD'
@@ -8306,7 +9086,7 @@ export type PaymentInitialize = {
   __typename?: 'PaymentInitialize';
   errors: Array<PaymentError>;
   initializedPayment?: Maybe<PaymentInitialized>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
 };
 
@@ -8326,8 +9106,12 @@ export type PaymentInput = {
   amount?: InputMaybe<Scalars['PositiveDecimal']>;
   /** A gateway to use with that payment. */
   gateway: Scalars['String'];
+  /** New in Saleor 3.1. User public metadata. */
+  metadata?: InputMaybe<Array<MetadataInput>>;
   /** URL of a storefront view where user should be redirected after requiring additional actions. Payment with additional actions will not be finished if this field is not provided. */
   returnUrl?: InputMaybe<Scalars['String']>;
+  /** New in Saleor 3.1. Payment store type. */
+  storePaymentMethod?: InputMaybe<StorePaymentMethodEnum>;
   /** Client-side generated payment token, representing customer's billing data in a secure manner. */
   token?: InputMaybe<Scalars['String']>;
 };
@@ -8338,7 +9122,7 @@ export type PaymentRefund = {
   errors: Array<PaymentError>;
   /** Updated payment. */
   payment?: Maybe<Payment>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
 };
 
@@ -8349,6 +9133,8 @@ export type PaymentSource = {
   creditCardInfo?: Maybe<CreditCard>;
   /** Payment gateway name. */
   gateway: Scalars['String'];
+  /** New in Saleor 3.1. List of public metadata items. Can be accessed without permissions. */
+  metadata: Array<Maybe<MetadataItem>>;
   /** ID of stored payment method. */
   paymentMethodId?: Maybe<Scalars['String']>;
 };
@@ -8359,7 +9145,7 @@ export type PaymentVoid = {
   errors: Array<PaymentError>;
   /** Updated payment. */
   payment?: Maybe<Payment>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
 };
 
@@ -8399,7 +9185,7 @@ export type PermissionGroupCreate = {
   __typename?: 'PermissionGroupCreate';
   errors: Array<PermissionGroupError>;
   group?: Maybe<Group>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   permissionGroupErrors: Array<PermissionGroupError>;
 };
 
@@ -8417,7 +9203,7 @@ export type PermissionGroupDelete = {
   __typename?: 'PermissionGroupDelete';
   errors: Array<PermissionGroupError>;
   group?: Maybe<Group>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   permissionGroupErrors: Array<PermissionGroupError>;
 };
 
@@ -8467,7 +9253,7 @@ export type PermissionGroupUpdate = {
   __typename?: 'PermissionGroupUpdate';
   errors: Array<PermissionGroupError>;
   group?: Maybe<Group>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   permissionGroupErrors: Array<PermissionGroupError>;
 };
 
@@ -8577,7 +9363,7 @@ export type PluginUpdate = {
   __typename?: 'PluginUpdate';
   errors: Array<PluginError>;
   plugin?: Maybe<Plugin>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pluginsErrors: Array<PluginError>;
 };
 
@@ -8592,6 +9378,40 @@ export type PluginUpdateInput = {
 export type PostalCodeRuleInclusionTypeEnum =
   | 'EXCLUDE'
   | 'INCLUDE';
+
+/** Represents preorder settings for product variant. */
+export type PreorderData = {
+  __typename?: 'PreorderData';
+  /** Preorder end date. */
+  endDate?: Maybe<Scalars['DateTime']>;
+  /** Total number of sold product variant during preorder. */
+  globalSoldUnits: Scalars['Int'];
+  /** The global preorder threshold for product variant. */
+  globalThreshold?: Maybe<Scalars['Int']>;
+};
+
+export type PreorderSettingsInput = {
+  /** The end date for preorder. */
+  endDate?: InputMaybe<Scalars['DateTime']>;
+  /** The global threshold for preorder variant. */
+  globalThreshold?: InputMaybe<Scalars['Int']>;
+};
+
+/** Represents preorder variant data for channel. */
+export type PreorderThreshold = {
+  __typename?: 'PreorderThreshold';
+  /** Preorder threshold for product variant in this channel. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** Number of sold product variant in this channel. */
+  soldUnits: Scalars['Int'];
+};
+
+export type PriceInput = {
+  /** Amount of money. */
+  amount: Scalars['PositiveDecimal'];
+  /** Currency code. */
+  currency: Scalars['String'];
+};
 
 export type PriceRangeInput = {
   /** Price greater than or equal to. */
@@ -8615,23 +9435,23 @@ export type Product = Node & ObjectWithMetadata & {
   chargeTaxes: Scalars['Boolean'];
   /** List of collections for the product. */
   collections?: Maybe<Array<Maybe<Collection>>>;
+  created: Scalars['DateTime'];
   defaultVariant?: Maybe<ProductVariant>;
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Description of the product (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /**
    * Get a single product image by ID.
-   * @deprecated Will be removed in Saleor 4.0. Use the `mediaById` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `mediaById` field instead.
    */
   imageById?: Maybe<ProductImage>;
   /**
    * List of images for the product.
-   * @deprecated Will be removed in Saleor 4.0. Use the `media` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `media` field instead.
    */
   images?: Maybe<Array<Maybe<ProductImage>>>;
   /** Whether the product is in stock and visible or not. */
@@ -8660,7 +9480,7 @@ export type Product = Node & ObjectWithMetadata & {
   thumbnail?: Maybe<Image>;
   /** Returns translated product fields for the given language code. */
   translation?: Maybe<ProductTranslation>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  updatedAt: Scalars['DateTime'];
   /** List of variants for the product. */
   variants?: Maybe<Array<Maybe<ProductVariant>>>;
   weight?: Maybe<Weight>;
@@ -8706,7 +9526,7 @@ export type ProductTranslationArgs = {
 export type ProductAttributeAssign = {
   __typename?: 'ProductAttributeAssign';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   /** The updated product type. */
   productType?: Maybe<ProductType>;
@@ -8717,6 +9537,25 @@ export type ProductAttributeAssignInput = {
   id: Scalars['ID'];
   /** The attribute type to be assigned as. */
   type: ProductAttributeType;
+  /** New in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric']. */
+  variantSelection?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** New in Saleor 3.1. Update attributes assigned to product variant for given product type. */
+export type ProductAttributeAssignmentUpdate = {
+  __typename?: 'ProductAttributeAssignmentUpdate';
+  errors: Array<ProductError>;
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
+  productErrors: Array<ProductError>;
+  /** The updated product type. */
+  productType?: Maybe<ProductType>;
+};
+
+export type ProductAttributeAssignmentUpdateInput = {
+  /** The ID of the attribute to assign. */
+  id: Scalars['ID'];
+  /** New in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric']. */
+  variantSelection: Scalars['Boolean'];
 };
 
 export type ProductAttributeType =
@@ -8727,7 +9566,7 @@ export type ProductAttributeType =
 export type ProductAttributeUnassign = {
   __typename?: 'ProductAttributeUnassign';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   /** The updated product type. */
   productType?: Maybe<ProductType>;
@@ -8739,7 +9578,7 @@ export type ProductBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -8750,7 +9589,6 @@ export type ProductChannelListing = Node & {
   channel: Channel;
   /** The price of the cheapest variant (including discounts). */
   discountedPrice?: Maybe<Money>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Whether the product is available for purchase. */
   isAvailableForPurchase?: Maybe<Scalars['Boolean']>;
@@ -8814,7 +9652,7 @@ export type ProductChannelListingUpdate = {
   errors: Array<ProductChannelListingError>;
   /** An updated product instance. */
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productChannelListingErrors: Array<ProductChannelListingError>;
 };
 
@@ -8847,7 +9685,7 @@ export type ProductCreate = {
   __typename?: 'ProductCreate';
   errors: Array<ProductError>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -8883,7 +9721,7 @@ export type ProductDelete = {
   __typename?: 'ProductDelete';
   errors: Array<ProductError>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -8914,6 +9752,7 @@ export type ProductErrorCode =
   | 'NOT_FOUND'
   | 'NOT_PRODUCTS_IMAGE'
   | 'NOT_PRODUCTS_VARIANT'
+  | 'PREORDER_VARIANT_CANNOT_BE_DEACTIVATED'
   | 'PRODUCT_NOT_ASSIGNED_TO_CHANNEL'
   | 'PRODUCT_WITHOUT_CATEGORY'
   | 'REQUIRED'
@@ -8930,6 +9769,7 @@ export type ProductFieldEnum =
   | 'PRODUCT_MEDIA'
   | 'PRODUCT_TYPE'
   | 'PRODUCT_WEIGHT'
+  | 'VARIANT_ID'
   | 'VARIANT_MEDIA'
   | 'VARIANT_SKU'
   | 'VARIANT_WEIGHT';
@@ -8937,10 +9777,16 @@ export type ProductFieldEnum =
 export type ProductFilterInput = {
   attributes?: InputMaybe<Array<InputMaybe<AttributeInput>>>;
   categories?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  /** Specifies the channel by which the data should be filtered. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel by which the data should be filtered.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   collections?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  giftCard?: InputMaybe<Scalars['Boolean']>;
   hasCategory?: InputMaybe<Scalars['Boolean']>;
+  hasPreorderedVariants?: InputMaybe<Scalars['Boolean']>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   isPublished?: InputMaybe<Scalars['Boolean']>;
   metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
@@ -8950,6 +9796,7 @@ export type ProductFilterInput = {
   search?: InputMaybe<Scalars['String']>;
   stockAvailability?: InputMaybe<StockAvailability>;
   stocks?: InputMaybe<ProductStockFilterInput>;
+  updatedAt?: InputMaybe<DateTimeRangeInput>;
 };
 
 /** Represents a product image. */
@@ -9000,7 +9847,6 @@ export type ProductInput = {
 export type ProductMedia = Node & {
   __typename?: 'ProductMedia';
   alt: Scalars['String'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   oembedData: Scalars['JSONString'];
   sortOrder?: Maybe<Scalars['Int']>;
@@ -9021,7 +9867,7 @@ export type ProductMediaBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9031,7 +9877,7 @@ export type ProductMediaCreate = {
   errors: Array<ProductError>;
   media?: Maybe<ProductMedia>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9052,7 +9898,7 @@ export type ProductMediaDelete = {
   errors: Array<ProductError>;
   media?: Maybe<ProductMedia>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9062,15 +9908,13 @@ export type ProductMediaReorder = {
   errors: Array<ProductError>;
   media?: Maybe<Array<ProductMedia>>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
 /** An enumeration. */
 export type ProductMediaType =
-  /** An uploaded image or an URL to an image */
   | 'IMAGE'
-  /** A URL to an external video */
   | 'VIDEO';
 
 /** Updates a product media. */
@@ -9079,7 +9923,7 @@ export type ProductMediaUpdate = {
   errors: Array<ProductError>;
   media?: Maybe<ProductMedia>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9094,7 +9938,11 @@ export type ProductOrder = {
    * Note: this doesn't take translations into account yet.
    */
   attributeId?: InputMaybe<Scalars['ID']>;
-  /** Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel in which to sort the data.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   /** Specifies the direction in which to sort products. */
   direction: OrderDirection;
@@ -9107,6 +9955,10 @@ export type ProductOrderField =
   | 'COLLECTION'
   /** Sort products by update date. */
   | 'DATE'
+  /** Sort products by update date. */
+  | 'LAST_MODIFIED'
+  /** Sort products by update date. */
+  | 'LAST_MODIFIED_AT'
   /** Sort products by a minimal price of a product's variant. */
   | 'MINIMAL_PRICE'
   /** Sort products by name. */
@@ -9117,7 +9969,9 @@ export type ProductOrderField =
   | 'PUBLICATION_DATE'
   /** Sort products by publication status. */
   | 'PUBLISHED'
-  /** Sort products by rank. Note: This option is available only with the `search` filter. */
+  /** Sort products by publication date. */
+  | 'PUBLISHED_AT'
+  /** Sort products by name. */
   | 'RANK'
   /** Sort products by rating. */
   | 'RATING'
@@ -9147,7 +10001,7 @@ export type ProductReorderAttributeValues = {
   errors: Array<ProductError>;
   /** Product from which attribute values are reordered. */
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9163,15 +10017,14 @@ export type ProductTranslatableContent = Node & {
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Description of the product (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   /**
    * Represents an individual item for sale in the storefront.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   product?: Maybe<Product>;
   seoDescription?: Maybe<Scalars['String']>;
@@ -9190,7 +10043,7 @@ export type ProductTranslate = {
   __typename?: 'ProductTranslate';
   errors: Array<TranslationError>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
@@ -9199,10 +10052,9 @@ export type ProductTranslation = Node & {
   description?: Maybe<Scalars['JSONString']>;
   /**
    * Translated description of the product (JSON).
-   * @deprecated Will be removed in Saleor 4.0. Use the `description` field instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `description` field instead.
    */
   descriptionJson?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -9214,12 +10066,15 @@ export type ProductTranslation = Node & {
 /** Represents a type of product. It defines what attributes are available to products of this type. */
 export type ProductType = Node & ObjectWithMetadata & {
   __typename?: 'ProductType';
+  /** New in Saleor 3.1. Variant attributes of that product type with attached variant selection. */
+  assignedVariantAttributes?: Maybe<Array<Maybe<AssignedVariantAttribute>>>;
   availableAttributes?: Maybe<AttributeCountableConnection>;
   hasVariants: Scalars['Boolean'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   isDigital: Scalars['Boolean'];
   isShippingRequired: Scalars['Boolean'];
+  /** The product type kind. */
+  kind: ProductTypeKindEnum;
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
   name: Scalars['String'];
@@ -9229,15 +10084,24 @@ export type ProductType = Node & ObjectWithMetadata & {
   productAttributes?: Maybe<Array<Maybe<Attribute>>>;
   /**
    * List of products of this type.
-   * @deprecated Will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.
+   * @deprecated This field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.
    */
   products?: Maybe<ProductCountableConnection>;
   slug: Scalars['String'];
   /** A type of tax. Assigned by enabled tax gateway */
   taxType?: Maybe<TaxType>;
-  /** Variant attributes of that product type. */
+  /**
+   * Variant attributes of that product type.
+   * @deprecated This field will be removed in Saleor 4.0. Use `assignedVariantAttributes` instead.
+   */
   variantAttributes?: Maybe<Array<Maybe<Attribute>>>;
   weight?: Maybe<Weight>;
+};
+
+
+/** Represents a type of product. It defines what attributes are available to products of this type. */
+export type ProductTypeAssignedVariantAttributesArgs = {
+  variantSelection?: InputMaybe<VariantAttributeScope>;
 };
 
 
@@ -9272,7 +10136,7 @@ export type ProductTypeBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9301,7 +10165,7 @@ export type ProductTypeCountableEdge = {
 export type ProductTypeCreate = {
   __typename?: 'ProductTypeCreate';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productType?: Maybe<ProductType>;
 };
@@ -9310,7 +10174,7 @@ export type ProductTypeCreate = {
 export type ProductTypeDelete = {
   __typename?: 'ProductTypeDelete';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productType?: Maybe<ProductType>;
 };
@@ -9322,6 +10186,7 @@ export type ProductTypeEnum =
 export type ProductTypeFilterInput = {
   configurable?: InputMaybe<ProductTypeConfigurable>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  kind?: InputMaybe<ProductTypeKindEnum>;
   metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
   productType?: InputMaybe<ProductTypeEnum>;
   search?: InputMaybe<Scalars['String']>;
@@ -9334,6 +10199,8 @@ export type ProductTypeInput = {
   isDigital?: InputMaybe<Scalars['Boolean']>;
   /** Determines if shipping is required for products of this variant. */
   isShippingRequired?: InputMaybe<Scalars['Boolean']>;
+  /** The product type kind. */
+  kind?: InputMaybe<ProductTypeKindEnum>;
   /** Name of the product type. */
   name?: InputMaybe<Scalars['String']>;
   /** List of attributes shared among all product variants. */
@@ -9348,11 +10215,16 @@ export type ProductTypeInput = {
   weight?: InputMaybe<Scalars['WeightScalar']>;
 };
 
+/** An enumeration. */
+export type ProductTypeKindEnum =
+  | 'GIFT_CARD'
+  | 'NORMAL';
+
 /** Reorder the attributes of a product type. */
 export type ProductTypeReorderAttributes = {
   __typename?: 'ProductTypeReorderAttributes';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   /** Product type from which attributes are reordered. */
   productType?: Maybe<ProductType>;
@@ -9377,7 +10249,7 @@ export type ProductTypeSortingInput = {
 export type ProductTypeUpdate = {
   __typename?: 'ProductTypeUpdate';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productType?: Maybe<ProductType>;
 };
@@ -9387,7 +10259,7 @@ export type ProductUpdate = {
   __typename?: 'ProductUpdate';
   errors: Array<ProductError>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9400,13 +10272,13 @@ export type ProductVariant = Node & ObjectWithMetadata & {
   channel?: Maybe<Scalars['String']>;
   /** List of price information in channels for the product. */
   channelListings?: Maybe<Array<ProductVariantChannelListing>>;
+  created: Scalars['DateTime'];
   /** Digital content for the product variant. */
   digitalContent?: Maybe<DigitalContent>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /**
    * List of images for the product variant.
-   * @deprecated Will be removed in Saleor 4.0. Use the `media` instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `media` field instead.
    */
   images?: Maybe<Array<Maybe<ProductImage>>>;
   /** Gross margin percentage value. */
@@ -9416,23 +10288,27 @@ export type ProductVariant = Node & ObjectWithMetadata & {
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
   name: Scalars['String'];
+  /** New in Saleor 3.1. Preorder data for product variant. Note: this feature is in a preview state and can be subject to changes at later point. */
+  preorder?: Maybe<PreorderData>;
   /** Lists the storefront variant's pricing, the current price and discounts, only meant for displaying. */
   pricing?: Maybe<VariantPricingInfo>;
   /** List of private metadata items.Requires proper staff permissions to access. */
   privateMetadata: Array<Maybe<MetadataItem>>;
   product: Product;
-  /** Quantity of a product available for sale in one checkout. */
-  quantityAvailable: Scalars['Int'];
+  /** Quantity of a product available for sale in one checkout. Field value will be `null` when no `limitQuantityPerCheckout` in global settings has been set, and `productVariant` stocks are not tracked. */
+  quantityAvailable?: Maybe<Scalars['Int']>;
+  quantityLimitPerCustomer?: Maybe<Scalars['Int']>;
   /** Total quantity ordered. */
   quantityOrdered?: Maybe<Scalars['Int']>;
   /** Total revenue generated by a variant in given period of time. Note: this field should be queried using `reportProductSales` query as it uses optimizations suitable for such calculations. */
   revenue?: Maybe<TaxedMoney>;
-  sku: Scalars['String'];
+  sku?: Maybe<Scalars['String']>;
   /** Stocks for the product variant. */
   stocks?: Maybe<Array<Maybe<Stock>>>;
   trackInventory: Scalars['Boolean'];
   /** Returns translated product variant fields for the given language code. */
   translation?: Maybe<ProductVariantTranslation>;
+  updatedAt: Scalars['DateTime'];
   weight?: Maybe<Weight>;
 };
 
@@ -9477,7 +10353,7 @@ export type ProductVariantTranslationArgs = {
 /** Creates product variants for a given product. */
 export type ProductVariantBulkCreate = {
   __typename?: 'ProductVariantBulkCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   bulkProductErrors: Array<BulkProductError>;
   /** Returns how many objects were created. */
   count: Scalars['Int'];
@@ -9491,8 +10367,12 @@ export type ProductVariantBulkCreateInput = {
   attributes: Array<BulkAttributeValueInput>;
   /** List of prices assigned to channels. */
   channelListings?: InputMaybe<Array<ProductVariantChannelListingAddInput>>;
+  /** New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point. */
+  preorder?: InputMaybe<PreorderSettingsInput>;
+  /** New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+  quantityLimitPerCustomer?: InputMaybe<Scalars['Int']>;
   /** Stock keeping unit. */
-  sku: Scalars['String'];
+  sku?: InputMaybe<Scalars['String']>;
   /** Stocks of a product available for sale. */
   stocks?: InputMaybe<Array<StockInput>>;
   /** Determines if the inventory of this variant should be tracked. If false, the quantity won't change when customers buy this item. */
@@ -9507,7 +10387,7 @@ export type ProductVariantBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9517,10 +10397,11 @@ export type ProductVariantChannelListing = Node & {
   channel: Channel;
   /** Cost price of the variant. */
   costPrice?: Maybe<Money>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Gross margin percentage value. */
   margin?: Maybe<Scalars['Int']>;
+  /** New in Saleor 3.1. Preorder variant data. Note: this feature is in a preview state and can be subject to changes at later point. */
+  preorderThreshold?: Maybe<PreorderThreshold>;
   price?: Maybe<Money>;
 };
 
@@ -9529,6 +10410,8 @@ export type ProductVariantChannelListingAddInput = {
   channelId: Scalars['ID'];
   /** Cost price of the variant in channel. */
   costPrice?: InputMaybe<Scalars['PositiveDecimal']>;
+  /** New in Saleor 3.1. The threshold for preorder variant in channel. Note: this feature is in a preview state and can be subject to changes at later point. */
+  preorderThreshold?: InputMaybe<Scalars['Int']>;
   /** Price of the particular variant in channel. */
   price: Scalars['PositiveDecimal'];
 };
@@ -9537,7 +10420,7 @@ export type ProductVariantChannelListingAddInput = {
 export type ProductVariantChannelListingUpdate = {
   __typename?: 'ProductVariantChannelListingUpdate';
   errors: Array<ProductChannelListingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productChannelListingErrors: Array<ProductChannelListingError>;
   /** An updated product variant instance. */
   variant?: Maybe<ProductVariant>;
@@ -9564,7 +10447,7 @@ export type ProductVariantCountableEdge = {
 export type ProductVariantCreate = {
   __typename?: 'ProductVariantCreate';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productVariant?: Maybe<ProductVariant>;
 };
@@ -9572,8 +10455,12 @@ export type ProductVariantCreate = {
 export type ProductVariantCreateInput = {
   /** List of attributes specific to this variant. */
   attributes: Array<AttributeValueInput>;
+  /** New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point. */
+  preorder?: InputMaybe<PreorderSettingsInput>;
   /** Product ID of which type is the variant. */
   product: Scalars['ID'];
+  /** New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+  quantityLimitPerCustomer?: InputMaybe<Scalars['Int']>;
   /** Stock keeping unit. */
   sku?: InputMaybe<Scalars['String']>;
   /** Stocks of a product available for sale. */
@@ -9588,20 +10475,26 @@ export type ProductVariantCreateInput = {
 export type ProductVariantDelete = {
   __typename?: 'ProductVariantDelete';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productVariant?: Maybe<ProductVariant>;
 };
 
 export type ProductVariantFilterInput = {
+  isPreorder?: InputMaybe<Scalars['Boolean']>;
   metadata?: InputMaybe<Array<InputMaybe<MetadataFilter>>>;
   search?: InputMaybe<Scalars['String']>;
   sku?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  updatedAt?: InputMaybe<DateTimeRangeInput>;
 };
 
 export type ProductVariantInput = {
   /** List of attributes specific to this variant. */
   attributes?: InputMaybe<Array<AttributeValueInput>>;
+  /** New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point. */
+  preorder?: InputMaybe<PreorderSettingsInput>;
+  /** New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point. */
+  quantityLimitPerCustomer?: InputMaybe<Scalars['Int']>;
   /** Stock keeping unit. */
   sku?: InputMaybe<Scalars['String']>;
   /** Determines if the inventory of this variant should be tracked. If false, the quantity won't change when customers buy this item. */
@@ -9610,12 +10503,20 @@ export type ProductVariantInput = {
   weight?: InputMaybe<Scalars['WeightScalar']>;
 };
 
+/** New in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point. */
+export type ProductVariantPreorderDeactivate = {
+  __typename?: 'ProductVariantPreorderDeactivate';
+  errors: Array<ProductError>;
+  /** Product variant with ended preorder. */
+  productVariant?: Maybe<ProductVariant>;
+};
+
 /** Reorder the variants of a product. Mutation updates updated_at on product and triggers PRODUCT_UPDATED webhook. */
 export type ProductVariantReorder = {
   __typename?: 'ProductVariantReorder';
   errors: Array<ProductError>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
 };
 
@@ -9623,7 +10524,7 @@ export type ProductVariantReorder = {
 export type ProductVariantReorderAttributeValues = {
   __typename?: 'ProductVariantReorderAttributeValues';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   /** Product variant from which attribute values are reordered. */
   productVariant?: Maybe<ProductVariant>;
@@ -9634,14 +10535,25 @@ export type ProductVariantSetDefault = {
   __typename?: 'ProductVariantSetDefault';
   errors: Array<ProductError>;
   product?: Maybe<Product>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
+};
+
+export type ProductVariantSortField =
+  /** Sort products variants by last modified at. */
+  | 'LAST_MODIFIED_AT';
+
+export type ProductVariantSortingInput = {
+  /** Specifies the direction in which to sort products. */
+  direction: OrderDirection;
+  /** Sort productVariants by the selected field. */
+  field: ProductVariantSortField;
 };
 
 /** Creates stocks for product variant. */
 export type ProductVariantStocksCreate = {
   __typename?: 'ProductVariantStocksCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   bulkStockErrors: Array<BulkStockError>;
   errors: Array<BulkStockError>;
   /** Updated product variant. */
@@ -9654,14 +10566,14 @@ export type ProductVariantStocksDelete = {
   errors: Array<StockError>;
   /** Updated product variant. */
   productVariant?: Maybe<ProductVariant>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   stockErrors: Array<StockError>;
 };
 
 /** Update stocks for product variant. */
 export type ProductVariantStocksUpdate = {
   __typename?: 'ProductVariantStocksUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   bulkStockErrors: Array<BulkStockError>;
   errors: Array<BulkStockError>;
   /** Updated product variant. */
@@ -9672,12 +10584,11 @@ export type ProductVariantTranslatableContent = Node & {
   __typename?: 'ProductVariantTranslatableContent';
   /** List of product variant attribute values that can be translated. */
   attributeValues: Array<AttributeValueTranslatableContent>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   /**
    * Represents a version of a product such as different size or color.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   productVariant?: Maybe<ProductVariant>;
   /** Returns translated product variant fields for the given language code. */
@@ -9694,13 +10605,12 @@ export type ProductVariantTranslate = {
   __typename?: 'ProductVariantTranslate';
   errors: Array<TranslationError>;
   productVariant?: Maybe<ProductVariant>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
 export type ProductVariantTranslation = Node & {
   __typename?: 'ProductVariantTranslation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -9711,7 +10621,7 @@ export type ProductVariantTranslation = Node & {
 export type ProductVariantUpdate = {
   __typename?: 'ProductVariantUpdate';
   errors: Array<ProductError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productVariant?: Maybe<ProductVariant>;
 };
@@ -9735,6 +10645,10 @@ export type Query = {
   addressValidationRules?: Maybe<AddressValidationData>;
   /** Look up an app by ID. If ID is not provided, return the currently authenticated app. */
   app?: Maybe<App>;
+  /** New in Saleor 3.1. Look up an app extension by ID. Note: this feature is in a preview state and can be subject to changes at later point. */
+  appExtension?: Maybe<AppExtension>;
+  /** New in Saleor 3.1. List of all extensions. Note: this feature is in a preview state and can be subject to changes at later point. */
+  appExtensions?: Maybe<AppExtensionCountableConnection>;
   /** List of the apps. */
   apps?: Maybe<AppCountableConnection>;
   /** List of all apps installations */
@@ -9775,6 +10689,12 @@ export type Query = {
   exportFiles?: Maybe<ExportFileCountableConnection>;
   /** Look up a gift card by ID. */
   giftCard?: Maybe<GiftCard>;
+  /** New in Saleor 3.1. List of gift card currencies. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardCurrencies: Array<Scalars['String']>;
+  /** Gift card related settings from site settings. */
+  giftCardSettings: GiftCardSettings;
+  /** New in Saleor 3.1. List of gift card tags. Note: this feature is in a preview state and can be subject to changes at later point. */
+  giftCardTags?: Maybe<GiftCardTagCountableConnection>;
   /** List of gift cards. */
   giftCards?: Maybe<GiftCardCountableConnection>;
   /** List of activity events to display on homepage (at the moment it only contains order-events). */
@@ -9866,7 +10786,10 @@ export type Query = {
   warehouses?: Maybe<WarehouseCountableConnection>;
   /** Look up a webhook by ID. */
   webhook?: Maybe<Webhook>;
-  /** List of all available webhook events. */
+  /**
+   * List of all available webhook events.
+   * @deprecated This field will be removed in Saleor 4.0. Use `WebhookEventTypeAsyncEnum` and `WebhookEventTypeSyncEnum` to get available event types.
+   */
   webhookEvents?: Maybe<Array<Maybe<WebhookEvent>>>;
   /** Retrieve a sample payload for a given webhook event based on real data. It can be useful for some integrations where sample payload is required. */
   webhookSamplePayload?: Maybe<Scalars['JSONString']>;
@@ -9893,6 +10816,20 @@ export type QueryAddressValidationRulesArgs = {
 
 export type QueryAppArgs = {
   id?: InputMaybe<Scalars['ID']>;
+};
+
+
+export type QueryAppExtensionArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type QueryAppExtensionsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<AppExtensionFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -9962,8 +10899,10 @@ export type QueryCheckoutsArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   channel?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<CheckoutFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<CheckoutSortingInput>;
 };
 
 
@@ -10038,11 +10977,22 @@ export type QueryGiftCardArgs = {
 };
 
 
+export type QueryGiftCardTagsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<GiftCardTagFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
 export type QueryGiftCardsArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<GiftCardFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<GiftCardSortingInput>;
 };
 
 
@@ -10229,6 +11179,7 @@ export type QueryProductVariantsArgs = {
   first?: InputMaybe<Scalars['Int']>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   last?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<ProductVariantSortingInput>;
 };
 
 
@@ -10386,7 +11337,7 @@ export type ReducedRate = {
 /** Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take refreshToken from the http-only cookie -refreshToken. csrfToken is required when refreshToken is provided as a cookie. */
 export type RefreshToken = {
   __typename?: 'RefreshToken';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** JWT token, required to authenticate. */
@@ -10409,7 +11360,7 @@ export type ReportingPeriod =
 /** Request email change of the logged in user. */
 export type RequestEmailChange = {
   __typename?: 'RequestEmailChange';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** A user instance. */
@@ -10419,7 +11370,7 @@ export type RequestEmailChange = {
 /** Sends an email with the account password modification link. */
 export type RequestPasswordReset = {
   __typename?: 'RequestPasswordReset';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
 };
@@ -10433,12 +11384,12 @@ export type Sale = Node & ObjectWithMetadata & {
   channelListings?: Maybe<Array<SaleChannelListing>>;
   /** List of collections this sale applies to. */
   collections?: Maybe<CollectionCountableConnection>;
+  created: Scalars['DateTime'];
   /** Currency code for sale. */
   currency?: Maybe<Scalars['String']>;
   /** Sale value. */
   discountValue?: Maybe<Scalars['Float']>;
   endDate?: Maybe<Scalars['DateTime']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
@@ -10451,7 +11402,8 @@ export type Sale = Node & ObjectWithMetadata & {
   /** Returns translated sale fields for the given language code. */
   translation?: Maybe<SaleTranslation>;
   type: SaleType;
-  /** List of product variants this sale applies to. */
+  updatedAt: Scalars['DateTime'];
+  /** New in Saleor 3.1. List of product variants this sale applies to. */
   variants?: Maybe<ProductVariantCountableConnection>;
 };
 
@@ -10500,7 +11452,7 @@ export type SaleVariantsArgs = {
 /** Adds products, categories, collections to a voucher. */
 export type SaleAddCatalogues = {
   __typename?: 'SaleAddCatalogues';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   /** Sale of which catalogue IDs will be modified. */
@@ -10512,7 +11464,7 @@ export type SaleBulkDelete = {
   __typename?: 'SaleBulkDelete';
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
 };
@@ -10523,7 +11475,6 @@ export type SaleChannelListing = Node & {
   channel: Channel;
   currency: Scalars['String'];
   discountValue: Scalars['Float'];
-  /** The ID of the object. */
   id: Scalars['ID'];
 };
 
@@ -10544,7 +11495,7 @@ export type SaleChannelListingInput = {
 /** Manage sale's availability in channels. */
 export type SaleChannelListingUpdate = {
   __typename?: 'SaleChannelListingUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   /** An updated sale instance. */
@@ -10571,7 +11522,7 @@ export type SaleCountableEdge = {
 /** Creates a new sale. */
 export type SaleCreate = {
   __typename?: 'SaleCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   sale?: Maybe<Sale>;
@@ -10580,7 +11531,7 @@ export type SaleCreate = {
 /** Deletes a sale. */
 export type SaleDelete = {
   __typename?: 'SaleDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   sale?: Maybe<Sale>;
@@ -10592,6 +11543,7 @@ export type SaleFilterInput = {
   search?: InputMaybe<Scalars['String']>;
   started?: InputMaybe<DateTimeRangeInput>;
   status?: InputMaybe<Array<InputMaybe<DiscountStatusEnum>>>;
+  updatedAt?: InputMaybe<DateTimeRangeInput>;
 };
 
 export type SaleInput = {
@@ -10617,7 +11569,7 @@ export type SaleInput = {
 /** Removes products, categories, collections from a sale. */
 export type SaleRemoveCatalogues = {
   __typename?: 'SaleRemoveCatalogues';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   /** Sale of which catalogue IDs will be modified. */
@@ -10625,8 +11577,12 @@ export type SaleRemoveCatalogues = {
 };
 
 export type SaleSortField =
+  /** Sort sales by created at. */
+  | 'CREATED_AT'
   /** Sort sales by end date. */
   | 'END_DATE'
+  /** Sort sales by last modified at. */
+  | 'LAST_MODIFIED_AT'
   /** Sort sales by name. */
   | 'NAME'
   /** Sort sales by start date. */
@@ -10637,7 +11593,11 @@ export type SaleSortField =
   | 'VALUE';
 
 export type SaleSortingInput = {
-  /** Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel in which to sort the data.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   /** Specifies the direction in which to sort products. */
   direction: OrderDirection;
@@ -10647,12 +11607,11 @@ export type SaleSortingInput = {
 
 export type SaleTranslatableContent = Node & {
   __typename?: 'SaleTranslatableContent';
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   /**
    * Sales allow creating discounts for categories, collections or products and are visible to all the customers.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   sale?: Maybe<Sale>;
   /** Returns translated sale fields for the given language code. */
@@ -10669,30 +11628,26 @@ export type SaleTranslate = {
   __typename?: 'SaleTranslate';
   errors: Array<TranslationError>;
   sale?: Maybe<Sale>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
 export type SaleTranslation = Node & {
   __typename?: 'SaleTranslation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
   name?: Maybe<Scalars['String']>;
 };
 
-/** An enumeration. */
 export type SaleType =
-  /** fixed */
   | 'FIXED'
-  /** % */
   | 'PERCENTAGE';
 
 /** Updates a sale. */
 export type SaleUpdate = {
   __typename?: 'SaleUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   sale?: Maybe<Sale>;
@@ -10717,7 +11672,7 @@ export type SeoInput = {
 /** Sets the user's password from the token sent by email using the RequestPasswordReset mutation. */
 export type SetPassword = {
   __typename?: 'SetPassword';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** CSRF token required to re-generate access token. */
   csrfToken?: Maybe<Scalars['String']>;
@@ -10755,7 +11710,7 @@ export type ShippingErrorCode =
   | 'REQUIRED'
   | 'UNIQUE';
 
-/** ('Shipping methods that can be used as means of shippingfor orders and checkouts.',) */
+/** Shipping methods that can be used as means of shipping for orders and checkouts. */
 export type ShippingMethod = Node & ObjectWithMetadata & {
   __typename?: 'ShippingMethod';
   /** Describes if this shipping method is active and can be selected. */
@@ -10802,7 +11757,7 @@ export type ShippingMethod = Node & ObjectWithMetadata & {
 };
 
 
-/** ('Shipping methods that can be used as means of shippingfor orders and checkouts.',) */
+/** Shipping methods that can be used as means of shipping for orders and checkouts. */
 export type ShippingMethodTranslationArgs = {
   languageCode: LanguageCodeEnum;
 };
@@ -10811,7 +11766,6 @@ export type ShippingMethodTranslationArgs = {
 export type ShippingMethodChannelListing = Node & {
   __typename?: 'ShippingMethodChannelListing';
   channel: Channel;
-  /** The ID of the object. */
   id: Scalars['ID'];
   maximumOrderPrice?: Maybe<Money>;
   minimumOrderPrice?: Maybe<Money>;
@@ -10840,7 +11794,7 @@ export type ShippingMethodChannelListingInput = {
 export type ShippingMethodChannelListingUpdate = {
   __typename?: 'ShippingMethodChannelListingUpdate';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   /** An updated shipping method instance. */
   shippingMethod?: Maybe<ShippingMethodType>;
@@ -10862,12 +11816,11 @@ export type ShippingMethodPostalCodeRule = Node & {
 export type ShippingMethodTranslatableContent = Node & {
   __typename?: 'ShippingMethodTranslatableContent';
   description?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   name: Scalars['String'];
   /**
    * Shipping method are the methods you'll use to get customer's orders  to them. They are directly exposed to the customers.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   shippingMethod?: Maybe<ShippingMethodType>;
   /** Returns translated shipping method fields for the given language code. */
@@ -10882,7 +11835,6 @@ export type ShippingMethodTranslatableContentTranslationArgs = {
 export type ShippingMethodTranslation = Node & {
   __typename?: 'ShippingMethodTranslation';
   description?: Maybe<Scalars['JSONString']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -10894,17 +11846,27 @@ export type ShippingMethodType = Node & ObjectWithMetadata & {
   __typename?: 'ShippingMethodType';
   /** List of channels available for the method. */
   channelListings?: Maybe<Array<ShippingMethodChannelListing>>;
+  /** Shipping method description. */
   description?: Maybe<Scalars['JSONString']>;
   /** List of excluded products for the shipping method. */
   excludedProducts?: Maybe<ProductCountableConnection>;
-  /** The ID of the object. */
+  /** Shipping method ID. */
   id: Scalars['ID'];
+  /** Maximum number of days for delivery. */
   maximumDeliveryDays?: Maybe<Scalars['Int']>;
+  /** The price of the cheapest variant (including discounts). */
+  maximumOrderPrice?: Maybe<Money>;
+  /** Maximum order weight to use this shipping method. */
   maximumOrderWeight?: Maybe<Weight>;
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
+  /** Minimal number of days for delivery. */
   minimumDeliveryDays?: Maybe<Scalars['Int']>;
+  /** The price of the cheapest variant (including discounts). */
+  minimumOrderPrice?: Maybe<Money>;
+  /** Minimum order weight to use this shipping method. */
   minimumOrderWeight?: Maybe<Weight>;
+  /** Shipping method name. */
   name: Scalars['String'];
   /** Postal code ranges rule of exclusion or inclusion of the shipping method. */
   postalCodeRules?: Maybe<Array<Maybe<ShippingMethodPostalCodeRule>>>;
@@ -10949,7 +11911,7 @@ export type ShippingPriceBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
 };
 
@@ -10957,7 +11919,7 @@ export type ShippingPriceBulkDelete = {
 export type ShippingPriceCreate = {
   __typename?: 'ShippingPriceCreate';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   shippingMethod?: Maybe<ShippingMethodType>;
   /** A shipping zone to which the shipping method belongs. */
@@ -10968,7 +11930,7 @@ export type ShippingPriceCreate = {
 export type ShippingPriceDelete = {
   __typename?: 'ShippingPriceDelete';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   /** A shipping method to delete. */
   shippingMethod?: Maybe<ShippingMethodType>;
@@ -10980,7 +11942,7 @@ export type ShippingPriceDelete = {
 export type ShippingPriceExcludeProducts = {
   __typename?: 'ShippingPriceExcludeProducts';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   /** A shipping method with new list of excluded products. */
   shippingMethod?: Maybe<ShippingMethodType>;
@@ -10996,7 +11958,7 @@ export type ShippingPriceInput = {
   addPostalCodeRules?: InputMaybe<Array<ShippingPostalCodeRulesCreateInputRange>>;
   /** Postal code rules to delete. */
   deletePostalCodeRules?: InputMaybe<Array<Scalars['ID']>>;
-  /** Shipping method description (JSON). */
+  /** Shipping method description. */
   description?: InputMaybe<Scalars['JSONString']>;
   /** Inclusion type for currently assigned postal code rules. */
   inclusionType?: InputMaybe<PostalCodeRuleInclusionTypeEnum>;
@@ -11020,7 +11982,7 @@ export type ShippingPriceInput = {
 export type ShippingPriceRemoveProductFromExclude = {
   __typename?: 'ShippingPriceRemoveProductFromExclude';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   /** A shipping method with new list of excluded products. */
   shippingMethod?: Maybe<ShippingMethodType>;
@@ -11031,7 +11993,7 @@ export type ShippingPriceTranslate = {
   __typename?: 'ShippingPriceTranslate';
   errors: Array<TranslationError>;
   shippingMethod?: Maybe<ShippingMethodType>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
@@ -11045,7 +12007,7 @@ export type ShippingPriceTranslationInput = {
 export type ShippingPriceUpdate = {
   __typename?: 'ShippingPriceUpdate';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   shippingMethod?: Maybe<ShippingMethodType>;
   /** A shipping zone to which the shipping method belongs. */
@@ -11062,7 +12024,6 @@ export type ShippingZone = Node & ObjectWithMetadata & {
   default: Scalars['Boolean'];
   /** Description of a shipping zone. */
   description?: Maybe<Scalars['String']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
@@ -11083,7 +12044,7 @@ export type ShippingZoneBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
 };
 
@@ -11108,7 +12069,7 @@ export type ShippingZoneCountableEdge = {
 export type ShippingZoneCreate = {
   __typename?: 'ShippingZoneCreate';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   shippingZone?: Maybe<ShippingZone>;
 };
@@ -11132,7 +12093,7 @@ export type ShippingZoneCreateInput = {
 export type ShippingZoneDelete = {
   __typename?: 'ShippingZoneDelete';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   shippingZone?: Maybe<ShippingZone>;
 };
@@ -11146,7 +12107,7 @@ export type ShippingZoneFilterInput = {
 export type ShippingZoneUpdate = {
   __typename?: 'ShippingZoneUpdate';
   errors: Array<ShippingError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shippingErrors: Array<ShippingError>;
   shippingZone?: Maybe<ShippingZone>;
 };
@@ -11181,6 +12142,8 @@ export type Shop = {
   availablePaymentGateways: Array<PaymentGateway>;
   /** Shipping methods that are available for the shop. */
   availableShippingMethods?: Maybe<Array<Maybe<ShippingMethod>>>;
+  /** New in Saleor 3.1. List of all currencies supported by shop's channels. */
+  channelCurrencies: Array<Scalars['String']>;
   /** Charge taxes on shipping. */
   chargeTaxesOnShipping: Scalars['Boolean'];
   /** Company address. */
@@ -11207,12 +12170,18 @@ export type Shop = {
   displayGrossPrices: Scalars['Boolean'];
   /** Shop's domain data. */
   domain: Domain;
+  /** New in Saleor 3.1. Allow to approve fulfillments which are unpaid. */
+  fulfillmentAllowUnpaid: Scalars['Boolean'];
+  /** New in Saleor 3.1. Automatically approve all new fulfillments. */
+  fulfillmentAutoApprove: Scalars['Boolean'];
   /** Header text. */
   headerText?: Maybe<Scalars['String']>;
   /** Include taxes in prices. */
   includeTaxesInPrices: Scalars['Boolean'];
   /** List of the shops's supported languages. */
   languages: Array<Maybe<LanguageDisplay>>;
+  /** New in Saleor 3.1. Default number of maximum line quantity in single checkout (per single checkout line). Note: this feature is in a preview state and can be subject to changes at later point. */
+  limitQuantityPerCheckout?: Maybe<Scalars['Int']>;
   /** Resource limitations and current usage if any set for a shop */
   limits: LimitInfo;
   /** Shop's name. */
@@ -11221,6 +12190,10 @@ export type Shop = {
   permissions: Array<Maybe<Permission>>;
   /** List of possible phone prefixes. */
   phonePrefixes: Array<Maybe<Scalars['String']>>;
+  /** New in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout or null when stock reservation is disabled. */
+  reserveStockDurationAnonymousUser?: Maybe<Scalars['Int']>;
+  /** New in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout or null when stock reservation is disabled. */
+  reserveStockDurationAuthenticatedUser?: Maybe<Scalars['Int']>;
   /** List of staff notification recipients. */
   staffNotificationRecipients?: Maybe<Array<Maybe<StaffNotificationRecipient>>>;
   /** Enable inventory tracking. */
@@ -11264,7 +12237,7 @@ export type ShopAddressUpdate = {
   errors: Array<ShopError>;
   /** Updated shop. */
   shop?: Maybe<Shop>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
 };
 
@@ -11274,7 +12247,7 @@ export type ShopDomainUpdate = {
   errors: Array<ShopError>;
   /** Updated shop. */
   shop?: Maybe<Shop>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
 };
 
@@ -11304,7 +12277,7 @@ export type ShopFetchTaxRates = {
   errors: Array<ShopError>;
   /** Updated shop. */
   shop?: Maybe<Shop>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
 };
 
@@ -11329,10 +12302,20 @@ export type ShopSettingsInput = {
   description?: InputMaybe<Scalars['String']>;
   /** Display prices with tax in store. */
   displayGrossPrices?: InputMaybe<Scalars['Boolean']>;
+  /** New in Saleor 3.1. Enable ability to approve fulfillments which are unpaid. */
+  fulfillmentAllowUnpaid?: InputMaybe<Scalars['Boolean']>;
+  /** New in Saleor 3.1. Enable automatic approval of all new fulfillments. */
+  fulfillmentAutoApprove?: InputMaybe<Scalars['Boolean']>;
   /** Header text. */
   headerText?: InputMaybe<Scalars['String']>;
   /** Include taxes in prices. */
   includeTaxesInPrices?: InputMaybe<Scalars['Boolean']>;
+  /** New in Saleor 3.1. Default number of maximum line quantity in single checkout. Minimum possible value is 1, default value is 50. Note: this feature is in a preview state and can be subject to changes at later point. */
+  limitQuantityPerCheckout?: InputMaybe<Scalars['Int']>;
+  /** New in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout. Enter 0 or null to disable. */
+  reserveStockDurationAnonymousUser?: InputMaybe<Scalars['Int']>;
+  /** New in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout. Enter 0 or null to disable. */
+  reserveStockDurationAuthenticatedUser?: InputMaybe<Scalars['Int']>;
   /** Enable inventory tracking. */
   trackInventoryByDefault?: InputMaybe<Scalars['Boolean']>;
 };
@@ -11343,7 +12326,7 @@ export type ShopSettingsTranslate = {
   errors: Array<TranslationError>;
   /** Updated shop settings. */
   shop?: Maybe<Shop>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
 };
 
@@ -11358,7 +12341,7 @@ export type ShopSettingsUpdate = {
   errors: Array<ShopError>;
   /** Updated shop. */
   shop?: Maybe<Shop>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
 };
 
@@ -11366,7 +12349,6 @@ export type ShopTranslation = Node & {
   __typename?: 'ShopTranslation';
   description: Scalars['String'];
   headerText: Scalars['String'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -11385,7 +12367,7 @@ export type StaffBulkDelete = {
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
   errors: Array<StaffError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   staffErrors: Array<StaffError>;
 };
 
@@ -11393,7 +12375,7 @@ export type StaffBulkDelete = {
 export type StaffCreate = {
   __typename?: 'StaffCreate';
   errors: Array<StaffError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   staffErrors: Array<StaffError>;
   user?: Maybe<User>;
 };
@@ -11419,7 +12401,7 @@ export type StaffCreateInput = {
 export type StaffDelete = {
   __typename?: 'StaffDelete';
   errors: Array<StaffError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   staffErrors: Array<StaffError>;
   user?: Maybe<User>;
 };
@@ -11455,7 +12437,6 @@ export type StaffNotificationRecipient = Node & {
   active?: Maybe<Scalars['Boolean']>;
   /** Returns email address of a user subscribed to email notifications. */
   email?: Maybe<Scalars['String']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Returns a user subscribed to email notifications. */
   user?: Maybe<User>;
@@ -11465,7 +12446,7 @@ export type StaffNotificationRecipient = Node & {
 export type StaffNotificationRecipientCreate = {
   __typename?: 'StaffNotificationRecipientCreate';
   errors: Array<ShopError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
   staffNotificationRecipient?: Maybe<StaffNotificationRecipient>;
 };
@@ -11474,7 +12455,7 @@ export type StaffNotificationRecipientCreate = {
 export type StaffNotificationRecipientDelete = {
   __typename?: 'StaffNotificationRecipientDelete';
   errors: Array<ShopError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
   staffNotificationRecipient?: Maybe<StaffNotificationRecipient>;
 };
@@ -11492,7 +12473,7 @@ export type StaffNotificationRecipientInput = {
 export type StaffNotificationRecipientUpdate = {
   __typename?: 'StaffNotificationRecipientUpdate';
   errors: Array<ShopError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   shopErrors: Array<ShopError>;
   staffNotificationRecipient?: Maybe<StaffNotificationRecipient>;
 };
@@ -11501,7 +12482,7 @@ export type StaffNotificationRecipientUpdate = {
 export type StaffUpdate = {
   __typename?: 'StaffUpdate';
   errors: Array<StaffError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   staffErrors: Array<StaffError>;
   user?: Maybe<User>;
 };
@@ -11532,13 +12513,14 @@ export type StaffUserInput = {
 /** Represents stock. */
 export type Stock = Node & {
   __typename?: 'Stock';
-  /** The ID of the object. */
   id: Scalars['ID'];
   productVariant: ProductVariant;
   /** Quantity of a product in the warehouse's possession, including the allocated stock that is waiting for shipment. */
   quantity: Scalars['Int'];
   /** Quantity allocated for orders */
   quantityAllocated: Scalars['Int'];
+  /** Quantity reserved for checkouts */
+  quantityReserved: Scalars['Int'];
   warehouse: Warehouse;
 };
 
@@ -11594,6 +12576,15 @@ export type StockInput = {
   warehouse: Scalars['ID'];
 };
 
+/** Enum representing the type of a payment storage in a gateway. */
+export type StorePaymentMethodEnum =
+  /** Storage is disabled. The payment is not stored. */
+  | 'NONE'
+  /** Off session storage type. The payment is stored to be reused even if the customer is absent. */
+  | 'OFF_SESSION'
+  /** On session storage type. The payment is stored only to be reused when the customer is present in the checkout flow. */
+  | 'ON_SESSION';
+
 /** Representation of tax types fetched from tax gateway. */
 export type TaxType = {
   __typename?: 'TaxType';
@@ -11625,6 +12616,28 @@ export type TaxedMoneyRange = {
   stop?: Maybe<TaxedMoney>;
 };
 
+export type TimePeriod = {
+  __typename?: 'TimePeriod';
+  /** The length of the period. */
+  amount: Scalars['Int'];
+  /** The type of the period. */
+  type: TimePeriodTypeEnum;
+};
+
+export type TimePeriodInputType = {
+  /** The length of the period. */
+  amount: Scalars['Int'];
+  /** The type of the period. */
+  type: TimePeriodTypeEnum;
+};
+
+/** An enumeration. */
+export type TimePeriodTypeEnum =
+  | 'DAY'
+  | 'MONTH'
+  | 'WEEK'
+  | 'YEAR';
+
 /** An object representing a single payment. */
 export type Transaction = Node & {
   __typename?: 'Transaction';
@@ -11633,7 +12646,6 @@ export type Transaction = Node & {
   created: Scalars['DateTime'];
   error?: Maybe<Scalars['String']>;
   gatewayResponse: Scalars['JSONString'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   isSuccess: Scalars['Boolean'];
   kind: TransactionKind;
@@ -11643,25 +12655,15 @@ export type Transaction = Node & {
 
 /** An enumeration. */
 export type TransactionKind =
-  /** Action to confirm */
   | 'ACTION_TO_CONFIRM'
-  /** Authorization */
   | 'AUTH'
-  /** Cancel */
   | 'CANCEL'
-  /** Capture */
   | 'CAPTURE'
-  /** Confirm */
   | 'CONFIRM'
-  /** External reference */
   | 'EXTERNAL'
-  /** Pending */
   | 'PENDING'
-  /** Refund */
   | 'REFUND'
-  /** Refund in progress */
   | 'REFUND_ONGOING'
-  /** Void */
   | 'VOID';
 
 export type TranslatableItem = AttributeTranslatableContent | AttributeValueTranslatableContent | CategoryTranslatableContent | CollectionTranslatableContent | MenuItemTranslatableContent | PageTranslatableContent | ProductTranslatableContent | ProductVariantTranslatableContent | SaleTranslatableContent | ShippingMethodTranslatableContent | VoucherTranslatableContent;
@@ -11709,6 +12711,7 @@ export type TranslationError = {
 /** An enumeration. */
 export type TranslationErrorCode =
   | 'GRAPHQL_ERROR'
+  | 'INVALID'
   | 'NOT_FOUND'
   | 'REQUIRED';
 
@@ -11731,7 +12734,7 @@ export type UpdateMetadata = {
   __typename?: 'UpdateMetadata';
   errors: Array<MetadataError>;
   item?: Maybe<ObjectWithMetadata>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   metadataErrors: Array<MetadataError>;
 };
 
@@ -11740,7 +12743,7 @@ export type UpdatePrivateMetadata = {
   __typename?: 'UpdatePrivateMetadata';
   errors: Array<MetadataError>;
   item?: Maybe<ObjectWithMetadata>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   metadataErrors: Array<MetadataError>;
 };
 
@@ -11766,7 +12769,7 @@ export type User = Node & ObjectWithMetadata & {
   avatar?: Maybe<Image>;
   /**
    * Returns the last open checkout of this user.
-   * @deprecated Will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.
+   * @deprecated This field will be removed in Saleor 4.0. Use the `checkoutTokens` field to fetch the user checkouts.
    */
   checkout?: Maybe<Checkout>;
   /** Returns the checkout UUID's assigned to this user. */
@@ -11782,7 +12785,6 @@ export type User = Node & ObjectWithMetadata & {
   firstName: Scalars['String'];
   /** List of the user gift cards. */
   giftCards?: Maybe<GiftCardCountableConnection>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   isActive: Scalars['Boolean'];
   isStaff: Scalars['Boolean'];
@@ -11802,6 +12804,7 @@ export type User = Node & ObjectWithMetadata & {
   privateMetadata: Array<Maybe<MetadataItem>>;
   /** List of stored payment sources. */
   storedPaymentSources?: Maybe<Array<Maybe<PaymentSource>>>;
+  updatedAt: Scalars['DateTime'];
   /** List of user's permissions. */
   userPermissions?: Maybe<Array<Maybe<UserPermission>>>;
 };
@@ -11845,7 +12848,7 @@ export type UserStoredPaymentSourcesArgs = {
 /** Deletes a user avatar. Only for staff members. */
 export type UserAvatarDelete = {
   __typename?: 'UserAvatarDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** An updated user instance. */
@@ -11855,7 +12858,7 @@ export type UserAvatarDelete = {
 /** Create a user avatar. Only for staff members. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec */
 export type UserAvatarUpdate = {
   __typename?: 'UserAvatarUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** An updated user instance. */
@@ -11865,7 +12868,7 @@ export type UserAvatarUpdate = {
 /** Activate or deactivate users. */
 export type UserBulkSetActive = {
   __typename?: 'UserBulkSetActive';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
@@ -11928,10 +12931,14 @@ export type UserPermissionSourcePermissionGroupsArgs = {
 };
 
 export type UserSortField =
+  /** Sort users by created at. */
+  | 'CREATED_AT'
   /** Sort users by email. */
   | 'EMAIL'
   /** Sort users by first name. */
   | 'FIRST_NAME'
+  /** Sort users by last modified at. */
+  | 'LAST_MODIFIED_AT'
   /** Sort users by last name. */
   | 'LAST_NAME'
   /** Sort users by order count. */
@@ -11965,7 +12972,7 @@ export type VariantMediaAssign = {
   __typename?: 'VariantMediaAssign';
   errors: Array<ProductError>;
   media?: Maybe<ProductMedia>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productVariant?: Maybe<ProductVariant>;
 };
@@ -11975,7 +12982,7 @@ export type VariantMediaUnassign = {
   __typename?: 'VariantMediaUnassign';
   errors: Array<ProductError>;
   media?: Maybe<ProductMedia>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   productErrors: Array<ProductError>;
   productVariant?: Maybe<ProductVariant>;
 };
@@ -12000,7 +13007,7 @@ export type VariantPricingInfo = {
 /** Verify JWT token. */
 export type VerifyToken = {
   __typename?: 'VerifyToken';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   accountErrors: Array<AccountError>;
   errors: Array<AccountError>;
   /** Determine if token is valid or not. */
@@ -12048,7 +13055,6 @@ export type Voucher = Node & ObjectWithMetadata & {
   /** Determines a type of discount for voucher - value or percentage */
   discountValueType: DiscountValueTypeEnum;
   endDate?: Maybe<Scalars['DateTime']>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
@@ -12068,7 +13074,7 @@ export type Voucher = Node & ObjectWithMetadata & {
   type: VoucherTypeEnum;
   usageLimit?: Maybe<Scalars['Int']>;
   used: Scalars['Int'];
-  /** List of product variants this voucher applies to. */
+  /** New in Saleor 3.1. List of product variants this voucher applies to. */
   variants?: Maybe<ProductVariantCountableConnection>;
 };
 
@@ -12117,7 +13123,7 @@ export type VoucherVariantsArgs = {
 /** Adds products, categories, collections to a voucher. */
 export type VoucherAddCatalogues = {
   __typename?: 'VoucherAddCatalogues';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   /** Voucher of which catalogue IDs will be modified. */
@@ -12129,7 +13135,7 @@ export type VoucherBulkDelete = {
   __typename?: 'VoucherBulkDelete';
   /** Returns how many objects were affected. */
   count: Scalars['Int'];
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
 };
@@ -12140,7 +13146,6 @@ export type VoucherChannelListing = Node & {
   channel: Channel;
   currency: Scalars['String'];
   discountValue: Scalars['Float'];
-  /** The ID of the object. */
   id: Scalars['ID'];
   minSpent?: Maybe<Money>;
 };
@@ -12164,7 +13169,7 @@ export type VoucherChannelListingInput = {
 /** Manage voucher's availability in channels. */
 export type VoucherChannelListingUpdate = {
   __typename?: 'VoucherChannelListingUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   /** An updated voucher instance. */
@@ -12191,7 +13196,7 @@ export type VoucherCountableEdge = {
 /** Creates a new voucher. */
 export type VoucherCreate = {
   __typename?: 'VoucherCreate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   voucher?: Maybe<Voucher>;
@@ -12200,7 +13205,7 @@ export type VoucherCreate = {
 /** Deletes a voucher. */
 export type VoucherDelete = {
   __typename?: 'VoucherDelete';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   voucher?: Maybe<Voucher>;
@@ -12251,14 +13256,14 @@ export type VoucherInput = {
   type?: InputMaybe<VoucherTypeEnum>;
   /** Limit number of times this voucher can be used in total. */
   usageLimit?: InputMaybe<Scalars['Int']>;
-  /** Variants discounted by the voucher. */
+  /** New in Saleor 3.1. Variants discounted by the voucher. */
   variants?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
 };
 
 /** Removes products, categories, collections from a voucher. */
 export type VoucherRemoveCatalogues = {
   __typename?: 'VoucherRemoveCatalogues';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   /** Voucher of which catalogue IDs will be modified. */
@@ -12282,7 +13287,11 @@ export type VoucherSortField =
   | 'VALUE';
 
 export type VoucherSortingInput = {
-  /** Specifies the channel in which to sort the data. DEPRECATED: Will be removed in Saleor 4.0.Use root-level channel argument instead. */
+  /**
+   * Specifies the channel in which to sort the data.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+   */
   channel?: InputMaybe<Scalars['String']>;
   /** Specifies the direction in which to sort products. */
   direction: OrderDirection;
@@ -12292,14 +13301,13 @@ export type VoucherSortingInput = {
 
 export type VoucherTranslatableContent = Node & {
   __typename?: 'VoucherTranslatableContent';
-  /** The ID of the object. */
   id: Scalars['ID'];
   name?: Maybe<Scalars['String']>;
   /** Returns translated voucher fields for the given language code. */
   translation?: Maybe<VoucherTranslation>;
   /**
    * Vouchers allow giving discounts to particular customers on categories, collections or specific products. They can be used during checkout by providing valid voucher codes.
-   * @deprecated Will be removed in Saleor 4.0. Get model fields from the root level.
+   * @deprecated This field will be removed in Saleor 4.0. Get model fields from the root level queries.
    */
   voucher?: Maybe<Voucher>;
 };
@@ -12313,14 +13321,13 @@ export type VoucherTranslatableContentTranslationArgs = {
 export type VoucherTranslate = {
   __typename?: 'VoucherTranslate';
   errors: Array<TranslationError>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   translationErrors: Array<TranslationError>;
   voucher?: Maybe<Voucher>;
 };
 
 export type VoucherTranslation = Node & {
   __typename?: 'VoucherTranslation';
-  /** The ID of the object. */
   id: Scalars['ID'];
   /** Translation language. */
   language: LanguageDisplay;
@@ -12335,7 +13342,7 @@ export type VoucherTypeEnum =
 /** Updates a voucher. */
 export type VoucherUpdate = {
   __typename?: 'VoucherUpdate';
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   discountErrors: Array<DiscountError>;
   errors: Array<DiscountError>;
   voucher?: Maybe<Voucher>;
@@ -12345,14 +13352,16 @@ export type VoucherUpdate = {
 export type Warehouse = Node & ObjectWithMetadata & {
   __typename?: 'Warehouse';
   address: Address;
+  /** New in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point. */
+  clickAndCollectOption: WarehouseClickAndCollectOptionEnum;
   /**
    * Warehouse company name.
-   * @deprecated Use address.CompanyName. This field will be removed in Saleor 4.0.
+   * @deprecated This field will be removed in Saleor 4.0. Use `Address.companyName` instead.
    */
   companyName: Scalars['String'];
   email: Scalars['String'];
-  /** The ID of the object. */
   id: Scalars['ID'];
+  isPrivate: Scalars['Boolean'];
   /** List of public metadata items. Can be accessed without permissions. */
   metadata: Array<Maybe<MetadataItem>>;
   name: Scalars['String'];
@@ -12370,6 +13379,12 @@ export type WarehouseShippingZonesArgs = {
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
+
+/** An enumeration. */
+export type WarehouseClickAndCollectOptionEnum =
+  | 'ALL'
+  | 'DISABLED'
+  | 'LOCAL';
 
 export type WarehouseCountableConnection = {
   __typename?: 'WarehouseCountableConnection';
@@ -12393,7 +13408,7 @@ export type WarehouseCreate = {
   __typename?: 'WarehouseCreate';
   errors: Array<WarehouseError>;
   warehouse?: Maybe<Warehouse>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   warehouseErrors: Array<WarehouseError>;
 };
 
@@ -12415,7 +13430,7 @@ export type WarehouseDelete = {
   __typename?: 'WarehouseDelete';
   errors: Array<WarehouseError>;
   warehouse?: Maybe<Warehouse>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   warehouseErrors: Array<WarehouseError>;
 };
 
@@ -12439,7 +13454,9 @@ export type WarehouseErrorCode =
   | 'UNIQUE';
 
 export type WarehouseFilterInput = {
+  clickAndCollectOption?: InputMaybe<WarehouseClickAndCollectOptionEnum>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  isPrivate?: InputMaybe<Scalars['Boolean']>;
   search?: InputMaybe<Scalars['String']>;
 };
 
@@ -12448,7 +13465,7 @@ export type WarehouseShippingZoneAssign = {
   __typename?: 'WarehouseShippingZoneAssign';
   errors: Array<WarehouseError>;
   warehouse?: Maybe<Warehouse>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   warehouseErrors: Array<WarehouseError>;
 };
 
@@ -12457,7 +13474,7 @@ export type WarehouseShippingZoneUnassign = {
   __typename?: 'WarehouseShippingZoneUnassign';
   errors: Array<WarehouseError>;
   warehouse?: Maybe<Warehouse>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   warehouseErrors: Array<WarehouseError>;
 };
 
@@ -12477,15 +13494,19 @@ export type WarehouseUpdate = {
   __typename?: 'WarehouseUpdate';
   errors: Array<WarehouseError>;
   warehouse?: Maybe<Warehouse>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   warehouseErrors: Array<WarehouseError>;
 };
 
 export type WarehouseUpdateInput = {
   /** Address of the warehouse. */
   address?: InputMaybe<AddressInput>;
+  /** New in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point. */
+  clickAndCollectOption?: InputMaybe<WarehouseClickAndCollectOptionEnum>;
   /** The email address of the warehouse. */
   email?: InputMaybe<Scalars['String']>;
+  /** New in Saleor 3.1. Visibility of warehouse stocks. Note: this feature is in a preview state and can be subject to changes at later point. */
+  isPrivate?: InputMaybe<Scalars['Boolean']>;
   /** Warehouse name. */
   name?: InputMaybe<Scalars['String']>;
   /** Warehouse slug. */
@@ -12496,14 +13517,33 @@ export type WarehouseUpdateInput = {
 export type Webhook = Node & {
   __typename?: 'Webhook';
   app: App;
-  /** List of webhook events. */
+  /** List of asynchronous webhook events. */
+  asyncEvents: Array<WebhookEventAsync>;
+  /** Event deliveries. */
+  eventDeliveries?: Maybe<EventDeliveryCountableConnection>;
+  /**
+   * List of webhook events.
+   * @deprecated This field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.
+   */
   events: Array<WebhookEvent>;
-  /** The ID of the object. */
   id: Scalars['ID'];
   isActive: Scalars['Boolean'];
   name: Scalars['String'];
   secretKey?: Maybe<Scalars['String']>;
+  /** List of synchronous webhook events. */
+  syncEvents: Array<WebhookEventSync>;
   targetUrl: Scalars['String'];
+};
+
+
+/** Webhook. */
+export type WebhookEventDeliveriesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<EventDeliveryFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<EventDeliverySortingInput>;
 };
 
 /** Creates a new webhook subscription. */
@@ -12511,14 +13551,20 @@ export type WebhookCreate = {
   __typename?: 'WebhookCreate';
   errors: Array<WebhookError>;
   webhook?: Maybe<Webhook>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   webhookErrors: Array<WebhookError>;
 };
 
 export type WebhookCreateInput = {
   /** ID of the app to which webhook belongs. */
   app?: InputMaybe<Scalars['ID']>;
-  /** The events that webhook wants to subscribe. */
+  /** The asynchronous events that webhook wants to subscribe. */
+  asyncEvents?: InputMaybe<Array<WebhookEventTypeAsyncEnum>>;
+  /**
+   * The events that webhook wants to subscribe.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.
+   */
   events?: InputMaybe<Array<InputMaybe<WebhookEventTypeEnum>>>;
   /** Determine if webhook will be set active or not. */
   isActive?: InputMaybe<Scalars['Boolean']>;
@@ -12526,6 +13572,8 @@ export type WebhookCreateInput = {
   name?: InputMaybe<Scalars['String']>;
   /** The secret key used to create a hash signature with each payload. */
   secretKey?: InputMaybe<Scalars['String']>;
+  /** The synchronous events that webhook wants to subscribe. */
+  syncEvents?: InputMaybe<Array<WebhookEventTypeSyncEnum>>;
   /** The url to receive the payload. */
   targetUrl?: InputMaybe<Scalars['String']>;
 };
@@ -12535,7 +13583,7 @@ export type WebhookDelete = {
   __typename?: 'WebhookDelete';
   errors: Array<WebhookError>;
   webhook?: Maybe<Webhook>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   webhookErrors: Array<WebhookError>;
 };
 
@@ -12566,15 +13614,38 @@ export type WebhookEvent = {
   name: Scalars['String'];
 };
 
+/** Asynchronous webhook event. */
+export type WebhookEventAsync = {
+  __typename?: 'WebhookEventAsync';
+  /** Internal name of the event type. */
+  eventType: WebhookEventTypeAsyncEnum;
+  /** Display name of the event. */
+  name: Scalars['String'];
+};
+
+/** Synchronous webhook event. */
+export type WebhookEventSync = {
+  __typename?: 'WebhookEventSync';
+  /** Internal name of the event type. */
+  eventType: WebhookEventTypeSyncEnum;
+  /** Display name of the event. */
+  name: Scalars['String'];
+};
+
 /** Enum determining type of webhook. */
-export type WebhookEventTypeEnum =
+export type WebhookEventTypeAsyncEnum =
   /** All the events. */
   | 'ANY_EVENTS'
   /** A new checkout is created. */
   | 'CHECKOUT_CREATED'
-  | 'CHECKOUT_FILTER_SHIPPING_METHODS'
   /** A checkout is updated. It also triggers all updates related to the checkout. */
   | 'CHECKOUT_UPDATED'
+  /** A new collection is created. */
+  | 'COLLECTION_CREATED'
+  /** A collection is deleted. */
+  | 'COLLECTION_DELETED'
+  /** A collection is updated. */
+  | 'COLLECTION_UPDATED'
   /** A new customer account is created. */
   | 'CUSTOMER_CREATED'
   /** A customer account is updated. */
@@ -12582,6 +13653,8 @@ export type WebhookEventTypeEnum =
   | 'DRAFT_ORDER_CREATED'
   | 'DRAFT_ORDER_DELETED'
   | 'DRAFT_ORDER_UPDATED'
+  /** A fulfillment is cancelled. */
+  | 'FULFILLMENT_CANCELED'
   /** A new fulfillment is created. */
   | 'FULFILLMENT_CREATED'
   /** An invoice is deleted. */
@@ -12598,7 +13671,6 @@ export type WebhookEventTypeEnum =
   | 'ORDER_CONFIRMED'
   /** A new order is placed. */
   | 'ORDER_CREATED'
-  | 'ORDER_FILTER_SHIPPING_METHODS'
   /** An order is fulfilled. */
   | 'ORDER_FULFILLED'
   /** Payment is made and an order is fully paid. */
@@ -12611,38 +13683,41 @@ export type WebhookEventTypeEnum =
   | 'PAGE_DELETED'
   /** A page is updated. */
   | 'PAGE_UPDATED'
-  | 'PAYMENT_AUTHORIZE'
-  | 'PAYMENT_CAPTURE'
-  | 'PAYMENT_CONFIRM'
-  | 'PAYMENT_LIST_GATEWAYS'
-  | 'PAYMENT_PROCESS'
-  | 'PAYMENT_REFUND'
-  | 'PAYMENT_VOID'
   /** A new product is created. */
   | 'PRODUCT_CREATED'
   /** A product is deleted. */
   | 'PRODUCT_DELETED'
   /** A product is updated. */
   | 'PRODUCT_UPDATED'
+  | 'PRODUCT_VARIANT_BACK_IN_STOCK'
   /** A new product variant is created. */
   | 'PRODUCT_VARIANT_CREATED'
   /** A product variant is deleted. */
   | 'PRODUCT_VARIANT_DELETED'
+  | 'PRODUCT_VARIANT_OUT_OF_STOCK'
   /** A product variant is updated. */
   | 'PRODUCT_VARIANT_UPDATED'
+  | 'SALE_CREATED'
+  | 'SALE_DELETED'
+  | 'SALE_UPDATED'
   | 'TRANSLATION_CREATED'
   | 'TRANSLATION_UPDATED';
 
-/** An enumeration. */
-export type WebhookSampleEventTypeEnum =
+/** Enum determining type of webhook. */
+export type WebhookEventTypeEnum =
+  | 'ANY_EVENTS'
   | 'CHECKOUT_CREATED'
   | 'CHECKOUT_FILTER_SHIPPING_METHODS'
   | 'CHECKOUT_UPDATED'
+  | 'COLLECTION_CREATED'
+  | 'COLLECTION_DELETED'
+  | 'COLLECTION_UPDATED'
   | 'CUSTOMER_CREATED'
   | 'CUSTOMER_UPDATED'
   | 'DRAFT_ORDER_CREATED'
   | 'DRAFT_ORDER_DELETED'
   | 'DRAFT_ORDER_UPDATED'
+  | 'FULFILLMENT_CANCELED'
   | 'FULFILLMENT_CREATED'
   | 'INVOICE_DELETED'
   | 'INVOICE_REQUESTED'
@@ -12668,9 +13743,69 @@ export type WebhookSampleEventTypeEnum =
   | 'PRODUCT_CREATED'
   | 'PRODUCT_DELETED'
   | 'PRODUCT_UPDATED'
+  | 'PRODUCT_VARIANT_BACK_IN_STOCK'
   | 'PRODUCT_VARIANT_CREATED'
   | 'PRODUCT_VARIANT_DELETED'
+  | 'PRODUCT_VARIANT_OUT_OF_STOCK'
   | 'PRODUCT_VARIANT_UPDATED'
+  | 'SALE_CREATED'
+  | 'SALE_DELETED'
+  | 'SALE_UPDATED'
+  | 'SHIPPING_LIST_METHODS_FOR_CHECKOUT'
+  | 'TRANSLATION_CREATED'
+  | 'TRANSLATION_UPDATED';
+
+/** Enum determining type of webhook. */
+export type WebhookEventTypeSyncEnum =
+  | 'CHECKOUT_FILTER_SHIPPING_METHODS'
+  | 'ORDER_FILTER_SHIPPING_METHODS'
+  | 'PAYMENT_AUTHORIZE'
+  | 'PAYMENT_CAPTURE'
+  | 'PAYMENT_CONFIRM'
+  | 'PAYMENT_LIST_GATEWAYS'
+  | 'PAYMENT_PROCESS'
+  | 'PAYMENT_REFUND'
+  | 'PAYMENT_VOID'
+  | 'SHIPPING_LIST_METHODS_FOR_CHECKOUT';
+
+/** An enumeration. */
+export type WebhookSampleEventTypeEnum =
+  | 'CHECKOUT_CREATED'
+  | 'CHECKOUT_UPDATED'
+  | 'COLLECTION_CREATED'
+  | 'COLLECTION_DELETED'
+  | 'COLLECTION_UPDATED'
+  | 'CUSTOMER_CREATED'
+  | 'CUSTOMER_UPDATED'
+  | 'DRAFT_ORDER_CREATED'
+  | 'DRAFT_ORDER_DELETED'
+  | 'DRAFT_ORDER_UPDATED'
+  | 'FULFILLMENT_CANCELED'
+  | 'FULFILLMENT_CREATED'
+  | 'INVOICE_DELETED'
+  | 'INVOICE_REQUESTED'
+  | 'INVOICE_SENT'
+  | 'NOTIFY_USER'
+  | 'ORDER_CANCELLED'
+  | 'ORDER_CONFIRMED'
+  | 'ORDER_CREATED'
+  | 'ORDER_FULFILLED'
+  | 'ORDER_FULLY_PAID'
+  | 'ORDER_UPDATED'
+  | 'PAGE_CREATED'
+  | 'PAGE_DELETED'
+  | 'PAGE_UPDATED'
+  | 'PRODUCT_CREATED'
+  | 'PRODUCT_DELETED'
+  | 'PRODUCT_UPDATED'
+  | 'PRODUCT_VARIANT_BACK_IN_STOCK'
+  | 'PRODUCT_VARIANT_CREATED'
+  | 'PRODUCT_VARIANT_DELETED'
+  | 'PRODUCT_VARIANT_OUT_OF_STOCK'
+  | 'PRODUCT_VARIANT_UPDATED'
+  | 'SALE_CREATED'
+  | 'SALE_DELETED'
+  | 'SALE_UPDATED'
   | 'TRANSLATION_CREATED'
   | 'TRANSLATION_UPDATED';
 
@@ -12679,14 +13814,20 @@ export type WebhookUpdate = {
   __typename?: 'WebhookUpdate';
   errors: Array<WebhookError>;
   webhook?: Maybe<Webhook>;
-  /** @deprecated Use errors field instead. This field will be removed in Saleor 4.0. */
+  /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   webhookErrors: Array<WebhookError>;
 };
 
 export type WebhookUpdateInput = {
   /** ID of the app to which webhook belongs. */
   app?: InputMaybe<Scalars['ID']>;
-  /** The events that webhook wants to subscribe. */
+  /** The asynchronous events that webhook wants to subscribe. */
+  asyncEvents?: InputMaybe<Array<WebhookEventTypeAsyncEnum>>;
+  /**
+   * The events that webhook wants to subscribe.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.
+   */
   events?: InputMaybe<Array<InputMaybe<WebhookEventTypeEnum>>>;
   /** Determine if webhook will be set active or not. */
   isActive?: InputMaybe<Scalars['Boolean']>;
@@ -12694,6 +13835,8 @@ export type WebhookUpdateInput = {
   name?: InputMaybe<Scalars['String']>;
   /** Use to create a hash signature with each payload. */
   secretKey?: InputMaybe<Scalars['String']>;
+  /** The synchronous events that webhook wants to subscribe. */
+  syncEvents?: InputMaybe<Array<WebhookEventTypeSyncEnum>>;
   /** The url to receive the payload. */
   targetUrl?: InputMaybe<Scalars['String']>;
 };
@@ -12715,8 +13858,10 @@ export type WeightUnitsEnum =
   | 'OZ'
   | 'TONNE';
 
+/** _Entity union as defined by Federation spec. */
 export type _Entity = Address | App | Category | Collection | Group | PageType | Product | ProductMedia | ProductType | ProductVariant | User;
 
+/** _Service manifest as defined by Federation spec. */
 export type _Service = {
   __typename?: '_Service';
   sdl?: Maybe<Scalars['String']>;
@@ -12728,7 +13873,7 @@ export type CategoryBasicFragment = { __typename?: 'Category', id: string, name:
 
 export type CategoryDetailsFragment = { __typename?: 'Category', id: string, seoTitle?: string | null, seoDescription?: string | null, description?: string | null, name: string, slug: string, translation?: { __typename?: 'CategoryTranslation', id: string, description?: string | null, name?: string | null } | null, backgroundImage?: { __typename?: 'Image', url: string, alt?: string | null } | null, ancestors?: { __typename?: 'CategoryCountableConnection', edges: Array<{ __typename?: 'CategoryCountableEdge', node: { __typename?: 'Category', id: string, name: string, slug: string, translation?: { __typename?: 'CategoryTranslation', id: string, name?: string | null } | null } }> } | null };
 
-export type CheckoutDetailsFragment = { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null };
+export type CheckoutDetailsFragment = { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null };
 
 export type CheckoutLineDetailsFragment = { __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } };
 
@@ -12754,11 +13899,11 @@ export type PriceFragment = { __typename?: 'Money', currency: string, amount: nu
 
 export type ProductCardFragment = { __typename?: 'Product', id: string, slug: string, name: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null, category?: { __typename?: 'Category', id: string, name: string, translation?: { __typename?: 'CategoryTranslation', id: string, name?: string | null } | null } | null, pricing?: { __typename?: 'ProductPricingInfo', onSale?: boolean | null, priceRange?: { __typename?: 'TaxedMoneyRange', start?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, stop?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null };
 
-export type ProductDetailsFragment = { __typename?: 'Product', id: string, name: string, slug: string, description?: string | null, seoDescription?: string | null, seoTitle?: string | null, isAvailableForPurchase?: boolean | null, translation?: { __typename?: 'ProductTranslation', id: string, description?: string | null, name?: string | null } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, category?: { __typename?: 'Category', name: string, id: string, slug: string, translation?: { __typename?: 'CategoryTranslation', id: string, name?: string | null } | null } | null, variants?: Array<{ __typename?: 'ProductVariant', id: string, name: string, quantityAvailable: number, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null> | null, pricing?: { __typename?: 'ProductPricingInfo', priceRange?: { __typename?: 'TaxedMoneyRange', start?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null };
+export type ProductDetailsFragment = { __typename?: 'Product', id: string, name: string, slug: string, description?: string | null, seoDescription?: string | null, seoTitle?: string | null, isAvailableForPurchase?: boolean | null, translation?: { __typename?: 'ProductTranslation', id: string, description?: string | null, name?: string | null } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, category?: { __typename?: 'Category', name: string, id: string, slug: string, translation?: { __typename?: 'CategoryTranslation', id: string, name?: string | null } | null } | null, variants?: Array<{ __typename?: 'ProductVariant', id: string, name: string, quantityAvailable?: number | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null> | null, pricing?: { __typename?: 'ProductPricingInfo', priceRange?: { __typename?: 'TaxedMoneyRange', start?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null };
 
 export type ProductMediaFragment = { __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType };
 
-export type ProductVariantDetailsFragment = { __typename?: 'ProductVariant', id: string, name: string, quantityAvailable: number, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null };
+export type ProductVariantDetailsFragment = { __typename?: 'ProductVariant', id: string, name: string, quantityAvailable?: number | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null };
 
 export type SelectedAttributeDetailsFragment = { __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> };
 
@@ -12785,7 +13930,7 @@ export type CheckoutAddProductLineMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutAddProductLineMutation = { __typename?: 'Mutation', checkoutLinesAdd?: { __typename?: 'CheckoutLinesAdd', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', message?: string | null, code: CheckoutErrorCode }> } | null };
+export type CheckoutAddProductLineMutation = { __typename?: 'Mutation', checkoutLinesAdd?: { __typename?: 'CheckoutLinesAdd', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', message?: string | null, code: CheckoutErrorCode }> } | null };
 
 export type CheckoutAddPromoCodeMutationVariables = Exact<{
   token: Scalars['UUID'];
@@ -12794,7 +13939,7 @@ export type CheckoutAddPromoCodeMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutAddPromoCodeMutation = { __typename?: 'Mutation', checkoutAddPromoCode?: { __typename?: 'CheckoutAddPromoCode', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', message?: string | null, field?: string | null }> } | null };
+export type CheckoutAddPromoCodeMutation = { __typename?: 'Mutation', checkoutAddPromoCode?: { __typename?: 'CheckoutAddPromoCode', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', message?: string | null, field?: string | null }> } | null };
 
 export type CheckoutBillingAddressUpdateMutationVariables = Exact<{
   token: Scalars['UUID'];
@@ -12803,7 +13948,7 @@ export type CheckoutBillingAddressUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutBillingAddressUpdateMutation = { __typename?: 'Mutation', checkoutBillingAddressUpdate?: { __typename?: 'CheckoutBillingAddressUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
+export type CheckoutBillingAddressUpdateMutation = { __typename?: 'Mutation', checkoutBillingAddressUpdate?: { __typename?: 'CheckoutBillingAddressUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
 
 export type CheckoutCompleteMutationVariables = Exact<{
   checkoutToken: Scalars['UUID'];
@@ -12837,7 +13982,7 @@ export type CheckoutEmailUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutEmailUpdateMutation = { __typename?: 'Mutation', checkoutEmailUpdate?: { __typename?: 'CheckoutEmailUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null }> } | null };
+export type CheckoutEmailUpdateMutation = { __typename?: 'Mutation', checkoutEmailUpdate?: { __typename?: 'CheckoutEmailUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null }> } | null };
 
 export type CheckoutLineUpdateMutationVariables = Exact<{
   token?: InputMaybe<Scalars['UUID']>;
@@ -12846,7 +13991,7 @@ export type CheckoutLineUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutLineUpdateMutation = { __typename?: 'Mutation', checkoutLinesUpdate?: { __typename?: 'CheckoutLinesUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
+export type CheckoutLineUpdateMutation = { __typename?: 'Mutation', checkoutLinesUpdate?: { __typename?: 'CheckoutLinesUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
 
 export type RemoveProductFromCheckoutMutationVariables = Exact<{
   checkoutToken: Scalars['UUID'];
@@ -12855,7 +14000,7 @@ export type RemoveProductFromCheckoutMutationVariables = Exact<{
 }>;
 
 
-export type RemoveProductFromCheckoutMutation = { __typename?: 'Mutation', checkoutLineDelete?: { __typename?: 'CheckoutLineDelete', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null }> } | null };
+export type RemoveProductFromCheckoutMutation = { __typename?: 'Mutation', checkoutLineDelete?: { __typename?: 'CheckoutLineDelete', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null }> } | null };
 
 export type CheckoutShippingAddressUpdateMutationVariables = Exact<{
   token: Scalars['UUID'];
@@ -12864,7 +14009,7 @@ export type CheckoutShippingAddressUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutShippingAddressUpdateMutation = { __typename?: 'Mutation', checkoutShippingAddressUpdate?: { __typename?: 'CheckoutShippingAddressUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
+export type CheckoutShippingAddressUpdateMutation = { __typename?: 'Mutation', checkoutShippingAddressUpdate?: { __typename?: 'CheckoutShippingAddressUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
 
 export type CheckoutShippingMethodUpdateMutationVariables = Exact<{
   token: Scalars['UUID'];
@@ -12873,7 +14018,7 @@ export type CheckoutShippingMethodUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CheckoutShippingMethodUpdateMutation = { __typename?: 'Mutation', checkoutShippingMethodUpdate?: { __typename?: 'CheckoutShippingMethodUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
+export type CheckoutShippingMethodUpdateMutation = { __typename?: 'Mutation', checkoutShippingMethodUpdate?: { __typename?: 'CheckoutShippingMethodUpdate', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, errors: Array<{ __typename?: 'CheckoutError', field?: string | null, message?: string | null, code: CheckoutErrorCode }> } | null };
 
 export type SetAddressDefaultMutationVariables = Exact<{
   id: Scalars['ID'];
@@ -12929,7 +14074,7 @@ export type CheckoutByTokenQueryVariables = Exact<{
 }>;
 
 
-export type CheckoutByTokenQuery = { __typename?: 'Query', checkout?: { __typename?: 'Checkout', id: string, token: any, email: string, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null };
+export type CheckoutByTokenQuery = { __typename?: 'Query', checkout?: { __typename?: 'Checkout', id: string, token: any, email?: string | null, isShippingRequired: boolean, discountName?: string | null, billingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingAddress?: { __typename?: 'Address', id: string, phone?: string | null, firstName: string, lastName: string, streetAddress1: string, city: string, postalCode: string, isDefaultBillingAddress?: boolean | null, isDefaultShippingAddress?: boolean | null, country: { __typename?: 'CountryDisplay', code: string, country: string } } | null, shippingMethod?: { __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null, availableShippingMethods: Array<{ __typename?: 'ShippingMethod', id: string, name: string, minimumDeliveryDays?: number | null, maximumDeliveryDays?: number | null, translation?: { __typename?: 'ShippingMethodTranslation', id: string, name?: string | null } | null, price: { __typename?: 'Money', currency: string, amount: number } } | null>, availablePaymentGateways: Array<{ __typename?: 'PaymentGateway', id: string, name: string, config: Array<{ __typename?: 'GatewayConfigLine', field: string, value?: string | null }> }>, lines?: Array<{ __typename?: 'CheckoutLine', id: string, quantity: number, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, variant: { __typename?: 'ProductVariant', id: string, name: string, product: { __typename?: 'Product', id: string, name: string, slug: string, translation?: { __typename?: 'ProductTranslation', id: string, name?: string | null } | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null }, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null } } | null> | null, discount?: { __typename?: 'Money', currency: string, amount: number } | null, subtotalPrice?: { __typename?: 'TaxedMoney', net: { __typename?: 'Money', currency: string, amount: number }, tax: { __typename?: 'Money', currency: string, amount: number } } | null, shippingPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null, totalPrice?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null };
 
 export type CollectionBySlugQueryVariables = Exact<{
   slug: Scalars['String'];
@@ -13014,7 +14159,7 @@ export type ProductBySlugQueryVariables = Exact<{
 }>;
 
 
-export type ProductBySlugQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, slug: string, description?: string | null, seoDescription?: string | null, seoTitle?: string | null, isAvailableForPurchase?: boolean | null, translation?: { __typename?: 'ProductTranslation', id: string, description?: string | null, name?: string | null } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, category?: { __typename?: 'Category', name: string, id: string, slug: string, translation?: { __typename?: 'CategoryTranslation', id: string, name?: string | null } | null } | null, variants?: Array<{ __typename?: 'ProductVariant', id: string, name: string, quantityAvailable: number, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null> | null, pricing?: { __typename?: 'ProductPricingInfo', priceRange?: { __typename?: 'TaxedMoneyRange', start?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null } | null };
+export type ProductBySlugQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, slug: string, description?: string | null, seoDescription?: string | null, seoTitle?: string | null, isAvailableForPurchase?: boolean | null, translation?: { __typename?: 'ProductTranslation', id: string, description?: string | null, name?: string | null } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, category?: { __typename?: 'Category', name: string, id: string, slug: string, translation?: { __typename?: 'CategoryTranslation', id: string, name?: string | null } | null } | null, variants?: Array<{ __typename?: 'ProductVariant', id: string, name: string, quantityAvailable?: number | null, translation?: { __typename?: 'ProductVariantTranslation', id: string, name: string } | null, attributes: Array<{ __typename?: 'SelectedAttribute', attribute: { __typename?: 'Attribute', id: string, name?: string | null, type?: AttributeTypeEnum | null, unit?: MeasurementUnitsEnum | null, translation?: { __typename?: 'AttributeTranslation', id: string, name: string } | null }, values: Array<{ __typename?: 'AttributeValue', id: string, name?: string | null, value?: string | null, translation?: { __typename?: 'AttributeValueTranslation', id: string, name: string, richText?: string | null } | null } | null> }>, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, pricing?: { __typename?: 'VariantPricingInfo', price?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null> | null, pricing?: { __typename?: 'ProductPricingInfo', priceRange?: { __typename?: 'TaxedMoneyRange', start?: { __typename?: 'TaxedMoney', gross: { __typename?: 'Money', currency: string, amount: number } } | null } | null } | null, media?: Array<{ __typename?: 'ProductMedia', url: string, alt: string, type: ProductMediaType }> | null, thumbnail?: { __typename?: 'Image', url: string, alt?: string | null } | null } | null };
 
 export type ProductCollectionQueryVariables = Exact<{
   before?: InputMaybe<Scalars['String']>;
@@ -15109,7 +16254,7 @@ export type AllocationFieldPolicy = {
 	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type AppKeySpecifier = ('aboutApp' | 'accessToken' | 'appUrl' | 'configurationUrl' | 'created' | 'dataPrivacy' | 'dataPrivacyUrl' | 'homepageUrl' | 'id' | 'isActive' | 'metadata' | 'name' | 'permissions' | 'privateMetadata' | 'supportUrl' | 'tokens' | 'type' | 'version' | 'webhooks' | AppKeySpecifier)[];
+export type AppKeySpecifier = ('aboutApp' | 'accessToken' | 'appUrl' | 'configurationUrl' | 'created' | 'dataPrivacy' | 'dataPrivacyUrl' | 'extensions' | 'homepageUrl' | 'id' | 'isActive' | 'metadata' | 'name' | 'permissions' | 'privateMetadata' | 'supportUrl' | 'tokens' | 'type' | 'version' | 'webhooks' | AppKeySpecifier)[];
 export type AppFieldPolicy = {
 	aboutApp?: FieldPolicy<any> | FieldReadFunction<any>,
 	accessToken?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -15118,6 +16263,7 @@ export type AppFieldPolicy = {
 	created?: FieldPolicy<any> | FieldReadFunction<any>,
 	dataPrivacy?: FieldPolicy<any> | FieldReadFunction<any>,
 	dataPrivacyUrl?: FieldPolicy<any> | FieldReadFunction<any>,
+	extensions?: FieldPolicy<any> | FieldReadFunction<any>,
 	homepageUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	isActive?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -15180,6 +16326,28 @@ export type AppErrorFieldPolicy = {
 	message?: FieldPolicy<any> | FieldReadFunction<any>,
 	permissions?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type AppExtensionKeySpecifier = ('accessToken' | 'app' | 'id' | 'label' | 'mount' | 'permissions' | 'target' | 'url' | AppExtensionKeySpecifier)[];
+export type AppExtensionFieldPolicy = {
+	accessToken?: FieldPolicy<any> | FieldReadFunction<any>,
+	app?: FieldPolicy<any> | FieldReadFunction<any>,
+	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	label?: FieldPolicy<any> | FieldReadFunction<any>,
+	mount?: FieldPolicy<any> | FieldReadFunction<any>,
+	permissions?: FieldPolicy<any> | FieldReadFunction<any>,
+	target?: FieldPolicy<any> | FieldReadFunction<any>,
+	url?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type AppExtensionCountableConnectionKeySpecifier = ('edges' | 'pageInfo' | 'totalCount' | AppExtensionCountableConnectionKeySpecifier)[];
+export type AppExtensionCountableConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type AppExtensionCountableEdgeKeySpecifier = ('cursor' | 'node' | AppExtensionCountableEdgeKeySpecifier)[];
+export type AppExtensionCountableEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type AppFetchManifestKeySpecifier = ('appErrors' | 'errors' | 'manifest' | AppFetchManifestKeySpecifier)[];
 export type AppFetchManifestFieldPolicy = {
 	appErrors?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -15201,6 +16369,14 @@ export type AppInstallationFieldPolicy = {
 	message?: FieldPolicy<any> | FieldReadFunction<any>,
 	status?: FieldPolicy<any> | FieldReadFunction<any>,
 	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type AppManifestExtensionKeySpecifier = ('label' | 'mount' | 'permissions' | 'target' | 'url' | AppManifestExtensionKeySpecifier)[];
+export type AppManifestExtensionFieldPolicy = {
+	label?: FieldPolicy<any> | FieldReadFunction<any>,
+	mount?: FieldPolicy<any> | FieldReadFunction<any>,
+	permissions?: FieldPolicy<any> | FieldReadFunction<any>,
+	target?: FieldPolicy<any> | FieldReadFunction<any>,
+	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type AppRetryInstallKeySpecifier = ('appErrors' | 'appInstallation' | 'errors' | AppRetryInstallKeySpecifier)[];
 export type AppRetryInstallFieldPolicy = {
@@ -15244,6 +16420,11 @@ export type AssignNavigationFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	menu?: FieldPolicy<any> | FieldReadFunction<any>,
 	menuErrors?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type AssignedVariantAttributeKeySpecifier = ('attribute' | 'variantSelection' | AssignedVariantAttributeKeySpecifier)[];
+export type AssignedVariantAttributeFieldPolicy = {
+	attribute?: FieldPolicy<any> | FieldReadFunction<any>,
+	variantSelection?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type AttributeKeySpecifier = ('availableInGrid' | 'choices' | 'entityType' | 'filterableInDashboard' | 'filterableInStorefront' | 'id' | 'inputType' | 'metadata' | 'name' | 'privateMetadata' | 'productTypes' | 'productVariantTypes' | 'slug' | 'storefrontSearchPosition' | 'translation' | 'type' | 'unit' | 'valueRequired' | 'visibleInStorefront' | 'withChoices' | AttributeKeySpecifier)[];
 export type AttributeFieldPolicy = {
@@ -15556,13 +16737,15 @@ export type ChannelUpdateFieldPolicy = {
 	channelErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	errors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type CheckoutKeySpecifier = ('availablePaymentGateways' | 'availableShippingMethods' | 'billingAddress' | 'channel' | 'created' | 'discount' | 'discountName' | 'email' | 'giftCards' | 'id' | 'isShippingRequired' | 'languageCode' | 'lastChange' | 'lines' | 'metadata' | 'note' | 'privateMetadata' | 'quantity' | 'shippingAddress' | 'shippingMethod' | 'shippingMethods' | 'shippingPrice' | 'subtotalPrice' | 'token' | 'totalPrice' | 'translatedDiscountName' | 'user' | 'voucherCode' | CheckoutKeySpecifier)[];
+export type CheckoutKeySpecifier = ('availableCollectionPoints' | 'availablePaymentGateways' | 'availableShippingMethods' | 'billingAddress' | 'channel' | 'created' | 'deliveryMethod' | 'discount' | 'discountName' | 'email' | 'giftCards' | 'id' | 'isShippingRequired' | 'languageCode' | 'lastChange' | 'lines' | 'metadata' | 'note' | 'privateMetadata' | 'quantity' | 'shippingAddress' | 'shippingMethod' | 'shippingMethods' | 'shippingPrice' | 'stockReservationExpires' | 'subtotalPrice' | 'token' | 'totalPrice' | 'translatedDiscountName' | 'user' | 'voucherCode' | CheckoutKeySpecifier)[];
 export type CheckoutFieldPolicy = {
+	availableCollectionPoints?: FieldPolicy<any> | FieldReadFunction<any>,
 	availablePaymentGateways?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableShippingMethods?: FieldPolicy<any> | FieldReadFunction<any>,
 	billingAddress?: FieldPolicy<any> | FieldReadFunction<any>,
 	channel?: FieldPolicy<any> | FieldReadFunction<any>,
 	created?: FieldPolicy<any> | FieldReadFunction<any>,
+	deliveryMethod?: FieldPolicy<any> | FieldReadFunction<any>,
 	discount?: FieldPolicy<any> | FieldReadFunction<any>,
 	discountName?: FieldPolicy<any> | FieldReadFunction<any>,
 	email?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -15580,6 +16763,7 @@ export type CheckoutFieldPolicy = {
 	shippingMethod?: FieldPolicy<any> | FieldReadFunction<any>,
 	shippingMethods?: FieldPolicy<any> | FieldReadFunction<any>,
 	shippingPrice?: FieldPolicy<any> | FieldReadFunction<any>,
+	stockReservationExpires?: FieldPolicy<any> | FieldReadFunction<any>,
 	subtotalPrice?: FieldPolicy<any> | FieldReadFunction<any>,
 	token?: FieldPolicy<any> | FieldReadFunction<any>,
 	totalPrice?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -15635,6 +16819,11 @@ export type CheckoutCustomerDetachKeySpecifier = ('checkout' | 'checkoutErrors' 
 export type CheckoutCustomerDetachFieldPolicy = {
 	checkout?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkoutErrors?: FieldPolicy<any> | FieldReadFunction<any>,
+	errors?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type CheckoutDeliveryMethodUpdateKeySpecifier = ('checkout' | 'errors' | CheckoutDeliveryMethodUpdateKeySpecifier)[];
+export type CheckoutDeliveryMethodUpdateFieldPolicy = {
+	checkout?: FieldPolicy<any> | FieldReadFunction<any>,
 	errors?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type CheckoutEmailUpdateKeySpecifier = ('checkout' | 'checkoutErrors' | 'errors' | CheckoutEmailUpdateKeySpecifier)[];
@@ -16061,6 +17250,53 @@ export type DraftOrderUpdateFieldPolicy = {
 	order?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type EventDeliveryKeySpecifier = ('attempts' | 'createdAt' | 'eventType' | 'id' | 'payload' | 'status' | EventDeliveryKeySpecifier)[];
+export type EventDeliveryFieldPolicy = {
+	attempts?: FieldPolicy<any> | FieldReadFunction<any>,
+	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
+	eventType?: FieldPolicy<any> | FieldReadFunction<any>,
+	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	payload?: FieldPolicy<any> | FieldReadFunction<any>,
+	status?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type EventDeliveryAttemptKeySpecifier = ('createdAt' | 'duration' | 'id' | 'requestHeaders' | 'response' | 'responseHeaders' | 'status' | 'taskId' | EventDeliveryAttemptKeySpecifier)[];
+export type EventDeliveryAttemptFieldPolicy = {
+	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
+	duration?: FieldPolicy<any> | FieldReadFunction<any>,
+	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	requestHeaders?: FieldPolicy<any> | FieldReadFunction<any>,
+	response?: FieldPolicy<any> | FieldReadFunction<any>,
+	responseHeaders?: FieldPolicy<any> | FieldReadFunction<any>,
+	status?: FieldPolicy<any> | FieldReadFunction<any>,
+	taskId?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type EventDeliveryAttemptCountableConnectionKeySpecifier = ('edges' | 'pageInfo' | 'totalCount' | EventDeliveryAttemptCountableConnectionKeySpecifier)[];
+export type EventDeliveryAttemptCountableConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type EventDeliveryAttemptCountableEdgeKeySpecifier = ('cursor' | 'node' | EventDeliveryAttemptCountableEdgeKeySpecifier)[];
+export type EventDeliveryAttemptCountableEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type EventDeliveryCountableConnectionKeySpecifier = ('edges' | 'pageInfo' | 'totalCount' | EventDeliveryCountableConnectionKeySpecifier)[];
+export type EventDeliveryCountableConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type EventDeliveryCountableEdgeKeySpecifier = ('cursor' | 'node' | EventDeliveryCountableEdgeKeySpecifier)[];
+export type EventDeliveryCountableEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type EventDeliveryRetryKeySpecifier = ('delivery' | 'errors' | EventDeliveryRetryKeySpecifier)[];
+export type EventDeliveryRetryFieldPolicy = {
+	delivery?: FieldPolicy<any> | FieldReadFunction<any>,
+	errors?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type ExportErrorKeySpecifier = ('code' | 'field' | 'message' | ExportErrorKeySpecifier)[];
 export type ExportErrorFieldPolicy = {
 	code?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16099,6 +17335,11 @@ export type ExportFileCountableEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type ExportGiftCardsKeySpecifier = ('errors' | 'exportFile' | ExportGiftCardsKeySpecifier)[];
+export type ExportGiftCardsFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	exportFile?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type ExportProductsKeySpecifier = ('errors' | 'exportErrors' | 'exportFile' | ExportProductsKeySpecifier)[];
 export type ExportProductsFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16121,6 +17362,16 @@ export type ExternalLogoutFieldPolicy = {
 	accountErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	logoutData?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type ExternalNotificationErrorKeySpecifier = ('code' | 'field' | 'message' | ExternalNotificationErrorKeySpecifier)[];
+export type ExternalNotificationErrorFieldPolicy = {
+	code?: FieldPolicy<any> | FieldReadFunction<any>,
+	field?: FieldPolicy<any> | FieldReadFunction<any>,
+	message?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type ExternalNotificationTriggerKeySpecifier = ('errors' | ExternalNotificationTriggerKeySpecifier)[];
+export type ExternalNotificationTriggerFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type ExternalObtainAccessTokensKeySpecifier = ('accountErrors' | 'csrfToken' | 'errors' | 'refreshToken' | 'token' | 'user' | ExternalObtainAccessTokensKeySpecifier)[];
 export type ExternalObtainAccessTokensFieldPolicy = {
@@ -16172,6 +17423,13 @@ export type FulfillmentFieldPolicy = {
 	trackingNumber?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type FulfillmentApproveKeySpecifier = ('errors' | 'fulfillment' | 'order' | 'orderErrors' | FulfillmentApproveKeySpecifier)[];
+export type FulfillmentApproveFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	fulfillment?: FieldPolicy<any> | FieldReadFunction<any>,
+	order?: FieldPolicy<any> | FieldReadFunction<any>,
+	orderErrors?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type FulfillmentCancelKeySpecifier = ('errors' | 'fulfillment' | 'order' | 'orderErrors' | FulfillmentCancelKeySpecifier)[];
 export type FulfillmentCancelFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16213,18 +17471,31 @@ export type GatewayConfigLineFieldPolicy = {
 	field?: FieldPolicy<any> | FieldReadFunction<any>,
 	value?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type GiftCardKeySpecifier = ('code' | 'created' | 'currentBalance' | 'displayCode' | 'endDate' | 'id' | 'initialBalance' | 'isActive' | 'lastUsedOn' | 'startDate' | 'user' | GiftCardKeySpecifier)[];
+export type GiftCardKeySpecifier = ('app' | 'boughtInChannel' | 'code' | 'created' | 'createdBy' | 'createdByEmail' | 'currentBalance' | 'displayCode' | 'endDate' | 'events' | 'expiryDate' | 'id' | 'initialBalance' | 'isActive' | 'last4CodeChars' | 'lastUsedOn' | 'metadata' | 'privateMetadata' | 'product' | 'startDate' | 'tags' | 'usedBy' | 'usedByEmail' | 'user' | GiftCardKeySpecifier)[];
 export type GiftCardFieldPolicy = {
+	app?: FieldPolicy<any> | FieldReadFunction<any>,
+	boughtInChannel?: FieldPolicy<any> | FieldReadFunction<any>,
 	code?: FieldPolicy<any> | FieldReadFunction<any>,
 	created?: FieldPolicy<any> | FieldReadFunction<any>,
+	createdBy?: FieldPolicy<any> | FieldReadFunction<any>,
+	createdByEmail?: FieldPolicy<any> | FieldReadFunction<any>,
 	currentBalance?: FieldPolicy<any> | FieldReadFunction<any>,
 	displayCode?: FieldPolicy<any> | FieldReadFunction<any>,
 	endDate?: FieldPolicy<any> | FieldReadFunction<any>,
+	events?: FieldPolicy<any> | FieldReadFunction<any>,
+	expiryDate?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	initialBalance?: FieldPolicy<any> | FieldReadFunction<any>,
 	isActive?: FieldPolicy<any> | FieldReadFunction<any>,
+	last4CodeChars?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastUsedOn?: FieldPolicy<any> | FieldReadFunction<any>,
+	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
+	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
+	product?: FieldPolicy<any> | FieldReadFunction<any>,
 	startDate?: FieldPolicy<any> | FieldReadFunction<any>,
+	tags?: FieldPolicy<any> | FieldReadFunction<any>,
+	usedBy?: FieldPolicy<any> | FieldReadFunction<any>,
+	usedByEmail?: FieldPolicy<any> | FieldReadFunction<any>,
 	user?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type GiftCardActivateKeySpecifier = ('errors' | 'giftCard' | 'giftCardErrors' | GiftCardActivateKeySpecifier)[];
@@ -16232,6 +17503,33 @@ export type GiftCardActivateFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCard?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCardErrors?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardAddNoteKeySpecifier = ('errors' | 'event' | 'giftCard' | GiftCardAddNoteKeySpecifier)[];
+export type GiftCardAddNoteFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	event?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCard?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardBulkActivateKeySpecifier = ('count' | 'errors' | GiftCardBulkActivateKeySpecifier)[];
+export type GiftCardBulkActivateFieldPolicy = {
+	count?: FieldPolicy<any> | FieldReadFunction<any>,
+	errors?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardBulkCreateKeySpecifier = ('count' | 'errors' | 'giftCards' | GiftCardBulkCreateKeySpecifier)[];
+export type GiftCardBulkCreateFieldPolicy = {
+	count?: FieldPolicy<any> | FieldReadFunction<any>,
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCards?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardBulkDeactivateKeySpecifier = ('count' | 'errors' | GiftCardBulkDeactivateKeySpecifier)[];
+export type GiftCardBulkDeactivateFieldPolicy = {
+	count?: FieldPolicy<any> | FieldReadFunction<any>,
+	errors?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardBulkDeleteKeySpecifier = ('count' | 'errors' | GiftCardBulkDeleteKeySpecifier)[];
+export type GiftCardBulkDeleteFieldPolicy = {
+	count?: FieldPolicy<any> | FieldReadFunction<any>,
+	errors?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type GiftCardCountableConnectionKeySpecifier = ('edges' | 'pageInfo' | 'totalCount' | GiftCardCountableConnectionKeySpecifier)[];
 export type GiftCardCountableConnectionFieldPolicy = {
@@ -16256,11 +17554,79 @@ export type GiftCardDeactivateFieldPolicy = {
 	giftCard?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCardErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type GiftCardErrorKeySpecifier = ('code' | 'field' | 'message' | GiftCardErrorKeySpecifier)[];
+export type GiftCardDeleteKeySpecifier = ('errors' | 'giftCard' | 'giftCardErrors' | GiftCardDeleteKeySpecifier)[];
+export type GiftCardDeleteFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCard?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardErrors?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardErrorKeySpecifier = ('code' | 'field' | 'message' | 'tags' | GiftCardErrorKeySpecifier)[];
 export type GiftCardErrorFieldPolicy = {
 	code?: FieldPolicy<any> | FieldReadFunction<any>,
 	field?: FieldPolicy<any> | FieldReadFunction<any>,
+	message?: FieldPolicy<any> | FieldReadFunction<any>,
+	tags?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardEventKeySpecifier = ('app' | 'balance' | 'date' | 'email' | 'expiryDate' | 'id' | 'message' | 'oldExpiryDate' | 'oldTags' | 'orderId' | 'orderNumber' | 'tags' | 'type' | 'user' | GiftCardEventKeySpecifier)[];
+export type GiftCardEventFieldPolicy = {
+	app?: FieldPolicy<any> | FieldReadFunction<any>,
+	balance?: FieldPolicy<any> | FieldReadFunction<any>,
+	date?: FieldPolicy<any> | FieldReadFunction<any>,
+	email?: FieldPolicy<any> | FieldReadFunction<any>,
+	expiryDate?: FieldPolicy<any> | FieldReadFunction<any>,
+	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	message?: FieldPolicy<any> | FieldReadFunction<any>,
+	oldExpiryDate?: FieldPolicy<any> | FieldReadFunction<any>,
+	oldTags?: FieldPolicy<any> | FieldReadFunction<any>,
+	orderId?: FieldPolicy<any> | FieldReadFunction<any>,
+	orderNumber?: FieldPolicy<any> | FieldReadFunction<any>,
+	tags?: FieldPolicy<any> | FieldReadFunction<any>,
+	type?: FieldPolicy<any> | FieldReadFunction<any>,
+	user?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardEventBalanceKeySpecifier = ('currentBalance' | 'initialBalance' | 'oldCurrentBalance' | 'oldInitialBalance' | GiftCardEventBalanceKeySpecifier)[];
+export type GiftCardEventBalanceFieldPolicy = {
+	currentBalance?: FieldPolicy<any> | FieldReadFunction<any>,
+	initialBalance?: FieldPolicy<any> | FieldReadFunction<any>,
+	oldCurrentBalance?: FieldPolicy<any> | FieldReadFunction<any>,
+	oldInitialBalance?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardResendKeySpecifier = ('errors' | 'giftCard' | GiftCardResendKeySpecifier)[];
+export type GiftCardResendFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCard?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardSettingsKeySpecifier = ('expiryPeriod' | 'expiryType' | GiftCardSettingsKeySpecifier)[];
+export type GiftCardSettingsFieldPolicy = {
+	expiryPeriod?: FieldPolicy<any> | FieldReadFunction<any>,
+	expiryType?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardSettingsErrorKeySpecifier = ('code' | 'field' | 'message' | GiftCardSettingsErrorKeySpecifier)[];
+export type GiftCardSettingsErrorFieldPolicy = {
+	code?: FieldPolicy<any> | FieldReadFunction<any>,
+	field?: FieldPolicy<any> | FieldReadFunction<any>,
 	message?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardSettingsUpdateKeySpecifier = ('errors' | 'giftCardSettings' | GiftCardSettingsUpdateKeySpecifier)[];
+export type GiftCardSettingsUpdateFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardSettings?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardTagKeySpecifier = ('id' | 'name' | GiftCardTagKeySpecifier)[];
+export type GiftCardTagFieldPolicy = {
+	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	name?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardTagCountableConnectionKeySpecifier = ('edges' | 'pageInfo' | 'totalCount' | GiftCardTagCountableConnectionKeySpecifier)[];
+export type GiftCardTagCountableConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GiftCardTagCountableEdgeKeySpecifier = ('cursor' | 'node' | GiftCardTagCountableEdgeKeySpecifier)[];
+export type GiftCardTagCountableEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type GiftCardUpdateKeySpecifier = ('errors' | 'giftCard' | 'giftCardErrors' | GiftCardUpdateKeySpecifier)[];
 export type GiftCardUpdateFieldPolicy = {
@@ -16373,13 +17739,14 @@ export type LimitsFieldPolicy = {
 	staffUsers?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouses?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ManifestKeySpecifier = ('about' | 'appUrl' | 'configurationUrl' | 'dataPrivacy' | 'dataPrivacyUrl' | 'homepageUrl' | 'identifier' | 'name' | 'permissions' | 'supportUrl' | 'tokenTargetUrl' | 'version' | ManifestKeySpecifier)[];
+export type ManifestKeySpecifier = ('about' | 'appUrl' | 'configurationUrl' | 'dataPrivacy' | 'dataPrivacyUrl' | 'extensions' | 'homepageUrl' | 'identifier' | 'name' | 'permissions' | 'supportUrl' | 'tokenTargetUrl' | 'version' | ManifestKeySpecifier)[];
 export type ManifestFieldPolicy = {
 	about?: FieldPolicy<any> | FieldReadFunction<any>,
 	appUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	configurationUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	dataPrivacy?: FieldPolicy<any> | FieldReadFunction<any>,
 	dataPrivacyUrl?: FieldPolicy<any> | FieldReadFunction<any>,
+	extensions?: FieldPolicy<any> | FieldReadFunction<any>,
 	homepageUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	identifier?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16540,7 +17907,7 @@ export type MoneyRangeFieldPolicy = {
 	start?: FieldPolicy<any> | FieldReadFunction<any>,
 	stop?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type MutationKeySpecifier = ('accountAddressCreate' | 'accountAddressDelete' | 'accountAddressUpdate' | 'accountDelete' | 'accountRegister' | 'accountRequestDeletion' | 'accountSetDefaultAddress' | 'accountUpdate' | 'addressCreate' | 'addressDelete' | 'addressSetDefault' | 'addressUpdate' | 'appActivate' | 'appCreate' | 'appDeactivate' | 'appDelete' | 'appDeleteFailedInstallation' | 'appFetchManifest' | 'appInstall' | 'appRetryInstall' | 'appTokenCreate' | 'appTokenDelete' | 'appTokenVerify' | 'appUpdate' | 'assignNavigation' | 'assignWarehouseShippingZone' | 'attributeBulkDelete' | 'attributeCreate' | 'attributeDelete' | 'attributeReorderValues' | 'attributeTranslate' | 'attributeUpdate' | 'attributeValueBulkDelete' | 'attributeValueCreate' | 'attributeValueDelete' | 'attributeValueTranslate' | 'attributeValueUpdate' | 'categoryBulkDelete' | 'categoryCreate' | 'categoryDelete' | 'categoryTranslate' | 'categoryUpdate' | 'channelActivate' | 'channelCreate' | 'channelDeactivate' | 'channelDelete' | 'channelUpdate' | 'checkoutAddPromoCode' | 'checkoutBillingAddressUpdate' | 'checkoutComplete' | 'checkoutCreate' | 'checkoutCustomerAttach' | 'checkoutCustomerDetach' | 'checkoutEmailUpdate' | 'checkoutLanguageCodeUpdate' | 'checkoutLineDelete' | 'checkoutLinesAdd' | 'checkoutLinesDelete' | 'checkoutLinesUpdate' | 'checkoutPaymentCreate' | 'checkoutRemovePromoCode' | 'checkoutShippingAddressUpdate' | 'checkoutShippingMethodUpdate' | 'collectionAddProducts' | 'collectionBulkDelete' | 'collectionChannelListingUpdate' | 'collectionCreate' | 'collectionDelete' | 'collectionRemoveProducts' | 'collectionReorderProducts' | 'collectionTranslate' | 'collectionUpdate' | 'confirmAccount' | 'confirmEmailChange' | 'createWarehouse' | 'customerBulkDelete' | 'customerCreate' | 'customerDelete' | 'customerUpdate' | 'deleteMetadata' | 'deletePrivateMetadata' | 'deleteWarehouse' | 'digitalContentCreate' | 'digitalContentDelete' | 'digitalContentUpdate' | 'digitalContentUrlCreate' | 'draftOrderBulkDelete' | 'draftOrderComplete' | 'draftOrderCreate' | 'draftOrderDelete' | 'draftOrderLinesBulkDelete' | 'draftOrderUpdate' | 'exportProducts' | 'externalAuthenticationUrl' | 'externalLogout' | 'externalObtainAccessTokens' | 'externalRefresh' | 'externalVerify' | 'fileUpload' | 'giftCardActivate' | 'giftCardCreate' | 'giftCardDeactivate' | 'giftCardUpdate' | 'invoiceCreate' | 'invoiceDelete' | 'invoiceRequest' | 'invoiceRequestDelete' | 'invoiceSendNotification' | 'invoiceUpdate' | 'menuBulkDelete' | 'menuCreate' | 'menuDelete' | 'menuItemBulkDelete' | 'menuItemCreate' | 'menuItemDelete' | 'menuItemMove' | 'menuItemTranslate' | 'menuItemUpdate' | 'menuUpdate' | 'orderAddNote' | 'orderBulkCancel' | 'orderCancel' | 'orderCapture' | 'orderConfirm' | 'orderDiscountAdd' | 'orderDiscountDelete' | 'orderDiscountUpdate' | 'orderFulfill' | 'orderFulfillmentCancel' | 'orderFulfillmentRefundProducts' | 'orderFulfillmentReturnProducts' | 'orderFulfillmentUpdateTracking' | 'orderLineDelete' | 'orderLineDiscountRemove' | 'orderLineDiscountUpdate' | 'orderLineUpdate' | 'orderLinesCreate' | 'orderMarkAsPaid' | 'orderRefund' | 'orderSettingsUpdate' | 'orderUpdate' | 'orderUpdateShipping' | 'orderVoid' | 'pageAttributeAssign' | 'pageAttributeUnassign' | 'pageBulkDelete' | 'pageBulkPublish' | 'pageCreate' | 'pageDelete' | 'pageReorderAttributeValues' | 'pageTranslate' | 'pageTypeBulkDelete' | 'pageTypeCreate' | 'pageTypeDelete' | 'pageTypeReorderAttributes' | 'pageTypeUpdate' | 'pageUpdate' | 'passwordChange' | 'paymentCapture' | 'paymentCheckBalance' | 'paymentInitialize' | 'paymentRefund' | 'paymentVoid' | 'permissionGroupCreate' | 'permissionGroupDelete' | 'permissionGroupUpdate' | 'pluginUpdate' | 'productAttributeAssign' | 'productAttributeUnassign' | 'productBulkDelete' | 'productChannelListingUpdate' | 'productCreate' | 'productDelete' | 'productMediaBulkDelete' | 'productMediaCreate' | 'productMediaDelete' | 'productMediaReorder' | 'productMediaUpdate' | 'productReorderAttributeValues' | 'productTranslate' | 'productTypeBulkDelete' | 'productTypeCreate' | 'productTypeDelete' | 'productTypeReorderAttributes' | 'productTypeUpdate' | 'productUpdate' | 'productVariantBulkCreate' | 'productVariantBulkDelete' | 'productVariantChannelListingUpdate' | 'productVariantCreate' | 'productVariantDelete' | 'productVariantReorder' | 'productVariantReorderAttributeValues' | 'productVariantSetDefault' | 'productVariantStocksCreate' | 'productVariantStocksDelete' | 'productVariantStocksUpdate' | 'productVariantTranslate' | 'productVariantUpdate' | 'requestEmailChange' | 'requestPasswordReset' | 'saleBulkDelete' | 'saleCataloguesAdd' | 'saleCataloguesRemove' | 'saleChannelListingUpdate' | 'saleCreate' | 'saleDelete' | 'saleTranslate' | 'saleUpdate' | 'setPassword' | 'shippingMethodChannelListingUpdate' | 'shippingPriceBulkDelete' | 'shippingPriceCreate' | 'shippingPriceDelete' | 'shippingPriceExcludeProducts' | 'shippingPriceRemoveProductFromExclude' | 'shippingPriceTranslate' | 'shippingPriceUpdate' | 'shippingZoneBulkDelete' | 'shippingZoneCreate' | 'shippingZoneDelete' | 'shippingZoneUpdate' | 'shopAddressUpdate' | 'shopDomainUpdate' | 'shopFetchTaxRates' | 'shopSettingsTranslate' | 'shopSettingsUpdate' | 'staffBulkDelete' | 'staffCreate' | 'staffDelete' | 'staffNotificationRecipientCreate' | 'staffNotificationRecipientDelete' | 'staffNotificationRecipientUpdate' | 'staffUpdate' | 'tokenCreate' | 'tokenRefresh' | 'tokenVerify' | 'tokensDeactivateAll' | 'unassignWarehouseShippingZone' | 'updateMetadata' | 'updatePrivateMetadata' | 'updateWarehouse' | 'userAvatarDelete' | 'userAvatarUpdate' | 'userBulkSetActive' | 'variantMediaAssign' | 'variantMediaUnassign' | 'voucherBulkDelete' | 'voucherCataloguesAdd' | 'voucherCataloguesRemove' | 'voucherChannelListingUpdate' | 'voucherCreate' | 'voucherDelete' | 'voucherTranslate' | 'voucherUpdate' | 'webhookCreate' | 'webhookDelete' | 'webhookUpdate' | MutationKeySpecifier)[];
+export type MutationKeySpecifier = ('accountAddressCreate' | 'accountAddressDelete' | 'accountAddressUpdate' | 'accountDelete' | 'accountRegister' | 'accountRequestDeletion' | 'accountSetDefaultAddress' | 'accountUpdate' | 'addressCreate' | 'addressDelete' | 'addressSetDefault' | 'addressUpdate' | 'appActivate' | 'appCreate' | 'appDeactivate' | 'appDelete' | 'appDeleteFailedInstallation' | 'appFetchManifest' | 'appInstall' | 'appRetryInstall' | 'appTokenCreate' | 'appTokenDelete' | 'appTokenVerify' | 'appUpdate' | 'assignNavigation' | 'assignWarehouseShippingZone' | 'attributeBulkDelete' | 'attributeCreate' | 'attributeDelete' | 'attributeReorderValues' | 'attributeTranslate' | 'attributeUpdate' | 'attributeValueBulkDelete' | 'attributeValueCreate' | 'attributeValueDelete' | 'attributeValueTranslate' | 'attributeValueUpdate' | 'categoryBulkDelete' | 'categoryCreate' | 'categoryDelete' | 'categoryTranslate' | 'categoryUpdate' | 'channelActivate' | 'channelCreate' | 'channelDeactivate' | 'channelDelete' | 'channelUpdate' | 'checkoutAddPromoCode' | 'checkoutBillingAddressUpdate' | 'checkoutComplete' | 'checkoutCreate' | 'checkoutCustomerAttach' | 'checkoutCustomerDetach' | 'checkoutDeliveryMethodUpdate' | 'checkoutEmailUpdate' | 'checkoutLanguageCodeUpdate' | 'checkoutLineDelete' | 'checkoutLinesAdd' | 'checkoutLinesDelete' | 'checkoutLinesUpdate' | 'checkoutPaymentCreate' | 'checkoutRemovePromoCode' | 'checkoutShippingAddressUpdate' | 'checkoutShippingMethodUpdate' | 'collectionAddProducts' | 'collectionBulkDelete' | 'collectionChannelListingUpdate' | 'collectionCreate' | 'collectionDelete' | 'collectionRemoveProducts' | 'collectionReorderProducts' | 'collectionTranslate' | 'collectionUpdate' | 'confirmAccount' | 'confirmEmailChange' | 'createWarehouse' | 'customerBulkDelete' | 'customerCreate' | 'customerDelete' | 'customerUpdate' | 'deleteMetadata' | 'deletePrivateMetadata' | 'deleteWarehouse' | 'digitalContentCreate' | 'digitalContentDelete' | 'digitalContentUpdate' | 'digitalContentUrlCreate' | 'draftOrderBulkDelete' | 'draftOrderComplete' | 'draftOrderCreate' | 'draftOrderDelete' | 'draftOrderLinesBulkDelete' | 'draftOrderUpdate' | 'eventDeliveryRetry' | 'exportGiftCards' | 'exportProducts' | 'externalAuthenticationUrl' | 'externalLogout' | 'externalNotificationTrigger' | 'externalObtainAccessTokens' | 'externalRefresh' | 'externalVerify' | 'fileUpload' | 'giftCardActivate' | 'giftCardAddNote' | 'giftCardBulkActivate' | 'giftCardBulkCreate' | 'giftCardBulkDeactivate' | 'giftCardBulkDelete' | 'giftCardCreate' | 'giftCardDeactivate' | 'giftCardDelete' | 'giftCardResend' | 'giftCardSettingsUpdate' | 'giftCardUpdate' | 'invoiceCreate' | 'invoiceDelete' | 'invoiceRequest' | 'invoiceRequestDelete' | 'invoiceSendNotification' | 'invoiceUpdate' | 'menuBulkDelete' | 'menuCreate' | 'menuDelete' | 'menuItemBulkDelete' | 'menuItemCreate' | 'menuItemDelete' | 'menuItemMove' | 'menuItemTranslate' | 'menuItemUpdate' | 'menuUpdate' | 'orderAddNote' | 'orderBulkCancel' | 'orderCancel' | 'orderCapture' | 'orderConfirm' | 'orderDiscountAdd' | 'orderDiscountDelete' | 'orderDiscountUpdate' | 'orderFulfill' | 'orderFulfillmentApprove' | 'orderFulfillmentCancel' | 'orderFulfillmentRefundProducts' | 'orderFulfillmentReturnProducts' | 'orderFulfillmentUpdateTracking' | 'orderLineDelete' | 'orderLineDiscountRemove' | 'orderLineDiscountUpdate' | 'orderLineUpdate' | 'orderLinesCreate' | 'orderMarkAsPaid' | 'orderRefund' | 'orderSettingsUpdate' | 'orderUpdate' | 'orderUpdateShipping' | 'orderVoid' | 'pageAttributeAssign' | 'pageAttributeUnassign' | 'pageBulkDelete' | 'pageBulkPublish' | 'pageCreate' | 'pageDelete' | 'pageReorderAttributeValues' | 'pageTranslate' | 'pageTypeBulkDelete' | 'pageTypeCreate' | 'pageTypeDelete' | 'pageTypeReorderAttributes' | 'pageTypeUpdate' | 'pageUpdate' | 'passwordChange' | 'paymentCapture' | 'paymentCheckBalance' | 'paymentInitialize' | 'paymentRefund' | 'paymentVoid' | 'permissionGroupCreate' | 'permissionGroupDelete' | 'permissionGroupUpdate' | 'pluginUpdate' | 'productAttributeAssign' | 'productAttributeAssignmentUpdate' | 'productAttributeUnassign' | 'productBulkDelete' | 'productChannelListingUpdate' | 'productCreate' | 'productDelete' | 'productMediaBulkDelete' | 'productMediaCreate' | 'productMediaDelete' | 'productMediaReorder' | 'productMediaUpdate' | 'productReorderAttributeValues' | 'productTranslate' | 'productTypeBulkDelete' | 'productTypeCreate' | 'productTypeDelete' | 'productTypeReorderAttributes' | 'productTypeUpdate' | 'productUpdate' | 'productVariantBulkCreate' | 'productVariantBulkDelete' | 'productVariantChannelListingUpdate' | 'productVariantCreate' | 'productVariantDelete' | 'productVariantPreorderDeactivate' | 'productVariantReorder' | 'productVariantReorderAttributeValues' | 'productVariantSetDefault' | 'productVariantStocksCreate' | 'productVariantStocksDelete' | 'productVariantStocksUpdate' | 'productVariantTranslate' | 'productVariantUpdate' | 'requestEmailChange' | 'requestPasswordReset' | 'saleBulkDelete' | 'saleCataloguesAdd' | 'saleCataloguesRemove' | 'saleChannelListingUpdate' | 'saleCreate' | 'saleDelete' | 'saleTranslate' | 'saleUpdate' | 'setPassword' | 'shippingMethodChannelListingUpdate' | 'shippingPriceBulkDelete' | 'shippingPriceCreate' | 'shippingPriceDelete' | 'shippingPriceExcludeProducts' | 'shippingPriceRemoveProductFromExclude' | 'shippingPriceTranslate' | 'shippingPriceUpdate' | 'shippingZoneBulkDelete' | 'shippingZoneCreate' | 'shippingZoneDelete' | 'shippingZoneUpdate' | 'shopAddressUpdate' | 'shopDomainUpdate' | 'shopFetchTaxRates' | 'shopSettingsTranslate' | 'shopSettingsUpdate' | 'staffBulkDelete' | 'staffCreate' | 'staffDelete' | 'staffNotificationRecipientCreate' | 'staffNotificationRecipientDelete' | 'staffNotificationRecipientUpdate' | 'staffUpdate' | 'tokenCreate' | 'tokenRefresh' | 'tokenVerify' | 'tokensDeactivateAll' | 'unassignWarehouseShippingZone' | 'updateMetadata' | 'updatePrivateMetadata' | 'updateWarehouse' | 'userAvatarDelete' | 'userAvatarUpdate' | 'userBulkSetActive' | 'variantMediaAssign' | 'variantMediaUnassign' | 'voucherBulkDelete' | 'voucherCataloguesAdd' | 'voucherCataloguesRemove' | 'voucherChannelListingUpdate' | 'voucherCreate' | 'voucherDelete' | 'voucherTranslate' | 'voucherUpdate' | 'webhookCreate' | 'webhookDelete' | 'webhookUpdate' | MutationKeySpecifier)[];
 export type MutationFieldPolicy = {
 	accountAddressCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	accountAddressDelete?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16595,6 +17962,7 @@ export type MutationFieldPolicy = {
 	checkoutCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkoutCustomerAttach?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkoutCustomerDetach?: FieldPolicy<any> | FieldReadFunction<any>,
+	checkoutDeliveryMethodUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkoutEmailUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkoutLanguageCodeUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkoutLineDelete?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16634,16 +18002,27 @@ export type MutationFieldPolicy = {
 	draftOrderDelete?: FieldPolicy<any> | FieldReadFunction<any>,
 	draftOrderLinesBulkDelete?: FieldPolicy<any> | FieldReadFunction<any>,
 	draftOrderUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
+	eventDeliveryRetry?: FieldPolicy<any> | FieldReadFunction<any>,
+	exportGiftCards?: FieldPolicy<any> | FieldReadFunction<any>,
 	exportProducts?: FieldPolicy<any> | FieldReadFunction<any>,
 	externalAuthenticationUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	externalLogout?: FieldPolicy<any> | FieldReadFunction<any>,
+	externalNotificationTrigger?: FieldPolicy<any> | FieldReadFunction<any>,
 	externalObtainAccessTokens?: FieldPolicy<any> | FieldReadFunction<any>,
 	externalRefresh?: FieldPolicy<any> | FieldReadFunction<any>,
 	externalVerify?: FieldPolicy<any> | FieldReadFunction<any>,
 	fileUpload?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCardActivate?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardAddNote?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardBulkActivate?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardBulkCreate?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardBulkDeactivate?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardBulkDelete?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCardCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCardDeactivate?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardDelete?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardResend?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardSettingsUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCardUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	invoiceCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	invoiceDelete?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16670,6 +18049,7 @@ export type MutationFieldPolicy = {
 	orderDiscountDelete?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderDiscountUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderFulfill?: FieldPolicy<any> | FieldReadFunction<any>,
+	orderFulfillmentApprove?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderFulfillmentCancel?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderFulfillmentRefundProducts?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderFulfillmentReturnProducts?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16710,6 +18090,7 @@ export type MutationFieldPolicy = {
 	permissionGroupUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	pluginUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	productAttributeAssign?: FieldPolicy<any> | FieldReadFunction<any>,
+	productAttributeAssignmentUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	productAttributeUnassign?: FieldPolicy<any> | FieldReadFunction<any>,
 	productBulkDelete?: FieldPolicy<any> | FieldReadFunction<any>,
 	productChannelListingUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16733,6 +18114,7 @@ export type MutationFieldPolicy = {
 	productVariantChannelListingUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariantCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariantDelete?: FieldPolicy<any> | FieldReadFunction<any>,
+	productVariantPreorderDeactivate?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariantReorder?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariantReorderAttributeValues?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariantSetDefault?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16810,15 +18192,18 @@ export type ObjectWithMetadataFieldPolicy = {
 	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type OrderKeySpecifier = ('actions' | 'availableShippingMethods' | 'billingAddress' | 'canFinalize' | 'channel' | 'created' | 'customerNote' | 'discount' | 'discountName' | 'discounts' | 'displayGrossPrices' | 'errors' | 'events' | 'fulfillments' | 'giftCards' | 'id' | 'invoices' | 'isPaid' | 'isShippingRequired' | 'languageCode' | 'languageCodeEnum' | 'lines' | 'metadata' | 'number' | 'origin' | 'original' | 'paymentStatus' | 'paymentStatusDisplay' | 'payments' | 'privateMetadata' | 'redirectUrl' | 'shippingAddress' | 'shippingMethod' | 'shippingMethodName' | 'shippingMethods' | 'shippingPrice' | 'shippingTaxRate' | 'status' | 'statusDisplay' | 'subtotal' | 'token' | 'total' | 'totalAuthorized' | 'totalBalance' | 'totalCaptured' | 'trackingClientId' | 'translatedDiscountName' | 'undiscountedTotal' | 'user' | 'userEmail' | 'voucher' | 'weight' | OrderKeySpecifier)[];
+export type OrderKeySpecifier = ('actions' | 'availableCollectionPoints' | 'availableShippingMethods' | 'billingAddress' | 'canFinalize' | 'channel' | 'collectionPointName' | 'created' | 'customerNote' | 'deliveryMethod' | 'discount' | 'discountName' | 'discounts' | 'displayGrossPrices' | 'errors' | 'events' | 'fulfillments' | 'giftCards' | 'id' | 'invoices' | 'isPaid' | 'isShippingRequired' | 'languageCode' | 'languageCodeEnum' | 'lines' | 'metadata' | 'number' | 'origin' | 'original' | 'paymentStatus' | 'paymentStatusDisplay' | 'payments' | 'privateMetadata' | 'redirectUrl' | 'shippingAddress' | 'shippingMethod' | 'shippingMethodName' | 'shippingMethods' | 'shippingPrice' | 'shippingTaxRate' | 'status' | 'statusDisplay' | 'subtotal' | 'token' | 'total' | 'totalAuthorized' | 'totalBalance' | 'totalCaptured' | 'trackingClientId' | 'translatedDiscountName' | 'undiscountedTotal' | 'updatedAt' | 'user' | 'userEmail' | 'voucher' | 'weight' | OrderKeySpecifier)[];
 export type OrderFieldPolicy = {
 	actions?: FieldPolicy<any> | FieldReadFunction<any>,
+	availableCollectionPoints?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableShippingMethods?: FieldPolicy<any> | FieldReadFunction<any>,
 	billingAddress?: FieldPolicy<any> | FieldReadFunction<any>,
 	canFinalize?: FieldPolicy<any> | FieldReadFunction<any>,
 	channel?: FieldPolicy<any> | FieldReadFunction<any>,
+	collectionPointName?: FieldPolicy<any> | FieldReadFunction<any>,
 	created?: FieldPolicy<any> | FieldReadFunction<any>,
 	customerNote?: FieldPolicy<any> | FieldReadFunction<any>,
+	deliveryMethod?: FieldPolicy<any> | FieldReadFunction<any>,
 	discount?: FieldPolicy<any> | FieldReadFunction<any>,
 	discountName?: FieldPolicy<any> | FieldReadFunction<any>,
 	discounts?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -16860,6 +18245,7 @@ export type OrderFieldPolicy = {
 	trackingClientId?: FieldPolicy<any> | FieldReadFunction<any>,
 	translatedDiscountName?: FieldPolicy<any> | FieldReadFunction<any>,
 	undiscountedTotal?: FieldPolicy<any> | FieldReadFunction<any>,
+	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	user?: FieldPolicy<any> | FieldReadFunction<any>,
 	userEmail?: FieldPolicy<any> | FieldReadFunction<any>,
 	voucher?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17007,7 +18393,7 @@ export type OrderFulfillFieldPolicy = {
 	order?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type OrderLineKeySpecifier = ('allocations' | 'digitalContentUrl' | 'id' | 'isShippingRequired' | 'productName' | 'productSku' | 'quantity' | 'quantityFulfilled' | 'taxRate' | 'thumbnail' | 'totalPrice' | 'translatedProductName' | 'translatedVariantName' | 'undiscountedUnitPrice' | 'unitDiscount' | 'unitDiscountReason' | 'unitDiscountType' | 'unitDiscountValue' | 'unitPrice' | 'variant' | 'variantName' | OrderLineKeySpecifier)[];
+export type OrderLineKeySpecifier = ('allocations' | 'digitalContentUrl' | 'id' | 'isShippingRequired' | 'productName' | 'productSku' | 'productVariantId' | 'quantity' | 'quantityFulfilled' | 'quantityToFulfill' | 'taxRate' | 'thumbnail' | 'totalPrice' | 'translatedProductName' | 'translatedVariantName' | 'undiscountedUnitPrice' | 'unitDiscount' | 'unitDiscountReason' | 'unitDiscountType' | 'unitDiscountValue' | 'unitPrice' | 'variant' | 'variantName' | OrderLineKeySpecifier)[];
 export type OrderLineFieldPolicy = {
 	allocations?: FieldPolicy<any> | FieldReadFunction<any>,
 	digitalContentUrl?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17015,8 +18401,10 @@ export type OrderLineFieldPolicy = {
 	isShippingRequired?: FieldPolicy<any> | FieldReadFunction<any>,
 	productName?: FieldPolicy<any> | FieldReadFunction<any>,
 	productSku?: FieldPolicy<any> | FieldReadFunction<any>,
+	productVariantId?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantityFulfilled?: FieldPolicy<any> | FieldReadFunction<any>,
+	quantityToFulfill?: FieldPolicy<any> | FieldReadFunction<any>,
 	taxRate?: FieldPolicy<any> | FieldReadFunction<any>,
 	thumbnail?: FieldPolicy<any> | FieldReadFunction<any>,
 	totalPrice?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17078,9 +18466,10 @@ export type OrderRefundFieldPolicy = {
 	order?: FieldPolicy<any> | FieldReadFunction<any>,
 	orderErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type OrderSettingsKeySpecifier = ('automaticallyConfirmAllNewOrders' | OrderSettingsKeySpecifier)[];
+export type OrderSettingsKeySpecifier = ('automaticallyConfirmAllNewOrders' | 'automaticallyFulfillNonShippableGiftCard' | OrderSettingsKeySpecifier)[];
 export type OrderSettingsFieldPolicy = {
-	automaticallyConfirmAllNewOrders?: FieldPolicy<any> | FieldReadFunction<any>
+	automaticallyConfirmAllNewOrders?: FieldPolicy<any> | FieldReadFunction<any>,
+	automaticallyFulfillNonShippableGiftCard?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type OrderSettingsErrorKeySpecifier = ('code' | 'field' | 'message' | OrderSettingsErrorKeySpecifier)[];
 export type OrderSettingsErrorFieldPolicy = {
@@ -17290,7 +18679,7 @@ export type PasswordChangeFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	user?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PaymentKeySpecifier = ('actions' | 'availableCaptureAmount' | 'availableRefundAmount' | 'capturedAmount' | 'chargeStatus' | 'checkout' | 'created' | 'creditCard' | 'customerIpAddress' | 'gateway' | 'id' | 'isActive' | 'modified' | 'order' | 'paymentMethodType' | 'token' | 'total' | 'transactions' | PaymentKeySpecifier)[];
+export type PaymentKeySpecifier = ('actions' | 'availableCaptureAmount' | 'availableRefundAmount' | 'capturedAmount' | 'chargeStatus' | 'checkout' | 'created' | 'creditCard' | 'customerIpAddress' | 'gateway' | 'id' | 'isActive' | 'metadata' | 'modified' | 'order' | 'paymentMethodType' | 'privateMetadata' | 'token' | 'total' | 'transactions' | PaymentKeySpecifier)[];
 export type PaymentFieldPolicy = {
 	actions?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableCaptureAmount?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17304,9 +18693,11 @@ export type PaymentFieldPolicy = {
 	gateway?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	isActive?: FieldPolicy<any> | FieldReadFunction<any>,
+	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	modified?: FieldPolicy<any> | FieldReadFunction<any>,
 	order?: FieldPolicy<any> | FieldReadFunction<any>,
 	paymentMethodType?: FieldPolicy<any> | FieldReadFunction<any>,
+	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	token?: FieldPolicy<any> | FieldReadFunction<any>,
 	total?: FieldPolicy<any> | FieldReadFunction<any>,
 	transactions?: FieldPolicy<any> | FieldReadFunction<any>
@@ -17366,10 +18757,11 @@ export type PaymentRefundFieldPolicy = {
 	payment?: FieldPolicy<any> | FieldReadFunction<any>,
 	paymentErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PaymentSourceKeySpecifier = ('creditCardInfo' | 'gateway' | 'paymentMethodId' | PaymentSourceKeySpecifier)[];
+export type PaymentSourceKeySpecifier = ('creditCardInfo' | 'gateway' | 'metadata' | 'paymentMethodId' | PaymentSourceKeySpecifier)[];
 export type PaymentSourceFieldPolicy = {
 	creditCardInfo?: FieldPolicy<any> | FieldReadFunction<any>,
 	gateway?: FieldPolicy<any> | FieldReadFunction<any>,
+	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	paymentMethodId?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type PaymentVoidKeySpecifier = ('errors' | 'payment' | 'paymentErrors' | PaymentVoidKeySpecifier)[];
@@ -17446,7 +18838,18 @@ export type PluginUpdateFieldPolicy = {
 	plugin?: FieldPolicy<any> | FieldReadFunction<any>,
 	pluginsErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ProductKeySpecifier = ('attributes' | 'availableForPurchase' | 'category' | 'channel' | 'channelListings' | 'chargeTaxes' | 'collections' | 'defaultVariant' | 'description' | 'descriptionJson' | 'id' | 'imageById' | 'images' | 'isAvailable' | 'isAvailableForPurchase' | 'media' | 'mediaById' | 'metadata' | 'name' | 'pricing' | 'privateMetadata' | 'productType' | 'rating' | 'seoDescription' | 'seoTitle' | 'slug' | 'taxType' | 'thumbnail' | 'translation' | 'updatedAt' | 'variants' | 'weight' | ProductKeySpecifier)[];
+export type PreorderDataKeySpecifier = ('endDate' | 'globalSoldUnits' | 'globalThreshold' | PreorderDataKeySpecifier)[];
+export type PreorderDataFieldPolicy = {
+	endDate?: FieldPolicy<any> | FieldReadFunction<any>,
+	globalSoldUnits?: FieldPolicy<any> | FieldReadFunction<any>,
+	globalThreshold?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type PreorderThresholdKeySpecifier = ('quantity' | 'soldUnits' | PreorderThresholdKeySpecifier)[];
+export type PreorderThresholdFieldPolicy = {
+	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
+	soldUnits?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type ProductKeySpecifier = ('attributes' | 'availableForPurchase' | 'category' | 'channel' | 'channelListings' | 'chargeTaxes' | 'collections' | 'created' | 'defaultVariant' | 'description' | 'descriptionJson' | 'id' | 'imageById' | 'images' | 'isAvailable' | 'isAvailableForPurchase' | 'media' | 'mediaById' | 'metadata' | 'name' | 'pricing' | 'privateMetadata' | 'productType' | 'rating' | 'seoDescription' | 'seoTitle' | 'slug' | 'taxType' | 'thumbnail' | 'translation' | 'updatedAt' | 'variants' | 'weight' | ProductKeySpecifier)[];
 export type ProductFieldPolicy = {
 	attributes?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableForPurchase?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17455,6 +18858,7 @@ export type ProductFieldPolicy = {
 	channelListings?: FieldPolicy<any> | FieldReadFunction<any>,
 	chargeTaxes?: FieldPolicy<any> | FieldReadFunction<any>,
 	collections?: FieldPolicy<any> | FieldReadFunction<any>,
+	created?: FieldPolicy<any> | FieldReadFunction<any>,
 	defaultVariant?: FieldPolicy<any> | FieldReadFunction<any>,
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	descriptionJson?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17483,6 +18887,12 @@ export type ProductFieldPolicy = {
 };
 export type ProductAttributeAssignKeySpecifier = ('errors' | 'productErrors' | 'productType' | ProductAttributeAssignKeySpecifier)[];
 export type ProductAttributeAssignFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
+	productErrors?: FieldPolicy<any> | FieldReadFunction<any>,
+	productType?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type ProductAttributeAssignmentUpdateKeySpecifier = ('errors' | 'productErrors' | 'productType' | ProductAttributeAssignmentUpdateKeySpecifier)[];
+export type ProductAttributeAssignmentUpdateFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	productErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	productType?: FieldPolicy<any> | FieldReadFunction<any>
@@ -17653,13 +19063,15 @@ export type ProductTranslationFieldPolicy = {
 	seoDescription?: FieldPolicy<any> | FieldReadFunction<any>,
 	seoTitle?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ProductTypeKeySpecifier = ('availableAttributes' | 'hasVariants' | 'id' | 'isDigital' | 'isShippingRequired' | 'metadata' | 'name' | 'privateMetadata' | 'productAttributes' | 'products' | 'slug' | 'taxType' | 'variantAttributes' | 'weight' | ProductTypeKeySpecifier)[];
+export type ProductTypeKeySpecifier = ('assignedVariantAttributes' | 'availableAttributes' | 'hasVariants' | 'id' | 'isDigital' | 'isShippingRequired' | 'kind' | 'metadata' | 'name' | 'privateMetadata' | 'productAttributes' | 'products' | 'slug' | 'taxType' | 'variantAttributes' | 'weight' | ProductTypeKeySpecifier)[];
 export type ProductTypeFieldPolicy = {
+	assignedVariantAttributes?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableAttributes?: FieldPolicy<any> | FieldReadFunction<any>,
 	hasVariants?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	isDigital?: FieldPolicy<any> | FieldReadFunction<any>,
 	isShippingRequired?: FieldPolicy<any> | FieldReadFunction<any>,
+	kind?: FieldPolicy<any> | FieldReadFunction<any>,
 	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17717,11 +19129,12 @@ export type ProductUpdateFieldPolicy = {
 	product?: FieldPolicy<any> | FieldReadFunction<any>,
 	productErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ProductVariantKeySpecifier = ('attributes' | 'channel' | 'channelListings' | 'digitalContent' | 'id' | 'images' | 'margin' | 'media' | 'metadata' | 'name' | 'pricing' | 'privateMetadata' | 'product' | 'quantityAvailable' | 'quantityOrdered' | 'revenue' | 'sku' | 'stocks' | 'trackInventory' | 'translation' | 'weight' | ProductVariantKeySpecifier)[];
+export type ProductVariantKeySpecifier = ('attributes' | 'channel' | 'channelListings' | 'created' | 'digitalContent' | 'id' | 'images' | 'margin' | 'media' | 'metadata' | 'name' | 'preorder' | 'pricing' | 'privateMetadata' | 'product' | 'quantityAvailable' | 'quantityLimitPerCustomer' | 'quantityOrdered' | 'revenue' | 'sku' | 'stocks' | 'trackInventory' | 'translation' | 'updatedAt' | 'weight' | ProductVariantKeySpecifier)[];
 export type ProductVariantFieldPolicy = {
 	attributes?: FieldPolicy<any> | FieldReadFunction<any>,
 	channel?: FieldPolicy<any> | FieldReadFunction<any>,
 	channelListings?: FieldPolicy<any> | FieldReadFunction<any>,
+	created?: FieldPolicy<any> | FieldReadFunction<any>,
 	digitalContent?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	images?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17729,16 +19142,19 @@ export type ProductVariantFieldPolicy = {
 	media?: FieldPolicy<any> | FieldReadFunction<any>,
 	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
+	preorder?: FieldPolicy<any> | FieldReadFunction<any>,
 	pricing?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	product?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantityAvailable?: FieldPolicy<any> | FieldReadFunction<any>,
+	quantityLimitPerCustomer?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantityOrdered?: FieldPolicy<any> | FieldReadFunction<any>,
 	revenue?: FieldPolicy<any> | FieldReadFunction<any>,
 	sku?: FieldPolicy<any> | FieldReadFunction<any>,
 	stocks?: FieldPolicy<any> | FieldReadFunction<any>,
 	trackInventory?: FieldPolicy<any> | FieldReadFunction<any>,
 	translation?: FieldPolicy<any> | FieldReadFunction<any>,
+	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	weight?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type ProductVariantBulkCreateKeySpecifier = ('bulkProductErrors' | 'count' | 'errors' | 'productVariants' | ProductVariantBulkCreateKeySpecifier)[];
@@ -17754,12 +19170,13 @@ export type ProductVariantBulkDeleteFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	productErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ProductVariantChannelListingKeySpecifier = ('channel' | 'costPrice' | 'id' | 'margin' | 'price' | ProductVariantChannelListingKeySpecifier)[];
+export type ProductVariantChannelListingKeySpecifier = ('channel' | 'costPrice' | 'id' | 'margin' | 'preorderThreshold' | 'price' | ProductVariantChannelListingKeySpecifier)[];
 export type ProductVariantChannelListingFieldPolicy = {
 	channel?: FieldPolicy<any> | FieldReadFunction<any>,
 	costPrice?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	margin?: FieldPolicy<any> | FieldReadFunction<any>,
+	preorderThreshold?: FieldPolicy<any> | FieldReadFunction<any>,
 	price?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type ProductVariantChannelListingUpdateKeySpecifier = ('errors' | 'productChannelListingErrors' | 'variant' | ProductVariantChannelListingUpdateKeySpecifier)[];
@@ -17789,6 +19206,11 @@ export type ProductVariantDeleteKeySpecifier = ('errors' | 'productErrors' | 'pr
 export type ProductVariantDeleteFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	productErrors?: FieldPolicy<any> | FieldReadFunction<any>,
+	productVariant?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type ProductVariantPreorderDeactivateKeySpecifier = ('errors' | 'productVariant' | ProductVariantPreorderDeactivateKeySpecifier)[];
+export type ProductVariantPreorderDeactivateFieldPolicy = {
+	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariant?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type ProductVariantReorderKeySpecifier = ('errors' | 'product' | 'productErrors' | ProductVariantReorderKeySpecifier)[];
@@ -17853,13 +19275,15 @@ export type ProductVariantUpdateFieldPolicy = {
 	productErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariant?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type QueryKeySpecifier = ('_entities' | '_service' | 'address' | 'addressValidationRules' | 'app' | 'apps' | 'appsInstallations' | 'attribute' | 'attributes' | 'categories' | 'category' | 'channel' | 'channels' | 'checkout' | 'checkoutLines' | 'checkouts' | 'collection' | 'collections' | 'customers' | 'digitalContent' | 'digitalContents' | 'draftOrders' | 'exportFile' | 'exportFiles' | 'giftCard' | 'giftCards' | 'homepageEvents' | 'me' | 'menu' | 'menuItem' | 'menuItems' | 'menus' | 'order' | 'orderByToken' | 'orderSettings' | 'orders' | 'ordersTotal' | 'page' | 'pageType' | 'pageTypes' | 'pages' | 'payment' | 'payments' | 'permissionGroup' | 'permissionGroups' | 'plugin' | 'plugins' | 'product' | 'productType' | 'productTypes' | 'productVariant' | 'productVariants' | 'products' | 'reportProductSales' | 'sale' | 'sales' | 'shippingZone' | 'shippingZones' | 'shop' | 'staffUsers' | 'stock' | 'stocks' | 'taxTypes' | 'translation' | 'translations' | 'user' | 'voucher' | 'vouchers' | 'warehouse' | 'warehouses' | 'webhook' | 'webhookEvents' | 'webhookSamplePayload' | QueryKeySpecifier)[];
+export type QueryKeySpecifier = ('_entities' | '_service' | 'address' | 'addressValidationRules' | 'app' | 'appExtension' | 'appExtensions' | 'apps' | 'appsInstallations' | 'attribute' | 'attributes' | 'categories' | 'category' | 'channel' | 'channels' | 'checkout' | 'checkoutLines' | 'checkouts' | 'collection' | 'collections' | 'customers' | 'digitalContent' | 'digitalContents' | 'draftOrders' | 'exportFile' | 'exportFiles' | 'giftCard' | 'giftCardCurrencies' | 'giftCardSettings' | 'giftCardTags' | 'giftCards' | 'homepageEvents' | 'me' | 'menu' | 'menuItem' | 'menuItems' | 'menus' | 'order' | 'orderByToken' | 'orderSettings' | 'orders' | 'ordersTotal' | 'page' | 'pageType' | 'pageTypes' | 'pages' | 'payment' | 'payments' | 'permissionGroup' | 'permissionGroups' | 'plugin' | 'plugins' | 'product' | 'productType' | 'productTypes' | 'productVariant' | 'productVariants' | 'products' | 'reportProductSales' | 'sale' | 'sales' | 'shippingZone' | 'shippingZones' | 'shop' | 'staffUsers' | 'stock' | 'stocks' | 'taxTypes' | 'translation' | 'translations' | 'user' | 'voucher' | 'vouchers' | 'warehouse' | 'warehouses' | 'webhook' | 'webhookEvents' | 'webhookSamplePayload' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	_entities?: FieldPolicy<any> | FieldReadFunction<any>,
 	_service?: FieldPolicy<any> | FieldReadFunction<any>,
 	address?: FieldPolicy<any> | FieldReadFunction<any>,
 	addressValidationRules?: FieldPolicy<any> | FieldReadFunction<any>,
 	app?: FieldPolicy<any> | FieldReadFunction<any>,
+	appExtension?: FieldPolicy<any> | FieldReadFunction<any>,
+	appExtensions?: FieldPolicy<any> | FieldReadFunction<any>,
 	apps?: FieldPolicy<any> | FieldReadFunction<any>,
 	appsInstallations?: FieldPolicy<any> | FieldReadFunction<any>,
 	attribute?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17880,6 +19304,9 @@ export type QueryFieldPolicy = {
 	exportFile?: FieldPolicy<any> | FieldReadFunction<any>,
 	exportFiles?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCard?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardCurrencies?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardSettings?: FieldPolicy<any> | FieldReadFunction<any>,
+	giftCardTags?: FieldPolicy<any> | FieldReadFunction<any>,
 	giftCards?: FieldPolicy<any> | FieldReadFunction<any>,
 	homepageEvents?: FieldPolicy<any> | FieldReadFunction<any>,
 	me?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17952,11 +19379,12 @@ export type RequestPasswordResetFieldPolicy = {
 	accountErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	errors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type SaleKeySpecifier = ('categories' | 'channelListings' | 'collections' | 'currency' | 'discountValue' | 'endDate' | 'id' | 'metadata' | 'name' | 'privateMetadata' | 'products' | 'startDate' | 'translation' | 'type' | 'variants' | SaleKeySpecifier)[];
+export type SaleKeySpecifier = ('categories' | 'channelListings' | 'collections' | 'created' | 'currency' | 'discountValue' | 'endDate' | 'id' | 'metadata' | 'name' | 'privateMetadata' | 'products' | 'startDate' | 'translation' | 'type' | 'updatedAt' | 'variants' | SaleKeySpecifier)[];
 export type SaleFieldPolicy = {
 	categories?: FieldPolicy<any> | FieldReadFunction<any>,
 	channelListings?: FieldPolicy<any> | FieldReadFunction<any>,
 	collections?: FieldPolicy<any> | FieldReadFunction<any>,
+	created?: FieldPolicy<any> | FieldReadFunction<any>,
 	currency?: FieldPolicy<any> | FieldReadFunction<any>,
 	discountValue?: FieldPolicy<any> | FieldReadFunction<any>,
 	endDate?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -17968,6 +19396,7 @@ export type SaleFieldPolicy = {
 	startDate?: FieldPolicy<any> | FieldReadFunction<any>,
 	translation?: FieldPolicy<any> | FieldReadFunction<any>,
 	type?: FieldPolicy<any> | FieldReadFunction<any>,
+	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	variants?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type SaleAddCataloguesKeySpecifier = ('discountErrors' | 'errors' | 'sale' | SaleAddCataloguesKeySpecifier)[];
@@ -18126,16 +19555,18 @@ export type ShippingMethodTranslationFieldPolicy = {
 	language?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ShippingMethodTypeKeySpecifier = ('channelListings' | 'description' | 'excludedProducts' | 'id' | 'maximumDeliveryDays' | 'maximumOrderWeight' | 'metadata' | 'minimumDeliveryDays' | 'minimumOrderWeight' | 'name' | 'postalCodeRules' | 'privateMetadata' | 'translation' | 'type' | ShippingMethodTypeKeySpecifier)[];
+export type ShippingMethodTypeKeySpecifier = ('channelListings' | 'description' | 'excludedProducts' | 'id' | 'maximumDeliveryDays' | 'maximumOrderPrice' | 'maximumOrderWeight' | 'metadata' | 'minimumDeliveryDays' | 'minimumOrderPrice' | 'minimumOrderWeight' | 'name' | 'postalCodeRules' | 'privateMetadata' | 'translation' | 'type' | ShippingMethodTypeKeySpecifier)[];
 export type ShippingMethodTypeFieldPolicy = {
 	channelListings?: FieldPolicy<any> | FieldReadFunction<any>,
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	excludedProducts?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	maximumDeliveryDays?: FieldPolicy<any> | FieldReadFunction<any>,
+	maximumOrderPrice?: FieldPolicy<any> | FieldReadFunction<any>,
 	maximumOrderWeight?: FieldPolicy<any> | FieldReadFunction<any>,
 	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	minimumDeliveryDays?: FieldPolicy<any> | FieldReadFunction<any>,
+	minimumOrderPrice?: FieldPolicy<any> | FieldReadFunction<any>,
 	minimumOrderWeight?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	postalCodeRules?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -18237,12 +19668,13 @@ export type ShippingZoneUpdateFieldPolicy = {
 	shippingErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	shippingZone?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ShopKeySpecifier = ('automaticFulfillmentDigitalProducts' | 'availableExternalAuthentications' | 'availablePaymentGateways' | 'availableShippingMethods' | 'chargeTaxesOnShipping' | 'companyAddress' | 'countries' | 'customerSetPasswordUrl' | 'defaultCountry' | 'defaultDigitalMaxDownloads' | 'defaultDigitalUrlValidDays' | 'defaultMailSenderAddress' | 'defaultMailSenderName' | 'defaultWeightUnit' | 'description' | 'displayGrossPrices' | 'domain' | 'headerText' | 'includeTaxesInPrices' | 'languages' | 'limits' | 'name' | 'permissions' | 'phonePrefixes' | 'staffNotificationRecipients' | 'trackInventoryByDefault' | 'translation' | 'version' | ShopKeySpecifier)[];
+export type ShopKeySpecifier = ('automaticFulfillmentDigitalProducts' | 'availableExternalAuthentications' | 'availablePaymentGateways' | 'availableShippingMethods' | 'channelCurrencies' | 'chargeTaxesOnShipping' | 'companyAddress' | 'countries' | 'customerSetPasswordUrl' | 'defaultCountry' | 'defaultDigitalMaxDownloads' | 'defaultDigitalUrlValidDays' | 'defaultMailSenderAddress' | 'defaultMailSenderName' | 'defaultWeightUnit' | 'description' | 'displayGrossPrices' | 'domain' | 'fulfillmentAllowUnpaid' | 'fulfillmentAutoApprove' | 'headerText' | 'includeTaxesInPrices' | 'languages' | 'limitQuantityPerCheckout' | 'limits' | 'name' | 'permissions' | 'phonePrefixes' | 'reserveStockDurationAnonymousUser' | 'reserveStockDurationAuthenticatedUser' | 'staffNotificationRecipients' | 'trackInventoryByDefault' | 'translation' | 'version' | ShopKeySpecifier)[];
 export type ShopFieldPolicy = {
 	automaticFulfillmentDigitalProducts?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableExternalAuthentications?: FieldPolicy<any> | FieldReadFunction<any>,
 	availablePaymentGateways?: FieldPolicy<any> | FieldReadFunction<any>,
 	availableShippingMethods?: FieldPolicy<any> | FieldReadFunction<any>,
+	channelCurrencies?: FieldPolicy<any> | FieldReadFunction<any>,
 	chargeTaxesOnShipping?: FieldPolicy<any> | FieldReadFunction<any>,
 	companyAddress?: FieldPolicy<any> | FieldReadFunction<any>,
 	countries?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -18256,13 +19688,18 @@ export type ShopFieldPolicy = {
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	displayGrossPrices?: FieldPolicy<any> | FieldReadFunction<any>,
 	domain?: FieldPolicy<any> | FieldReadFunction<any>,
+	fulfillmentAllowUnpaid?: FieldPolicy<any> | FieldReadFunction<any>,
+	fulfillmentAutoApprove?: FieldPolicy<any> | FieldReadFunction<any>,
 	headerText?: FieldPolicy<any> | FieldReadFunction<any>,
 	includeTaxesInPrices?: FieldPolicy<any> | FieldReadFunction<any>,
 	languages?: FieldPolicy<any> | FieldReadFunction<any>,
+	limitQuantityPerCheckout?: FieldPolicy<any> | FieldReadFunction<any>,
 	limits?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	permissions?: FieldPolicy<any> | FieldReadFunction<any>,
 	phonePrefixes?: FieldPolicy<any> | FieldReadFunction<any>,
+	reserveStockDurationAnonymousUser?: FieldPolicy<any> | FieldReadFunction<any>,
+	reserveStockDurationAuthenticatedUser?: FieldPolicy<any> | FieldReadFunction<any>,
 	staffNotificationRecipients?: FieldPolicy<any> | FieldReadFunction<any>,
 	trackInventoryByDefault?: FieldPolicy<any> | FieldReadFunction<any>,
 	translation?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -18370,12 +19807,13 @@ export type StaffUpdateFieldPolicy = {
 	staffErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	user?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type StockKeySpecifier = ('id' | 'productVariant' | 'quantity' | 'quantityAllocated' | 'warehouse' | StockKeySpecifier)[];
+export type StockKeySpecifier = ('id' | 'productVariant' | 'quantity' | 'quantityAllocated' | 'quantityReserved' | 'warehouse' | StockKeySpecifier)[];
 export type StockFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	productVariant?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantityAllocated?: FieldPolicy<any> | FieldReadFunction<any>,
+	quantityReserved?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type StockCountableConnectionKeySpecifier = ('edges' | 'pageInfo' | 'totalCount' | StockCountableConnectionKeySpecifier)[];
@@ -18411,6 +19849,11 @@ export type TaxedMoneyRangeKeySpecifier = ('start' | 'stop' | TaxedMoneyRangeKey
 export type TaxedMoneyRangeFieldPolicy = {
 	start?: FieldPolicy<any> | FieldReadFunction<any>,
 	stop?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type TimePeriodKeySpecifier = ('amount' | 'type' | TimePeriodKeySpecifier)[];
+export type TimePeriodFieldPolicy = {
+	amount?: FieldPolicy<any> | FieldReadFunction<any>,
+	type?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type TransactionKeySpecifier = ('amount' | 'created' | 'error' | 'gatewayResponse' | 'id' | 'isSuccess' | 'kind' | 'payment' | 'token' | TransactionKeySpecifier)[];
 export type TransactionFieldPolicy = {
@@ -18459,7 +19902,7 @@ export type UploadErrorFieldPolicy = {
 	field?: FieldPolicy<any> | FieldReadFunction<any>,
 	message?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type UserKeySpecifier = ('addresses' | 'avatar' | 'checkout' | 'checkoutTokens' | 'dateJoined' | 'defaultBillingAddress' | 'defaultShippingAddress' | 'editableGroups' | 'email' | 'events' | 'firstName' | 'giftCards' | 'id' | 'isActive' | 'isStaff' | 'languageCode' | 'lastLogin' | 'lastName' | 'metadata' | 'note' | 'orders' | 'permissionGroups' | 'privateMetadata' | 'storedPaymentSources' | 'userPermissions' | UserKeySpecifier)[];
+export type UserKeySpecifier = ('addresses' | 'avatar' | 'checkout' | 'checkoutTokens' | 'dateJoined' | 'defaultBillingAddress' | 'defaultShippingAddress' | 'editableGroups' | 'email' | 'events' | 'firstName' | 'giftCards' | 'id' | 'isActive' | 'isStaff' | 'languageCode' | 'lastLogin' | 'lastName' | 'metadata' | 'note' | 'orders' | 'permissionGroups' | 'privateMetadata' | 'storedPaymentSources' | 'updatedAt' | 'userPermissions' | UserKeySpecifier)[];
 export type UserFieldPolicy = {
 	addresses?: FieldPolicy<any> | FieldReadFunction<any>,
 	avatar?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -18485,6 +19928,7 @@ export type UserFieldPolicy = {
 	permissionGroups?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	storedPaymentSources?: FieldPolicy<any> | FieldReadFunction<any>,
+	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	userPermissions?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type UserAvatarDeleteKeySpecifier = ('accountErrors' | 'errors' | 'user' | UserAvatarDeleteKeySpecifier)[];
@@ -18667,12 +20111,14 @@ export type VoucherUpdateFieldPolicy = {
 	errors?: FieldPolicy<any> | FieldReadFunction<any>,
 	voucher?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type WarehouseKeySpecifier = ('address' | 'companyName' | 'email' | 'id' | 'metadata' | 'name' | 'privateMetadata' | 'shippingZones' | 'slug' | WarehouseKeySpecifier)[];
+export type WarehouseKeySpecifier = ('address' | 'clickAndCollectOption' | 'companyName' | 'email' | 'id' | 'isPrivate' | 'metadata' | 'name' | 'privateMetadata' | 'shippingZones' | 'slug' | WarehouseKeySpecifier)[];
 export type WarehouseFieldPolicy = {
 	address?: FieldPolicy<any> | FieldReadFunction<any>,
+	clickAndCollectOption?: FieldPolicy<any> | FieldReadFunction<any>,
 	companyName?: FieldPolicy<any> | FieldReadFunction<any>,
 	email?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	isPrivate?: FieldPolicy<any> | FieldReadFunction<any>,
 	metadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -18726,14 +20172,17 @@ export type WarehouseUpdateFieldPolicy = {
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouseErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type WebhookKeySpecifier = ('app' | 'events' | 'id' | 'isActive' | 'name' | 'secretKey' | 'targetUrl' | WebhookKeySpecifier)[];
+export type WebhookKeySpecifier = ('app' | 'asyncEvents' | 'eventDeliveries' | 'events' | 'id' | 'isActive' | 'name' | 'secretKey' | 'syncEvents' | 'targetUrl' | WebhookKeySpecifier)[];
 export type WebhookFieldPolicy = {
 	app?: FieldPolicy<any> | FieldReadFunction<any>,
+	asyncEvents?: FieldPolicy<any> | FieldReadFunction<any>,
+	eventDeliveries?: FieldPolicy<any> | FieldReadFunction<any>,
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	isActive?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	secretKey?: FieldPolicy<any> | FieldReadFunction<any>,
+	syncEvents?: FieldPolicy<any> | FieldReadFunction<any>,
 	targetUrl?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type WebhookCreateKeySpecifier = ('errors' | 'webhook' | 'webhookErrors' | WebhookCreateKeySpecifier)[];
@@ -18756,6 +20205,16 @@ export type WebhookErrorFieldPolicy = {
 };
 export type WebhookEventKeySpecifier = ('eventType' | 'name' | WebhookEventKeySpecifier)[];
 export type WebhookEventFieldPolicy = {
+	eventType?: FieldPolicy<any> | FieldReadFunction<any>,
+	name?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type WebhookEventAsyncKeySpecifier = ('eventType' | 'name' | WebhookEventAsyncKeySpecifier)[];
+export type WebhookEventAsyncFieldPolicy = {
+	eventType?: FieldPolicy<any> | FieldReadFunction<any>,
+	name?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type WebhookEventSyncKeySpecifier = ('eventType' | 'name' | WebhookEventSyncKeySpecifier)[];
+export type WebhookEventSyncFieldPolicy = {
 	eventType?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -18875,6 +20334,18 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | AppErrorKeySpecifier | (() => undefined | AppErrorKeySpecifier),
 		fields?: AppErrorFieldPolicy,
 	},
+	AppExtension?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | AppExtensionKeySpecifier | (() => undefined | AppExtensionKeySpecifier),
+		fields?: AppExtensionFieldPolicy,
+	},
+	AppExtensionCountableConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | AppExtensionCountableConnectionKeySpecifier | (() => undefined | AppExtensionCountableConnectionKeySpecifier),
+		fields?: AppExtensionCountableConnectionFieldPolicy,
+	},
+	AppExtensionCountableEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | AppExtensionCountableEdgeKeySpecifier | (() => undefined | AppExtensionCountableEdgeKeySpecifier),
+		fields?: AppExtensionCountableEdgeFieldPolicy,
+	},
 	AppFetchManifest?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AppFetchManifestKeySpecifier | (() => undefined | AppFetchManifestKeySpecifier),
 		fields?: AppFetchManifestFieldPolicy,
@@ -18886,6 +20357,10 @@ export type StrictTypedTypePolicies = {
 	AppInstallation?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AppInstallationKeySpecifier | (() => undefined | AppInstallationKeySpecifier),
 		fields?: AppInstallationFieldPolicy,
+	},
+	AppManifestExtension?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | AppManifestExtensionKeySpecifier | (() => undefined | AppManifestExtensionKeySpecifier),
+		fields?: AppManifestExtensionFieldPolicy,
 	},
 	AppRetryInstall?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AppRetryInstallKeySpecifier | (() => undefined | AppRetryInstallKeySpecifier),
@@ -18914,6 +20389,10 @@ export type StrictTypedTypePolicies = {
 	AssignNavigation?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AssignNavigationKeySpecifier | (() => undefined | AssignNavigationKeySpecifier),
 		fields?: AssignNavigationFieldPolicy,
+	},
+	AssignedVariantAttribute?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | AssignedVariantAttributeKeySpecifier | (() => undefined | AssignedVariantAttributeKeySpecifier),
+		fields?: AssignedVariantAttributeFieldPolicy,
 	},
 	Attribute?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AttributeKeySpecifier | (() => undefined | AttributeKeySpecifier),
@@ -19114,6 +20593,10 @@ export type StrictTypedTypePolicies = {
 	CheckoutCustomerDetach?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | CheckoutCustomerDetachKeySpecifier | (() => undefined | CheckoutCustomerDetachKeySpecifier),
 		fields?: CheckoutCustomerDetachFieldPolicy,
+	},
+	CheckoutDeliveryMethodUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | CheckoutDeliveryMethodUpdateKeySpecifier | (() => undefined | CheckoutDeliveryMethodUpdateKeySpecifier),
+		fields?: CheckoutDeliveryMethodUpdateFieldPolicy,
 	},
 	CheckoutEmailUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | CheckoutEmailUpdateKeySpecifier | (() => undefined | CheckoutEmailUpdateKeySpecifier),
@@ -19363,6 +20846,34 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | DraftOrderUpdateKeySpecifier | (() => undefined | DraftOrderUpdateKeySpecifier),
 		fields?: DraftOrderUpdateFieldPolicy,
 	},
+	EventDelivery?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryKeySpecifier | (() => undefined | EventDeliveryKeySpecifier),
+		fields?: EventDeliveryFieldPolicy,
+	},
+	EventDeliveryAttempt?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryAttemptKeySpecifier | (() => undefined | EventDeliveryAttemptKeySpecifier),
+		fields?: EventDeliveryAttemptFieldPolicy,
+	},
+	EventDeliveryAttemptCountableConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryAttemptCountableConnectionKeySpecifier | (() => undefined | EventDeliveryAttemptCountableConnectionKeySpecifier),
+		fields?: EventDeliveryAttemptCountableConnectionFieldPolicy,
+	},
+	EventDeliveryAttemptCountableEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryAttemptCountableEdgeKeySpecifier | (() => undefined | EventDeliveryAttemptCountableEdgeKeySpecifier),
+		fields?: EventDeliveryAttemptCountableEdgeFieldPolicy,
+	},
+	EventDeliveryCountableConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryCountableConnectionKeySpecifier | (() => undefined | EventDeliveryCountableConnectionKeySpecifier),
+		fields?: EventDeliveryCountableConnectionFieldPolicy,
+	},
+	EventDeliveryCountableEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryCountableEdgeKeySpecifier | (() => undefined | EventDeliveryCountableEdgeKeySpecifier),
+		fields?: EventDeliveryCountableEdgeFieldPolicy,
+	},
+	EventDeliveryRetry?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EventDeliveryRetryKeySpecifier | (() => undefined | EventDeliveryRetryKeySpecifier),
+		fields?: EventDeliveryRetryFieldPolicy,
+	},
 	ExportError?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ExportErrorKeySpecifier | (() => undefined | ExportErrorKeySpecifier),
 		fields?: ExportErrorFieldPolicy,
@@ -19383,6 +20894,10 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | ExportFileCountableEdgeKeySpecifier | (() => undefined | ExportFileCountableEdgeKeySpecifier),
 		fields?: ExportFileCountableEdgeFieldPolicy,
 	},
+	ExportGiftCards?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | ExportGiftCardsKeySpecifier | (() => undefined | ExportGiftCardsKeySpecifier),
+		fields?: ExportGiftCardsFieldPolicy,
+	},
 	ExportProducts?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ExportProductsKeySpecifier | (() => undefined | ExportProductsKeySpecifier),
 		fields?: ExportProductsFieldPolicy,
@@ -19398,6 +20913,14 @@ export type StrictTypedTypePolicies = {
 	ExternalLogout?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ExternalLogoutKeySpecifier | (() => undefined | ExternalLogoutKeySpecifier),
 		fields?: ExternalLogoutFieldPolicy,
+	},
+	ExternalNotificationError?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | ExternalNotificationErrorKeySpecifier | (() => undefined | ExternalNotificationErrorKeySpecifier),
+		fields?: ExternalNotificationErrorFieldPolicy,
+	},
+	ExternalNotificationTrigger?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | ExternalNotificationTriggerKeySpecifier | (() => undefined | ExternalNotificationTriggerKeySpecifier),
+		fields?: ExternalNotificationTriggerFieldPolicy,
 	},
 	ExternalObtainAccessTokens?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ExternalObtainAccessTokensKeySpecifier | (() => undefined | ExternalObtainAccessTokensKeySpecifier),
@@ -19422,6 +20945,10 @@ export type StrictTypedTypePolicies = {
 	Fulfillment?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | FulfillmentKeySpecifier | (() => undefined | FulfillmentKeySpecifier),
 		fields?: FulfillmentFieldPolicy,
+	},
+	FulfillmentApprove?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | FulfillmentApproveKeySpecifier | (() => undefined | FulfillmentApproveKeySpecifier),
+		fields?: FulfillmentApproveFieldPolicy,
 	},
 	FulfillmentCancel?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | FulfillmentCancelKeySpecifier | (() => undefined | FulfillmentCancelKeySpecifier),
@@ -19455,6 +20982,26 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | GiftCardActivateKeySpecifier | (() => undefined | GiftCardActivateKeySpecifier),
 		fields?: GiftCardActivateFieldPolicy,
 	},
+	GiftCardAddNote?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardAddNoteKeySpecifier | (() => undefined | GiftCardAddNoteKeySpecifier),
+		fields?: GiftCardAddNoteFieldPolicy,
+	},
+	GiftCardBulkActivate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardBulkActivateKeySpecifier | (() => undefined | GiftCardBulkActivateKeySpecifier),
+		fields?: GiftCardBulkActivateFieldPolicy,
+	},
+	GiftCardBulkCreate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardBulkCreateKeySpecifier | (() => undefined | GiftCardBulkCreateKeySpecifier),
+		fields?: GiftCardBulkCreateFieldPolicy,
+	},
+	GiftCardBulkDeactivate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardBulkDeactivateKeySpecifier | (() => undefined | GiftCardBulkDeactivateKeySpecifier),
+		fields?: GiftCardBulkDeactivateFieldPolicy,
+	},
+	GiftCardBulkDelete?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardBulkDeleteKeySpecifier | (() => undefined | GiftCardBulkDeleteKeySpecifier),
+		fields?: GiftCardBulkDeleteFieldPolicy,
+	},
 	GiftCardCountableConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | GiftCardCountableConnectionKeySpecifier | (() => undefined | GiftCardCountableConnectionKeySpecifier),
 		fields?: GiftCardCountableConnectionFieldPolicy,
@@ -19471,9 +21018,49 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | GiftCardDeactivateKeySpecifier | (() => undefined | GiftCardDeactivateKeySpecifier),
 		fields?: GiftCardDeactivateFieldPolicy,
 	},
+	GiftCardDelete?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardDeleteKeySpecifier | (() => undefined | GiftCardDeleteKeySpecifier),
+		fields?: GiftCardDeleteFieldPolicy,
+	},
 	GiftCardError?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | GiftCardErrorKeySpecifier | (() => undefined | GiftCardErrorKeySpecifier),
 		fields?: GiftCardErrorFieldPolicy,
+	},
+	GiftCardEvent?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardEventKeySpecifier | (() => undefined | GiftCardEventKeySpecifier),
+		fields?: GiftCardEventFieldPolicy,
+	},
+	GiftCardEventBalance?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardEventBalanceKeySpecifier | (() => undefined | GiftCardEventBalanceKeySpecifier),
+		fields?: GiftCardEventBalanceFieldPolicy,
+	},
+	GiftCardResend?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardResendKeySpecifier | (() => undefined | GiftCardResendKeySpecifier),
+		fields?: GiftCardResendFieldPolicy,
+	},
+	GiftCardSettings?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardSettingsKeySpecifier | (() => undefined | GiftCardSettingsKeySpecifier),
+		fields?: GiftCardSettingsFieldPolicy,
+	},
+	GiftCardSettingsError?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardSettingsErrorKeySpecifier | (() => undefined | GiftCardSettingsErrorKeySpecifier),
+		fields?: GiftCardSettingsErrorFieldPolicy,
+	},
+	GiftCardSettingsUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardSettingsUpdateKeySpecifier | (() => undefined | GiftCardSettingsUpdateKeySpecifier),
+		fields?: GiftCardSettingsUpdateFieldPolicy,
+	},
+	GiftCardTag?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardTagKeySpecifier | (() => undefined | GiftCardTagKeySpecifier),
+		fields?: GiftCardTagFieldPolicy,
+	},
+	GiftCardTagCountableConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardTagCountableConnectionKeySpecifier | (() => undefined | GiftCardTagCountableConnectionKeySpecifier),
+		fields?: GiftCardTagCountableConnectionFieldPolicy,
+	},
+	GiftCardTagCountableEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GiftCardTagCountableEdgeKeySpecifier | (() => undefined | GiftCardTagCountableEdgeKeySpecifier),
+		fields?: GiftCardTagCountableEdgeFieldPolicy,
 	},
 	GiftCardUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | GiftCardUpdateKeySpecifier | (() => undefined | GiftCardUpdateKeySpecifier),
@@ -19979,6 +21566,14 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | PluginUpdateKeySpecifier | (() => undefined | PluginUpdateKeySpecifier),
 		fields?: PluginUpdateFieldPolicy,
 	},
+	PreorderData?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | PreorderDataKeySpecifier | (() => undefined | PreorderDataKeySpecifier),
+		fields?: PreorderDataFieldPolicy,
+	},
+	PreorderThreshold?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | PreorderThresholdKeySpecifier | (() => undefined | PreorderThresholdKeySpecifier),
+		fields?: PreorderThresholdFieldPolicy,
+	},
 	Product?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ProductKeySpecifier | (() => undefined | ProductKeySpecifier),
 		fields?: ProductFieldPolicy,
@@ -19986,6 +21581,10 @@ export type StrictTypedTypePolicies = {
 	ProductAttributeAssign?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ProductAttributeAssignKeySpecifier | (() => undefined | ProductAttributeAssignKeySpecifier),
 		fields?: ProductAttributeAssignFieldPolicy,
+	},
+	ProductAttributeAssignmentUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | ProductAttributeAssignmentUpdateKeySpecifier | (() => undefined | ProductAttributeAssignmentUpdateKeySpecifier),
+		fields?: ProductAttributeAssignmentUpdateFieldPolicy,
 	},
 	ProductAttributeUnassign?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ProductAttributeUnassignKeySpecifier | (() => undefined | ProductAttributeUnassignKeySpecifier),
@@ -20146,6 +21745,10 @@ export type StrictTypedTypePolicies = {
 	ProductVariantDelete?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ProductVariantDeleteKeySpecifier | (() => undefined | ProductVariantDeleteKeySpecifier),
 		fields?: ProductVariantDeleteFieldPolicy,
+	},
+	ProductVariantPreorderDeactivate?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | ProductVariantPreorderDeactivateKeySpecifier | (() => undefined | ProductVariantPreorderDeactivateKeySpecifier),
+		fields?: ProductVariantPreorderDeactivateFieldPolicy,
 	},
 	ProductVariantReorder?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ProductVariantReorderKeySpecifier | (() => undefined | ProductVariantReorderKeySpecifier),
@@ -20455,6 +22058,10 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | TaxedMoneyRangeKeySpecifier | (() => undefined | TaxedMoneyRangeKeySpecifier),
 		fields?: TaxedMoneyRangeFieldPolicy,
 	},
+	TimePeriod?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | TimePeriodKeySpecifier | (() => undefined | TimePeriodKeySpecifier),
+		fields?: TimePeriodFieldPolicy,
+	},
 	Transaction?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | TransactionKeySpecifier | (() => undefined | TransactionKeySpecifier),
 		fields?: TransactionFieldPolicy,
@@ -20642,6 +22249,14 @@ export type StrictTypedTypePolicies = {
 	WebhookEvent?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | WebhookEventKeySpecifier | (() => undefined | WebhookEventKeySpecifier),
 		fields?: WebhookEventFieldPolicy,
+	},
+	WebhookEventAsync?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | WebhookEventAsyncKeySpecifier | (() => undefined | WebhookEventAsyncKeySpecifier),
+		fields?: WebhookEventAsyncFieldPolicy,
+	},
+	WebhookEventSync?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | WebhookEventSyncKeySpecifier | (() => undefined | WebhookEventSyncKeySpecifier),
+		fields?: WebhookEventSyncFieldPolicy,
 	},
 	WebhookUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | WebhookUpdateKeySpecifier | (() => undefined | WebhookUpdateKeySpecifier),


### PR DESCRIPTION
Changes:
- variant selector as a select widget
- payment details prepopulated for the DEMO mode
- changed links after order completed
- fixed layout for the account pages
- image optimization will allow for the images from API endpoint out of the box (instead of hardcoded value)
- redirection out of the checkout pages if the cart is empty 