### PR TITLE
Fix missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dotenv-cli": "^5.1.0",
     "editorjs-blocks-react-renderer": "^1.2.4",
     "graphql": "16.3.0",
+    "graphql-tag": "^2.12.6",
     "next": "12.1.4",
     "next-seo": "^5.3.0",
     "next-sitemap": "^2.4.3",
@@ -79,6 +80,15 @@
     "react-use": "^17.3.2",
     "tailwindcss": "3.0.23",
     "typescript": "4.6.3"
+  },
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "react": "18",
+        "react-dom": "18",
+        "graphql": "16"
+      }
+    }
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --cache --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,7 @@ specifiers:
   eslint-plugin-react-hooks: ^4.3.0
   eslint-plugin-simple-import-sort: ^7.0.0
   graphql: 16.3.0
+  graphql-tag: ^2.12.6
   husky: ^7.0.4
   next: 12.1.4
   next-seo: ^5.3.0
@@ -76,6 +77,7 @@ dependencies:
   dotenv-cli: 5.1.0
   editorjs-blocks-react-renderer: 1.2.4_react-dom@18.0.0+react@18.0.0
   graphql: 16.3.0
+  graphql-tag: 2.12.6_graphql@16.3.0
   next: 12.1.4_react-dom@18.0.0+react@18.0.0
   next-seo: 5.3.0_c0abbb53577d424fe320649841fdc7d4
   next-sitemap: 2.4.3_next@12.1.4
@@ -94,7 +96,7 @@ devDependencies:
   '@graphql-codegen/introspection': 2.1.1_graphql@16.3.0
   '@graphql-codegen/typescript': 2.4.8_graphql@16.3.0
   '@graphql-codegen/typescript-operations': 2.3.5_graphql@16.3.0
-  '@graphql-codegen/typescript-react-apollo': 3.2.11_graphql@16.3.0
+  '@graphql-codegen/typescript-react-apollo': 3.2.11_e20029557891e0afb887c44ec7f516f8
   '@next/bundle-analyzer': 12.1.4
   '@types/qs': 6.9.7
   '@types/react': 17.0.43
