### PR TITLE
Add docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm i
 Start the dev server:
 
 ```bash
-npm run dev
+pnpm dev
 ```
 
 Storefront can be now accessed at http://localhost:3001/.
@@ -52,9 +52,7 @@ Storefront can be now accessed at http://localhost:3001/.
 
 ### Configuration
 
-The `.env` file contains environment variables used by the application. You can override them by creating `.env.local` file.
-
-[Read more](https://nextjs.org/docs/basic-features/environment-variables)
+Instructions how to configure the application (e.g. change the graphql API URL) can be found [here](docs/configuration.md).
 
 ### GraphQL queries
 
@@ -62,12 +60,12 @@ Graphql queries are located under the `./graphql`. We strongly encourage use of 
 
 Our client of choice is [Apollo](https://www.apollographql.com/docs/react/), which provides excellent cache and features out of the box. To get fully typed requests and responses, [GraphQL Code Generator](https://www.graphql-code-generator.com/) transforms all `.graphql` files into ready to use hooks. Generated code is located at `./saleor/api.tsx` file.
 
-API endpoint can be configured via `.env` file.
+API endpoint can be configured via `.env` file as described in [docs](docs/configuration.md).
 
 #### Workflow
 
 - Modify or create GraphQL file. For example, new query at `./graphql/queries/FeaturedProducts.graphql`
-- Run `npm run generate` command
+- Run `pnpm generate` command
 - New query will be added to the `./saleor/api.tsx` file
 - Import generated hook (`import { useFeaturedProductsQuery } from "@/saleor/api";`) in your component code
 
@@ -86,7 +84,7 @@ Project use [file based routing](https://nextjs.org/docs/routing/introduction). 
 To ensure, that Link components use only the existing URLs with required arguments, we use [pathpida](https://github.com/aspida/pathpida). It is used to automatically generate the `./lib/$path.ts` file with all available routes. File should not be updated manually, instead run:
 
 ```bash
-npm run paths
+pnpm paths
 ```
 
 Since routes require additional arguments with current locale and channel, you should use `usePaths` hook which will automatically add those. Let's create example component with link to the product page:
@@ -107,10 +105,10 @@ export const ProductLinkComponent = () => {
 
 ### Code style
 
-Before commiting the code, make sure to run code linters and formatters:
+Before committing the code, Git pre-hooks will check staged changes for following the code styles. If you would like to format the code by yourself, run the command:
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 ## Other tools
@@ -122,7 +120,7 @@ The repository contains ready to use VS Code debugger configuration (`.vscode/la
 Start server in debug mode
 
 ```bash
-npm run debug
+pnpm debug
 ```
 
 Add [breakpoints](https://code.visualstudio.com/docs/editor/debugging#_breakpoints), and start debugging session in your editor.
@@ -138,7 +136,7 @@ VS Marketplace [link](https://marketplace.visualstudio.com/items?itemName=GraphQ
 If you want to check how your changes impact page size, use command:
 
 ```bash
-npm run analyze-build
+pnpm analyze-build
 ```
 
 After the build, report will open in your browser.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,27 @@
+# Configuration
+
+## Environment variables
+
+SRS is built using Next.js framework which comes with complete workflow for working with environment variables. You can read more at [documentation](https://nextjs.org/docs/basic-features/environment-variables) pages.
+
+All of the options available to change via environment variables can be found in `.env` file.
+
+### Example - Changing the API URI
+
+For local development we are recommending configuration via `.env.local` file:
+
+1. Create `.env.local` in the root of the project
+2. Add entry `NEXT_PUBLIC_API_URI=https://my-saleor-instance/graphql/`
+3. If dev server was running, new values will be loaded after the server restart
+
+To ensure that local configuration will not be exposed, `.env.local` file is ignored by Git.
+
+For application deployments we suggest to setup environment variables instead of files. Depending of hosting provider, the way you can set them vary. In case of using Vercel, related documentation can be found [here](https://vercel.com/docs/concepts/projects/environment-variables).
+
+## Changing available channels
+
+List of available channels can be changed by adding new entries to `CHANNELS` constant located in the `lib/regions.ts` file.
+
+## Languages
+
+To configure available languages, read [translation](docs/translations.md) docs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,3 +25,7 @@ List of available channels can be changed by adding new entries to `CHANNELS` co
 ## Languages
 
 To configure available languages, read [translation](docs/translations.md) docs.
+
+## Homepage
+
+By default homepage will show content blocks based at Menu object fetched from the API. Slug of the object can be configured with the `NEXT_PUBLIC_HOMEPAGE_MENU` variable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,25 +2,25 @@
 
 ## Environment variables
 
-SRS is built using Next.js framework which comes with complete workflow for working with environment variables. You can read more at [documentation](https://nextjs.org/docs/basic-features/environment-variables) pages.
+SRS is built using the Next.js framework. It comes with a complete workflow for working with environment variables. You can read more at these [documentation](https://nextjs.org/docs/basic-features/environment-variables) pages.
 
-All of the options available to change via environment variables can be found in `.env` file.
+All available options to change via environment variables can be found in the `.env` file.
 
 ### Example - Changing the API URI
 
-For local development we are recommending configuration via `.env.local` file:
+For local development, we recommend configuration via the `.env.local` file:
 
 1. Create `.env.local` in the root of the project
 2. Add entry `NEXT_PUBLIC_API_URI=https://my-saleor-instance/graphql/`
 3. If dev server was running, new values will be loaded after the server restart
 
-To ensure that local configuration will not be exposed, `.env.local` file is ignored by Git.
+Git ignores the `.env.local` file to ensure that the local configuration is not exposed.
 
-For application deployments we suggest to setup environment variables instead of files. Depending of hosting provider, the way you can set them vary. In case of using Vercel, related documentation can be found [here](https://vercel.com/docs/concepts/projects/environment-variables).
+For application deployments, we suggest setting environment variables instead of files. The way you can set them varies depending on the hosting provider. In the case of using Vercel, related documentation can be found [here](https://vercel.com/docs/concepts/projects/environment-variables).
 
 ## Changing available channels
 
-List of available channels can be changed by adding new entries to `CHANNELS` constant located in the `lib/regions.ts` file.
+The list of available channels can be changed by adding new entries to the `CHANNELS` constant located in the `lib/regions.ts` file.
 
 ## Languages
 
@@ -28,4 +28,4 @@ To configure available languages, read [translation](docs/translations.md) docs.
 
 ## Homepage
 
-By default homepage will show content blocks based at Menu object fetched from the API. Slug of the object can be configured with the `NEXT_PUBLIC_HOMEPAGE_MENU` variable.
+The homepage will show content blocks based, by default, on the Menu object fetched from the API. Slug of the object can be configured with the `NEXT_PUBLIC_HOMEPAGE_MENU` variable.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,33 @@
+# Translations
+
+There are 2 types of translations:
+
+- translations which can be managed via Dashboard and are fetched from the API. For example: name of a certain product
+- interface translations. For example label on "Add to cart" button
+
+## API translations
+
+Documentation for API can be found [here](https://docs.saleor.io/docs/3.x/developer/api-conventions/translations). Dashboard guide is located [here](https://docs.saleor.io/docs/3.x/dashboard/translations).
+
+React Storefront has helper for displaying translated field called `translate` located in th `lib/translations.ts` file. Function will fall back to default language, if API has no translation available.
+
+## Interface translations
+
+SRS use [FormatJS](https://formatjs.io/) as a library for translating the interface. If you haven't used it before, we recommend reading it's [documentation](https://formatjs.io/docs/getting-started/application-workflow).
+
+Translation sources are located at `locale` directory. Please note: SRS use full language code names to differentiate between language dialects (eg. `en-US` and `en-UK`).
+
+### Adding new languages
+
+1. Create a new json file in the `locale` directory
+2. Add a language to the `LOCALES` constant in the `lib/regions.ts` file
+3. Extend the `importMessages` function to import the proper json file based on chosen locale
+
+### Translation management
+
+Instead of editing file by hand, we recommend using translation platforms like:
+
+- [Transifex](https://www.transifex.com/)
+- [POEditor](https://poeditor.com/)
+
+There are multiple other online platforms and locally installed software to choose from. The only requirement is to use JSON files to synchronize.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,21 +1,21 @@
 # Translations
 
-There are 2 types of translations:
+There are two types of translations:
 
-- translations which can be managed via Dashboard and are fetched from the API. For example: name of a certain product
-- interface translations. For example label on "Add to cart" button
+- Translations that can be managed via Dashboard and are fetched from the API. For example, the name of a specific product.
+- Interface translations. For example, the label on the "Add to cart" button.
 
 ## API translations
 
-Documentation for API can be found [here](https://docs.saleor.io/docs/3.x/developer/api-conventions/translations). Dashboard guide is located [here](https://docs.saleor.io/docs/3.x/dashboard/translations).
+Documentation for the API can be found [here](https://docs.saleor.io/docs/3.x/developer/api-conventions/translations). The dashboard guide is located [here](https://docs.saleor.io/docs/3.x/dashboard/translations).
 
-React Storefront has helper for displaying translated field called `translate` located in th `lib/translations.ts` file. Function will fall back to default language, if API has no translation available.
+React Storefront has a helper for displaying translated fields called `translate` located in the `lib/translations.ts` file. The function will revert back to the default language if the API has no translation available.
 
 ## Interface translations
 
-SRS use [FormatJS](https://formatjs.io/) as a library for translating the interface. If you haven't used it before, we recommend reading it's [documentation](https://formatjs.io/docs/getting-started/application-workflow).
+SRS uses [FormatJS](https://formatjs.io/) as a library for translating the interface. We recommend reading its [documentation](https://formatjs.io/docs/getting-started/application-workflow) if you haven't used it before.
 
-Translation sources are located at `locale` directory. Please note: SRS use full language code names to differentiate between language dialects (eg. `en-US` and `en-UK`).
+Translation sources are located in the `locale` directory. Please note that SRS uses full language code names to differentiate between language dialects (e.g., en-US and `en-UK`).
 
 ### Adding new languages
 
@@ -25,7 +25,7 @@ Translation sources are located at `locale` directory. Please note: SRS use full
 
 ### Translation management
 
-Instead of editing file by hand, we recommend using translation platforms like:
+Instead of editing files manually, we recommend using translation platforms like:
 
 - [Transifex](https://www.transifex.com/)
 - [POEditor](https://poeditor.com/)


### PR DESCRIPTION
- use pnpm instead of npm in the readme
- add new docs:
  - configuration page (how to configure API endpoint, channels)
  - how to manage translations