### PR TITLE
Lock pnpm version in Dockerfile to 7.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 #cypress
 cypress/screenshots
 cypress/videos
+
+.idea/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:16
 WORKDIR /app
 
 # Setup pnpm package manager
-RUN npm install -g pnpm@7.6.0
+RUN npm install -g pnpm@7.5.2
 
 # Setup proxy to API used in saleor-platform
 RUN apt-get update && apt-get install -y nginx

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:16
 WORKDIR /app
 
 # Setup pnpm package manager
-RUN npm install -g pnpm
+RUN npm install -g pnpm@7.6.0
 
 # Setup proxy to API used in saleor-platform
 RUN apt-get update && apt-get install -y nginx


### PR DESCRIPTION
In the future this should prevent unexpected behavior, when image is downloading newer version than we tested with