@@ -129,9 +131,9 @@ packages:
   /@apollo/client/3.5.10_graphql@16.3.0+react@18.0.0:
     resolution: {integrity: sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
       graphql-ws: ^5.5.5
-      react: ^16.8.0 || ^17.0.0
+      react: ^16.8.0 || ^17.0.0 || 18
       subscriptions-transport-ws: ^0.9.0 || ^0.11.0
     peerDependenciesMeta:
       graphql-ws:
@@ -865,7 +867,7 @@ packages:
   /@graphql-codegen/add/3.1.1_graphql@16.3.0:
     resolution: {integrity: sha512-XkVwcqosa0CVBlL1HaQT0gp+EUfhuQE3LzrEpzMQLwchxaj/NPVYtOJL6MUHaYDsHzLqxWrufjfbeB3y2NQgRw==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       graphql: 16.3.0
@@ -876,7 +878,7 @@ packages:
     resolution: {integrity: sha512-UO75msoVgvLEvfjCezM09cQQqp32+mR8Ma1ACsBpr7nroFvHbgcu2ulx1cMovg4sxDBCsvd9Eq/xOOMpARUxtw==}
     hasBin: true
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/core': 2.5.1_graphql@16.3.0
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
@@ -932,7 +934,7 @@ packages:
   /@graphql-codegen/core/2.5.1_graphql@16.3.0:
     resolution: {integrity: sha512-alctBVl2hMnBXDLwkgmnFPrZVIiBDsWJSmxJcM4GKg1PB23+xuov35GE47YAyAhQItE1B1fbYnbb1PtGiDZ4LA==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       '@graphql-tools/schema': 8.3.1_graphql@16.3.0
@@ -944,7 +946,7 @@ packages:
   /@graphql-codegen/introspection/2.1.1_graphql@16.3.0:
     resolution: {integrity: sha512-O9zsy0IoFYDo37pBVF4pSvRMDx/AKdgOxyko4R/O+0DHEw9Nya/pQ3dbn+LDLj2n6X+xOXUBUfFvqhODTqU28w==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       graphql: 16.3.0
@@ -954,7 +956,7 @@ packages:
   /@graphql-codegen/plugin-helpers/2.4.1_graphql@16.3.0:
     resolution: {integrity: sha512-OPMma7aUnES3Dh+M0BfiNBnJLmYuH60EnbULAhufxFDn/Y2OA0Ht/LQok9beX6VN4ASZEMCOAGItJezGJr5DJw==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16 || 16 || 16 || 16 || 16 || 16 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       change-case-all: 1.0.14
@@ -967,7 +969,7 @@ packages:
   /@graphql-codegen/schema-ast/2.4.1_graphql@16.3.0:
     resolution: {integrity: sha512-bIWlKk/ShoVJfghA4Rt1OWnd34/dQmZM/vAe6fu6QKyOh44aAdqPtYQ2dbTyFXoknmu504etKJGEDllYNUJRfg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -978,7 +980,7 @@ packages:
   /@graphql-codegen/typescript-apollo-client-helpers/2.1.15_graphql@16.3.0:
     resolution: {integrity: sha512-XXv54LXJX1Nf51BgGS8kZ2kDeWuqdmPnXHRxOFD51vRy2brpOFML/lzSt4sW1Fwv7EBvcRI02be0sPN9ObwLgg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       '@graphql-codegen/visitor-plugin-common': 2.7.4_graphql@16.3.0
@@ -994,7 +996,7 @@ packages:
   /@graphql-codegen/typescript-operations/2.3.5_graphql@16.3.0:
     resolution: {integrity: sha512-GCZQW+O+cIF62ioPkQMoSJGzjJhtr7ttZGJOAoN/Q/oolG8ph9jNFePKO67tSQ/POAs5HLqfat4kAlCK8OPV3Q==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       '@graphql-codegen/typescript': 2.4.8_graphql@16.3.0
@@ -1007,10 +1009,10 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-codegen/typescript-react-apollo/3.2.11_graphql@16.3.0:
+  /@graphql-codegen/typescript-react-apollo/3.2.11_e20029557891e0afb887c44ec7f516f8:
     resolution: {integrity: sha512-Bfo7/OprnWk/srhA/3I0cKySg/SyVPX3ZoxzTk6ChYVBsy69jKDkdPWwlmE7Fjfv7+5G+xXb99OoqUUgBLma3w==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
       graphql-tag: ^2.0.0
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
@@ -1018,6 +1020,7 @@ packages:
       auto-bind: 4.0.0
       change-case-all: 1.0.14
       graphql: 16.3.0
+      graphql-tag: 2.12.6_graphql@16.3.0
       tslib: 2.3.1
     transitivePeerDependencies:
       - encoding
@@ -1027,7 +1030,7 @@ packages:
   /@graphql-codegen/typescript/2.4.8_graphql@16.3.0:
     resolution: {integrity: sha512-tVsHIkuyenBany7c5IMU1yi4S1er2hgyXJGNY7PcyhpJMx0eChmbqz1VTiZxDEwi8mDBS2mn3TaSJMh6xuJM5g==}
     peerDependencies:
-      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       '@graphql-codegen/schema-ast': 2.4.1_graphql@16.3.0
@@ -1043,7 +1046,7 @@ packages:
   /@graphql-codegen/visitor-plugin-common/2.7.4_graphql@16.3.0:
     resolution: {integrity: sha512-aaDoEudDD+B7DK/UwDSL2Fzej75N9hNJ3N8FQuTIeDyw6FNGWUxmkjVBLQGlzfnYfK8IYkdfYkrPn3Skq0pVxA==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16 || 16 || 16 || 16
     dependencies:
       '@graphql-codegen/plugin-helpers': 2.4.1_graphql@16.3.0
       '@graphql-tools/optimize': 1.2.0_graphql@16.3.0
@@ -1063,7 +1066,7 @@ packages:
   /@graphql-tools/apollo-engine-loader/7.2.2_graphql@16.3.0:
     resolution: {integrity: sha512-jrtA1IvgbaHzla9nyBngNyvajudTcQAVE3//mgrK+DoN7UpUhtoXfxTOOq2tzZN67o4a6Bv/RJsxB3rSI3NLzg==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       cross-undici-fetch: 0.1.24
@@ -1077,7 +1080,7 @@ packages:
   /@graphql-tools/batch-execute/8.3.1_graphql@16.3.0:
     resolution: {integrity: sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       dataloader: 2.0.0
@@ -1089,7 +1092,7 @@ packages:
   /@graphql-tools/code-file-loader/7.2.3_graphql@16.3.0:
     resolution: {integrity: sha512-aNVG3/VG5cUpS389rpCum+z7RY98qvPwOzd+J4LVr+f5hWQbDREnSFM+5RVTDfULujrsi7edKaGxGKp68pGmAA==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/graphql-tag-pluck': 7.1.5_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1104,7 +1107,7 @@ packages:
   /@graphql-tools/delegate/8.5.0_graphql@16.3.0:
     resolution: {integrity: sha512-P2LLahWpv8eFrqXQi9v/NDLxLBKAugd3rmB8lxeTnCqma19ZM/VaSpvGAgGyjjHKQe097mAeBEkM/7uYbG/NFg==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/batch-execute': 8.3.1_graphql@16.3.0
       '@graphql-tools/schema': 8.3.1_graphql@16.3.0
@@ -1119,7 +1122,7 @@ packages:
   /@graphql-tools/git-loader/7.1.2_graphql@16.3.0:
     resolution: {integrity: sha512-vIMrISQPKQgHS893b8K/pEE1InPV+7etzFhHoyQRhYkVHXP2RBkfI64Wq9bNPezF8Ss/dwIjI/keLaPp9EQDmA==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/graphql-tag-pluck': 7.1.5_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1135,7 +1138,7 @@ packages:
   /@graphql-tools/github-loader/7.2.3_graphql@16.3.0:
     resolution: {integrity: sha512-enbMT5lWtKaLGw0PB9RL9Xg/oc9y89e6ihuxD/ZnnNXo60J1JVNtTy3+gRgXvGOX9WtJgy3UDVudDefrOHsqaA==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/graphql-tag-pluck': 7.1.5_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1151,7 +1154,7 @@ packages:
   /@graphql-tools/graphql-file-loader/7.3.3_graphql@16.3.0:
     resolution: {integrity: sha512-6kUJZiNpYKVhum9E5wfl5PyLLupEDYdH7c8l6oMrk6c7EPEVs6iSUyB7yQoWrtJccJLULBW2CRQ5IHp5JYK0mA==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/import': 6.6.5_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1164,7 +1167,7 @@ packages:
   /@graphql-tools/graphql-tag-pluck/7.1.5_graphql@16.3.0:
     resolution: {integrity: sha512-NKbFcjlg7cbK+scLXc6eVxXIhX4k8QL6lZ/y5Ju7yrpIN18k2vA78dI6W3Qb5qdftxbDNuC+kDmScZfzzxVPjQ==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16 || 16 || 16
     dependencies:
       '@babel/parser': 7.17.3
       '@babel/traverse': 7.17.3
@@ -1179,7 +1182,7 @@ packages:
   /@graphql-tools/import/6.6.5_graphql@16.3.0:
     resolution: {integrity: sha512-w0/cYuhrr2apn+iGoTToCqt65x2NN2iHQyqRNk/Zw1NJ+e8/C3eKVw0jmW4pYQvSocuPxL4UCSI56SdKO7m3+Q==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       graphql: 16.3.0
@@ -1190,7 +1193,7 @@ packages:
   /@graphql-tools/json-file-loader/7.3.3_graphql@16.3.0:
     resolution: {integrity: sha512-CN2Qk9rt+Gepa3rb3X/mpxYA5MIYLwZBPj2Njw6lbZ6AaxG+O1ArDCL5ACoiWiBimn1FCOM778uhRM9znd0b3Q==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       globby: 11.1.0
@@ -1202,7 +1205,7 @@ packages:
   /@graphql-tools/load/7.5.1_graphql@16.3.0:
     resolution: {integrity: sha512-j9XcLYZPZdl/TzzqA83qveJmwcCxgGizt5L1+C1/Z68brTEmQHLdQCOR3Ma3ewESJt6DU05kSTu2raKaunkjRg==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/schema': 8.3.1_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1214,7 +1217,7 @@ packages:
   /@graphql-tools/merge/8.2.2_graphql@16.3.0:
     resolution: {integrity: sha512-2DyqhIOMUMKbCPqo8p6xSdll2OBcBxGdOrxlJJlFQvinsSaYqp/ct3dhAxNtzaIcvSVgXvttQqfD7O2ziFtE7Q==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       graphql: 16.3.0
@@ -1224,7 +1227,7 @@ packages:
   /@graphql-tools/optimize/1.2.0_graphql@16.3.0:
     resolution: {integrity: sha512-l0PTqgHeorQdeOizUor6RB49eOAng9+abSxiC5/aHRo6hMmXVaqv5eqndlmxCpx9BkgNb3URQbK+ZZHVktkP/g==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       graphql: 16.3.0
       tslib: 2.3.1
@@ -1232,7 +1235,7 @@ packages:
   /@graphql-tools/prisma-loader/7.1.1_graphql@16.3.0:
     resolution: {integrity: sha512-9hVpG3BNsXAYMLPlZhSHubk6qBmiHLo/UlU0ldL100sMpqI46iBaHNhTNXZCSdd81hT+4HNqaDXNFqyKJ22OGQ==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/url-loader': 7.7.1_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1266,7 +1269,7 @@ packages:
   /@graphql-tools/relay-operation-optimizer/6.4.1_graphql@16.3.0:
     resolution: {integrity: sha512-2b9D5L+31sIBnvmcmIW5tfvNUV+nJFtbHpUyarTRDmFT6EZ2cXo4WZMm9XJcHQD/Z5qvMXfPHxzQ3/JUs4xI+w==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
       graphql: 16.3.0
@@ -1279,7 +1282,7 @@ packages:
   /@graphql-tools/schema/8.3.1_graphql@16.3.0:
     resolution: {integrity: sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16 || 16
     dependencies:
       '@graphql-tools/merge': 8.2.2_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1291,7 +1294,7 @@ packages:
   /@graphql-tools/url-loader/7.7.1_graphql@16.3.0:
     resolution: {integrity: sha512-K/5amdeHtKYI976HVd/AXdSNvLL7vx5QVjMlwN0OHeYyxSgC+UOH+KkS7cshYgL13SekGu0Mxbg9ABfgQ34ECA==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/delegate': 8.5.0_graphql@16.3.0
       '@graphql-tools/utils': 8.6.1_graphql@16.3.0
@@ -1323,7 +1326,7 @@ packages:
   /@graphql-tools/utils/8.6.1_graphql@16.3.0:
     resolution: {integrity: sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16 || 16
     dependencies:
       graphql: 16.3.0
       tslib: 2.3.1
@@ -1331,7 +1334,7 @@ packages:
   /@graphql-tools/wrap/8.4.0_graphql@16.3.0:
     resolution: {integrity: sha512-fPB3+UnxLIPWDfMvAfBQnGmm8rrejeQjmCy7h9avWHBbkEELcvtrSWnKAvoKowe+WR9PVDM15XQ/PQvcddV0kQ==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@graphql-tools/delegate': 8.5.0_graphql@16.3.0
       '@graphql-tools/schema': 8.3.1_graphql@16.3.0
@@ -1344,7 +1347,7 @@ packages:
   /@graphql-typed-document-node/core/3.1.1_graphql@16.3.0:
     resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       graphql: 16.3.0
     dev: false
@@ -1353,8 +1356,8 @@ packages:
     resolution: {integrity: sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^16 || ^17 || ^18
-      react-dom: ^16 || ^17 || ^18
+      react: ^16 || ^17 || ^18 || 18
+      react-dom: ^16 || ^17 || ^18 || 18
     dependencies:
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1363,7 +1366,7 @@ packages:
   /@heroicons/react/1.0.5_react@18.0.0:
     resolution: {integrity: sha512-UDMyLM2KavIu2vlWfMspapw9yii7aoLwzI2Hudx4fyoPwfKfxU8r3cL8dEBXOjcLG0/oOONZzbT14M1HoNtEcg==}
     peerDependencies:
-      react: '>= 16'
+      react: '>= 16 || 18'
     dependencies:
       react: 18.0.0
     dev: false
@@ -1403,7 +1406,7 @@ packages:
   /@n1ru4l/graphql-live-query/0.9.0_graphql@16.3.0:
     resolution: {integrity: sha512-BTpWy1e+FxN82RnLz4x1+JcEewVdfmUhV1C6/XYD5AjS7PQp9QFF7K8bCD6gzPTr2l+prvqOyVueQhFJxB1vfg==}
     peerDependencies:
-      graphql: ^15.4.0 || ^16.0.0
+      graphql: ^15.4.0 || ^16.0.0 || 16
     dependencies:
       graphql: 16.3.0
     dev: true
@@ -1569,8 +1572,8 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@apollo/client': ^3.3.19
-      graphql: ^15.5.0
-      react: ^16.8.0 || ^17.0.0
+      graphql: ^15.5.0 || 16
+      react: ^16.8.0 || ^17.0.0 || 18
     dependencies:
       '@apollo/client': 3.5.10_graphql@16.3.0+react@18.0.0
       cross-fetch: 3.1.5
@@ -1606,8 +1609,8 @@ packages:
     resolution: {integrity: sha512-L20v8Jq0TDZFL2+y+uXD751t6q9SalSFkSYZpmZ2VWrGZGK7HAGfRQ804dzYSSr5fGenW6iz6y7U0YKfC/TK3g==}
     peerDependencies:
       '@stripe/stripe-js': ^1.20.3
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: ^16.8.0 || ^17.0.0 || 18
+      react-dom: ^16.8.0 || ^17.0.0 || 18
     dependencies:
       '@stripe/stripe-js': 1.26.0
       prop-types: 15.8.1
@@ -2913,8 +2916,8 @@ packages:
     resolution: {integrity: sha512-oplMOLKAgMBJ/URPXDOa5pm5XAoTTAn1p+NS9AdbH+Fr2fbnTZuiYIhQdmlkXQfH+DVtPztAFtz5G54z6aDq3w==}
     engines: {node: '>=14'}
     peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
+      react: '>=16 || 18'
+      react-dom: '>=16 || 18'
     dependencies:
       html-react-parser: 1.4.8_react@18.0.0
       react: 18.0.0
@@ -3660,7 +3663,7 @@ packages:
     resolution: {integrity: sha512-Myqay6pmdcmX3KqoH+bMbeKZ1cTODpHS2CxF1ZzNnfTE+YUpGTcp01bOw6LpzamRb0T/WTYtGFbZeXGo9Hab2Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_ec5c0ebd3030a0a5109338876648df1b
       '@graphql-tools/graphql-file-loader': 7.3.3_graphql@16.3.0
@@ -3686,7 +3689,7 @@ packages:
     resolution: {integrity: sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==}
     engines: {node: ^12.22.0 || ^14.16.0 || >=16.0.0}
     peerDependencies:
-      graphql: ^15.0.0 || ^16.0.0
+      graphql: ^15.0.0 || ^16.0.0 || 16
     dependencies:
       graphql: 16.3.0
     dev: true
@@ -3694,7 +3697,7 @@ packages:
   /graphql-request/3.7.0_graphql@16.3.0:
     resolution: {integrity: sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==}
     peerDependencies:
-      graphql: 14 - 16
+      graphql: 14 - 16 || 16
     dependencies:
       cross-fetch: 3.1.5
       extract-files: 9.0.0
@@ -3708,7 +3711,7 @@ packages:
     resolution: {integrity: sha512-y2mVBN2KwNrzxX2KBncQ6kzc6JWvecxuBernrl0j65hsr6MAS3+Yn8PTFSOgRmtolxugepxveyZVQEuaNEbw3w==}
     engines: {node: '>=12'}
     peerDependencies:
-      graphql: '>=0.11 <=16'
+      graphql: '>=0.11 <=16 || 16'
     dependencies:
       graphql: 16.3.0
     dev: true
@@ -3717,7 +3720,7 @@ packages:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
     peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || 16
     dependencies:
       graphql: 16.3.0
       tslib: 2.3.1
@@ -3726,7 +3729,7 @@ packages:
     resolution: {integrity: sha512-Kz/4z1u9yGKWMtzlvia9wW8AJGjx68OyCCV40dabYq1OeyUxgU9t8Ll43vLAje7TYiLwZSwGbvtHviHaPyGYxw==}
     engines: {node: '>=10'}
     peerDependencies:
-      graphql: '>=0.11 <=16'
+      graphql: '>=0.11 <=16 || 16'
     dependencies:
       graphql: 16.3.0
     dev: true
@@ -3801,7 +3804,7 @@ packages:
   /html-react-parser/1.4.8_react@18.0.0:
     resolution: {integrity: sha512-5XsBdFVhJLxdtRp7tWwZ6DwqOt6fJ+2lJc0lctwjX1yaxWNB41S5uzqii7vJcSCaabM+CK28U75e5f4wIMqdSg==}
     peerDependencies:
-      react: 0.14 || 15 || 16 || 17
+      react: 0.14 || 15 || 16 || 17 || 18
     dependencies:
       domhandler: 4.3.0
       html-dom-parser: 1.1.0
@@ -4648,8 +4651,8 @@ packages:
     resolution: {integrity: sha512-ofXUGGZ4l6j4oCxu6aecTWTkNbN/g+zbYUOvLRBKl96bJrt+WWyo4riRxQqqczvk1niGH4ibN7cCEwVjlYZs2g==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
+      react: '>=16.0.0 || 18'
+      react-dom: '>=16.0.0 || 18'
     dependencies:
       next: 12.1.4_react-dom@18.0.0+react@18.0.0
       react: 18.0.0
@@ -4687,8 +4690,8 @@ packages:
     peerDependencies:
       fibers: '>= 3.1.0'
       node-sass: ^6.0.0 || ^7.0.0
-      react: ^17.0.2 || ^18.0.0-0
-      react-dom: ^17.0.2 || ^18.0.0-0
+      react: ^17.0.2 || ^18.0.0-0 || 18
+      react-dom: ^17.0.2 || ^18.0.0-0 || 18
       sass: ^1.3.0
     peerDependenciesMeta:
       fibers:
@@ -5186,7 +5189,7 @@ packages:
   /react-dom/18.0.0_react@18.0.0:
     resolution: {integrity: sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==}
     peerDependencies:
-      react: ^18.0.0
+      react: ^18.0.0 || 18
     dependencies:
       loose-envify: 1.4.0
       react: 18.0.0
@@ -5197,7 +5200,7 @@ packages:
     resolution: {integrity: sha512-NcJqWRF6el5HMW30fqZRt27s+lorvlCCDbTpAyHoodQeYWXgQCvZJJQLC1kRMKdrJknVH0NIg3At6TUzlZJFOQ==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
+      react: ^16.8.0 || ^17 || ^18 || 18
     dependencies:
       react: 18.0.0
     dev: false
@@ -5205,7 +5208,7 @@ packages:
   /react-intl/5.24.6_react@18.0.0+typescript@4.6.3:
     resolution: {integrity: sha512-6gUhQwNAeAoRpN6F3N+bR66aot/mI6yduRwQS5ajfmXHX/YFvOfINkgMFTTrcbf3+qjBhACNU3ek4wFt6cn2ww==}
     peerDependencies:
-      react: ^16.3.0 || 17
+      react: ^16.3.0 || 17 || 18
       typescript: ^4.5
     peerDependenciesMeta:
       typescript:
@@ -5245,8 +5248,8 @@ packages:
   /react-use/17.3.2_react-dom@18.0.0+react@18.0.0:
     resolution: {integrity: sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==}
     peerDependencies:
-      react: ^16.8.0  || ^17.0.0
-      react-dom: ^16.8.0  || ^17.0.0
+      react: ^16.8.0  || ^17.0.0 || 18
+      react-dom: ^16.8.0  || ^17.0.0 || 18
     dependencies:
       '@types/js-cookie': 2.2.7
       '@xobotyi/scrollbar-width': 1.9.5
@@ -5323,7 +5326,7 @@ packages:
     resolution: {integrity: sha512-SWqeSQZ+AMU/Cr7iZsHi1e78Z7oh00I5SvR092iCJq79aupqJ6Ds+I1Pz/Vzo5uY5PY0jvC4rBJXzlIN5g9boQ==}
     hasBin: true
     peerDependencies:
-      graphql: ^15.0.0
+      graphql: ^15.0.0 || 16
     dependencies:
       '@babel/core': 7.17.5
       '@babel/generator': 7.17.3
@@ -5757,7 +5760,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
       babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || 18'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -5774,7 +5777,7 @@ packages:
   /subscriptions-transport-ws/0.11.0_graphql@16.3.0:
     resolution: {integrity: sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==}
     peerDependencies:
-      graphql: ^15.7.2 || ^16.0.0
+      graphql: ^15.7.2 || ^16.0.0 || 16
     dependencies:
       backo2: 1.0.2
       eventemitter3: 3.1.2


### PR DESCRIPTION
The latest version of the pnpm throws an error if there are issues with unmet dependencies/wrong version used. 
Submitted patch adds missing graphql-tag dependency and whitelist react 18 and graphql 16 as valid packages.

PNPM docs: https://pnpm.io/errors#err_pnpm_peer_dep_issues