### PR TITLE
cleanup in tests

### DIFF
--- a/cypress/e2e/filteringProducts.cy.ts
+++ b/cypress/e2e/filteringProducts.cy.ts
@@ -2,7 +2,7 @@ import { CATEGORY } from "../elements/category";
 import { NAVIGATION } from "../elements/navigation";
 import { filterProducts, sortingProductsByName } from "../support/pages/category";
 import { selectNotEmptyCategory } from "../support/pages/main-page";
-import { waitForProgressBarToNotBeVisible } from "../support/shared";
+import { waitForProgressBarToNotBeVisible } from "../support/shared-operations";
 
 describe("Using filters and sorting on products list", () => {
   const sortByList = ["Name descending", "Name ascending"];

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -5,16 +5,15 @@ import { productsToSearch } from "../fixtures/search";
 import { navigateAndSearch } from "../support/pages/search";
 
 describe("Search for products", () => {
-  let typedText;
-
   beforeEach(() => {
     cy.visit("/");
   });
 
   it("should search for products SRS_0405", () => {
-    typedText = productsToSearch.polo;
-    navigateAndSearch(typedText);
-    cy.url().should("include", `/search?q=${typedText}`);
+    const searchQuery = productsToSearch.polo;
+
+    navigateAndSearch(searchQuery);
+    cy.url().should("include", `/search?q=${searchQuery}`);
   });
 
   it("should see no errors on search page SRS_0404", () => {
@@ -27,8 +26,9 @@ describe("Search for products", () => {
   });
 
   it("should see no results message SRS_0405", () => {
-    typedText = productsToSearch.nonExistingProduct;
-    navigateAndSearch(typedText);
+    const searchQuery = productsToSearch.nonExistingProduct;
+
+    navigateAndSearch(searchQuery);
     cy.get(SEARCH_PAGE_SELECTORS.noResultsText)
       .should("contain", productsToSearch.noProductsInfo)
       .get(SHARED_ELEMENTS.productsList)

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1,15 +1,16 @@
 import { NAVIGATION } from "../elements/navigation";
 import { SEARCH_PAGE_SELECTORS } from "../elements/search-page";
-import { SHARED } from "../elements/shared";
+import { SHARED_ELEMENTS } from "../elements/shared-elements";
 import { productsToSearch } from "../fixtures/search";
 import { navigateAndSearch } from "../support/pages/search";
 
-let typedText;
-
 describe("Search for products", () => {
+  let typedText;
+
   beforeEach(() => {
     cy.visit("/");
   });
+
   it("should search for products SRS_0405", () => {
     typedText = productsToSearch.polo;
     navigateAndSearch(typedText);
@@ -21,7 +22,7 @@ describe("Search for products", () => {
       .click()
       .url()
       .should("include", "/search")
-      .get(SHARED.productsList)
+      .get(SHARED_ELEMENTS.productsList)
       .should("be.visible");
   });
 
@@ -30,7 +31,7 @@ describe("Search for products", () => {
     navigateAndSearch(typedText);
     cy.get(SEARCH_PAGE_SELECTORS.noResultsText)
       .should("contain", productsToSearch.noProductsInfo)
-      .get(SHARED.productsList)
+      .get(SHARED_ELEMENTS.productsList)
       .should("not.exist");
   });
 });

--- a/cypress/elements/search-page.ts
+++ b/cypress/elements/search-page.ts
@@ -1,4 +1,4 @@
 export const SEARCH_PAGE_SELECTORS = {
-  searchInput: "[data-testid=searchInput]",
-  noResultsText: "[data-testid=noResultsText]",
+  searchInput: "[data-testid='searchInput']",
+  noResultsText: "[data-testid='noResultsText']",
 };

--- a/cypress/elements/shared-elements.ts
+++ b/cypress/elements/shared-elements.ts
@@ -1,4 +1,4 @@
-export const SHARED = {
+export const SHARED_ELEMENTS = {
   spinner: "[data-testid='spinner']",
   productsList: "[data-testid='productsList']",
   productName: "[data-testid*='productName']",

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -3,6 +3,7 @@
 Cypress.Commands.add("addAliasToGraphRequest", (operationName) => {
   cy.intercept("POST", Cypress.env("API_URL"), (req) => {
     const requestBody = req.body;
+
     if (Array.isArray(requestBody)) {
       requestBody.forEach((element) => {
         if (element.operationName === operationName) {

--- a/cypress/support/pages/category.ts
+++ b/cypress/support/pages/category.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { CATEGORY } from "../../elements/category";
-import { SHARED } from "../../elements/shared";
+import { SHARED_ELEMENTS } from "../../elements/shared-elements";
 
 export function filterProducts(filterProductsBy, selectedFilter) {
   cy.addAliasToGraphRequest("ProductCollection");
@@ -18,7 +18,7 @@ export function filterProducts(filterProductsBy, selectedFilter) {
 }
 
 export function getListOfProducts(productsArray) {
-  cy.get(SHARED.productName).each(($listOfProducts) => {
+  cy.get(SHARED_ELEMENTS.productName).each(($listOfProducts) => {
     cy.wrap($listOfProducts)
       .invoke("text")
       .then((productsNames) => {
@@ -43,7 +43,7 @@ export function sortingProductsByName(sortOrder: string) {
   cy.then(() => {
     listOfProductsNames = listOfProductsNames.sort();
     if (sortOrder === "Name descending") {
-      listOfProductsNames = listOfProductsNames.sort().reverse();
+      listOfProductsNames = listOfProductsNames.reverse();
     }
     expect(
       JSON.stringify(listOfProductsNames) === JSON.stringify(sortedListOfProducts)

--- a/cypress/support/pages/main-page.ts
+++ b/cypress/support/pages/main-page.ts
@@ -1,11 +1,11 @@
 import { CATEGORY } from "../../elements/category";
 import { MAIN_PAGE } from "../../elements/main-page";
 import { NAVIGATION } from "../../elements/navigation";
-import { SHARED } from "../../elements/shared";
+import { SHARED_ELEMENTS } from "../../elements/shared-elements";
 
 export function selectNotEmptyCategory() {
   cy.get(MAIN_PAGE.categorySection)
-    .find(SHARED.productsList)
+    .find(SHARED_ELEMENTS.productsList)
     .first()
     .parents(MAIN_PAGE.categorySection)
     .children(MAIN_PAGE.categoryName)

--- a/cypress/support/shared-operations.ts
+++ b/cypress/support/shared-operations.ts
@@ -1,0 +1,5 @@
+import { SHARED_ELEMENTS } from "../elements/shared-elements";
+
+export function waitForProgressBarToNotBeVisible() {
+  cy.get(SHARED_ELEMENTS.spinner).should("not.exist");
+}

--- a/cypress/support/shared.ts
+++ b/cypress/support/shared.ts
@@ -1,5 +1,0 @@
-import { SHARED } from "../elements/shared";
-
-export function waitForProgressBarToNotBeVisible() {
-  cy.get(SHARED.spinner).should("not.exist");
-}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "lint": "prettier --write . && next lint --fix",
     "generate": "dotenv -c -- graphql-codegen --config codegen.yml -w",
     "paths": "pathpida --ignorePath .gitignore",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "cy:run": "cypress run",
+    "cy:open": "cypress open"
   },
   "dependencies": {
     "@apollo/client": "3.5.10",


### PR DESCRIPTION
- adding `' '` characters at `data-testid` selectors,
- adding empty lines between variables, 
- changing names of the files `shared` -> `shared-elements` and `shared` -> `shared-operations`
- adding scripts `cy:run` and `cy:open`