### PR TITLE
Provide default values in ENVs for simplicity

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,1 @@
 NEXT_PUBLIC_API_URI=https://vercel.saleor.cloud/graphql/
-NEXT_PUBLIC_DEFAULT_CHANNEL=default-channel
-NEXT_PUBLIC_HOMEPAGE_MENU=homepage
-NEXT_PUBLIC_VERCEL_URL=https://localhost:3001
-NEXT_PUBLIC_DEMO_MODE=false

--- a/lib/const.ts
+++ b/lib/const.ts
@@ -1,4 +1,4 @@
 export const CHECKOUT_TOKEN = "checkoutToken";
 export const API_URI = process.env.NEXT_PUBLIC_API_URI || "";
-export const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
-export const HOMEPAGE_MENU = process.env.NEXT_PUBLIC_HOMEPAGE_MENU || "";
+export const DEMO_MODE = (process.env.NEXT_PUBLIC_DEMO_MODE || "false") === "true";
+export const HOMEPAGE_MENU = process.env.NEXT_PUBLIC_HOMEPAGE_MENU || "homepage";

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,7 +1,7 @@
 const excludedPaths = ["/cart", "/checkout", "/account/*"];
 
 module.exports = {
-  siteUrl: process.env.NEXT_PUBLIC_VERCEL_URL,
+  siteUrl: process.env.NEXT_PUBLIC_VERCEL_URL || "http://localhost:3001",
   generateRobotsTxt: true,
   exclude: excludedPaths + ["/[sitemap]"],
   robotsTxtOptions: {


### PR DESCRIPTION
The current `.env` is a source of confusion (e.g. [this question](https://github.com/saleor/react-storefront/discussions/164)). Let's set the _default_ values in the code whenever and use environment only to overwrite that or set something that cannot have a default value (i.e. a GraphQL endpoint).