### PR TITLE
Fix invariant errors in API routes for TEST_* vars

### DIFF
--- a/apps/saleor-app-checkout/.env
+++ b/apps/saleor-app-checkout/.env
@@ -1,3 +1,14 @@
 NEXT_PUBLIC_SALEOR_API_URL=$SALEOR_API_URL
 NEXT_PUBLIC_CHECKOUT_APP_URL=$CHECKOUT_APP_URL
-SALEOR_APP_TOKEN=
+
+# Default values for tests
+# They will work only when replaying requests with Polly.js
+# To record new requests, use real credentials in .env.local
+TEST_MOLLIE_KEY=mollie_test_key
+TEST_MOLLIE_PROFILE_ID=mollie_profile_id
+TEST_ADYEN_MERCHANT_ACCOUNT=Saleor
+TEST_ADYEN_CLIENT_KEY=adyen_test_client_key
+TEST_ADYEN_API_KEY=adyen_test_api_key
+TEST_ADYEN_HMAC=adyen_hmac
+TEST_ADYEN_WEBHOOK_PASSWORD=adyen_webhook_password
+TEST_ADYEN_WEBHOOK_USERNAME=adyen_webhook_username

--- a/apps/saleor-app-checkout/.env.template
+++ b/apps/saleor-app-checkout/.env.template
@@ -1,11 +1,13 @@
-NEXT_PUBLIC_SALEOR_API_URL=https://master.staging.saleor.cloud/graphql/
-SALEOR_APP_TOKEN=
-SETTINGS_ENCRYPTION_SECRET=development-key
-TEST_MOLLIE_KEY
-TEST_MOLLIE_PROFILE_ID
-TEST_ADYEN_MERCHANT_ACCOUNT
-TEST_ADYEN_CLIENT_KEY
-TEST_ADYEN_API_KEY
-TEST_ADYEN_HMAC
-TEST_ADYEN_WEBHOOK_PASSWORD
-TEST_ADYEN_WEBHOOK_USERNAME
+# URL used when app is running locally with `saleor app tunnel`
+DEBUG_APP_URL=https://saleor-checkout-my-account.saleor
+
+# Variables used for recording tests.
+# Refer to ../../docs/vercel.md (Vercel deployment guide) on how to get those variables
+TEST_MOLLIE_KEY=
+TEST_MOLLIE_PROFILE_ID=
+TEST_ADYEN_MERCHANT_ACCOUNT=
+TEST_ADYEN_CLIENT_KEY=
+TEST_ADYEN_API_KEY=
+TEST_ADYEN_HMAC=
+TEST_ADYEN_WEBHOOK_PASSWORD=
+TEST_ADYEN_WEBHOOK_USERNAME=

--- a/apps/saleor-app-checkout/backend/environment.ts
+++ b/apps/saleor-app-checkout/backend/environment.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
-import { envVars, serverEnvVars } from "../constants";
+import { envVars, serverEnvVars, IS_TEST } from "../constants";
 import { AppDocument, AppQuery, AppQueryVariables } from "../graphql";
-import { IS_TEST } from "../test-utils";
 import { getClient } from "./client";
 
 const maskToken = (token: string) => "*".repeat(Math.max(token.length - 4, 0)) + token.slice(-4);

--- a/apps/saleor-app-checkout/constants.ts
+++ b/apps/saleor-app-checkout/constants.ts
@@ -37,4 +37,4 @@ export const debugEnvVars: DebugEnvVars | null =
       appUrl: process.env.DEBUG_APP_URL,
     };
 
-export const IS_TEST = typeof jest !== "undefined";
+export const IS_TEST = process.env.NODE_ENV === 'test';

--- a/apps/saleor-app-checkout/constants.ts
+++ b/apps/saleor-app-checkout/constants.ts
@@ -36,3 +36,5 @@ export const debugEnvVars: DebugEnvVars | null =
     : {
       appUrl: process.env.DEBUG_APP_URL,
     };
+
+export const IS_TEST = typeof jest !== "undefined";

--- a/apps/saleor-app-checkout/mocks/consts.ts
+++ b/apps/saleor-app-checkout/mocks/consts.ts
@@ -5,20 +5,24 @@ export const testingVars = {
   mollieKey: process.env.TEST_MOLLIE_KEY!,
   mollieProfileId: process.env.TEST_MOLLIE_PROFILE_ID!,
 
-  adyenMarchantAccount: process.env.TEST_ADYEN_MERCHANT_ACCOUNT ?? "",
-  adyenClientKey: process.env.TEST_ADYEN_CLIENT_KEY ?? "",
-  adyenApiKey: process.env.TEST_ADYEN_API_KEY ?? "",
-  adyenHmac: process.env.TEST_ADYEN_HMAC ?? "",
-  adyenWebhookPassword: process.env.TEST_ADYEN_WEBHOOK_PASSWORD ?? "",
-  adyenWebhookUsername: process.env.TEST_ADYEN_WEBHOOK_USERNAME ?? "",
+  adyenMerchantAccount: process.env.TEST_ADYEN_MERCHANT_ACCOUNT!,
+  adyenClientKey: process.env.TEST_ADYEN_CLIENT_KEY!,
+  adyenApiKey: process.env.TEST_ADYEN_API_KEY!,
+  adyenHmac: process.env.TEST_ADYEN_HMAC!,
+  adyenWebhookPassword: process.env.TEST_ADYEN_WEBHOOK_PASSWORD!,
+  adyenWebhookUsername: process.env.TEST_ADYEN_WEBHOOK_USERNAME!,
 };
 
 if (IS_TEST) {
   invariant(testingVars.mollieKey, "TEST_MOLLIE_KEY is not defined");
-  invariant(
-    testingVars.mollieProfileId,
-    "TEST_MOLLIE_PROFILE_ID is not defined"
-  );
+  invariant(testingVars.mollieProfileId,"TEST_MOLLIE_PROFILE_ID is not defined");
+
+  invariant(testingVars.adyenMerchantAccount, "TEST_ADYEN_MERCHANT_ACCOUNT is not defined")
+  invariant(testingVars.adyenClientKey, "TEST_ADYEN_CLIENT_KEY is not defined")
+  invariant(testingVars.adyenApiKey, "TEST_ADYEN_API_KEY is not defined")
+  invariant(testingVars.adyenHmac, "TEST_ADYEN_HMAC is not defined")
+  invariant(testingVars.adyenWebhookPassword, "TEST_ADYEN_WEBHOOK_PASSWORD is not defined")
+  invariant(testingVars.adyenWebhookUsername, "TEST_ADYEN_WEBHOOK_USERNAME is not defined")
 }
 
 export type TestingEnvVar = keyof typeof testingVars;

--- a/apps/saleor-app-checkout/mocks/consts.ts
+++ b/apps/saleor-app-checkout/mocks/consts.ts
@@ -1,6 +1,9 @@
+import invariant from "ts-invariant";
+import { IS_TEST } from "../constants";
+
 export const testingVars = {
-  mollieKey: process.env.TEST_MOLLIE_KEY,
-  mollieProfileId: process.env.TEST_MOLLIE_PROFILE_ID,
+  mollieKey: process.env.TEST_MOLLIE_KEY!,
+  mollieProfileId: process.env.TEST_MOLLIE_PROFILE_ID!,
 
   adyenMarchantAccount: process.env.TEST_ADYEN_MERCHANT_ACCOUNT ?? "",
   adyenClientKey: process.env.TEST_ADYEN_CLIENT_KEY ?? "",
@@ -9,6 +12,14 @@ export const testingVars = {
   adyenWebhookPassword: process.env.TEST_ADYEN_WEBHOOK_PASSWORD ?? "",
   adyenWebhookUsername: process.env.TEST_ADYEN_WEBHOOK_USERNAME ?? "",
 };
+
+if (IS_TEST) {
+  invariant(testingVars.mollieKey, "TEST_MOLLIE_KEY is not defined");
+  invariant(
+    testingVars.mollieProfileId,
+    "TEST_MOLLIE_PROFILE_ID is not defined"
+  );
+}
 
 export type TestingEnvVar = keyof typeof testingVars;
 

--- a/apps/saleor-app-checkout/mocks/fixtures/saleor.ts
+++ b/apps/saleor-app-checkout/mocks/fixtures/saleor.ts
@@ -1,11 +1,5 @@
 import { encryptSetting } from "@/saleor-app-checkout/backend/configuration/encryption";
-import { serverEnvVars } from "@/saleor-app-checkout/constants";
-import { invariant } from "ts-invariant";
 import { testingVars } from "../consts";
-
-invariant(testingVars.mollieKey, "TEST_MOLLIE_KEY is not defined");
-invariant(testingVars.mollieProfileId, "TEST_MOLLIE_PROFILE_ID is not defined");
-invariant(serverEnvVars.settingsEncryptionSecret, "SETTINGS_ENCRYPTION_SECRET is not defined");
 
 export const paymentProviders = {
   mollie: {

--- a/apps/saleor-app-checkout/mocks/fixtures/saleor.ts
+++ b/apps/saleor-app-checkout/mocks/fixtures/saleor.ts
@@ -13,7 +13,7 @@ export const paymentProviders = {
   adyen: {
     merchantAccount: {
       encrypted: false,
-      value: testingVars.adyenMarchantAccount,
+      value: testingVars.adyenMerchantAccount,
     },
     clientKey: {
       encrypted: false,

--- a/apps/saleor-app-checkout/test-utils.ts
+++ b/apps/saleor-app-checkout/test-utils.ts
@@ -45,19 +45,35 @@ const VARIABLES_BLACKLIST = [
   "csrfToken",
 ];
 
-export const removeBlacklistedVariables = (obj: {}): {} => {
+export const removeBlacklistedVariables = (
+  obj: {} | undefined | string
+): {} | undefined | string => {
+  if (!obj || typeof obj === "string") return obj;
+
   return omitDeep(obj, ...VARIABLES_BLACKLIST);
+};
+
+const tryParse = (text: string | undefined) => {
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    return text;
+  }
 };
 
 export const setupPollyMiddleware = (server: PollyServer) => {
   // Hide sensitive data in headers or in body
   server.any().on("beforePersist", (_, recording, event) => {
-    const requestJson = JSON.parse(recording.request.postData.text);
+    console.log(recording.request.postData);
+    const requestJson = tryParse(recording.request.postData?.text);
     const requestHeaders = recording.request.headers.filter(
       (el: Record<string, string>) => !HEADERS_BLACKLIST.has(el.name)
     );
 
-    const responseJson = JSON.parse(recording.response.content.text);
+    const responseJson = tryParse(recording.response.content?.text);
     const responseHeaders = recording.response.headers.filter(
       (el: Record<string, string>) => !HEADERS_BLACKLIST.has(el.name)
     );
@@ -65,10 +81,14 @@ export const setupPollyMiddleware = (server: PollyServer) => {
     const filteredRequestJson = removeBlacklistedVariables(requestJson);
     const filteredResponseJson = removeBlacklistedVariables(responseJson);
 
-    recording.request.postData.text = JSON.stringify(filteredRequestJson);
+    if (filteredRequestJson) {
+      recording.request.postData.text = JSON.stringify(filteredRequestJson);
+    }
+    if (filteredResponseJson) {
+      recording.response.content.text = JSON.stringify(filteredResponseJson);
+    }
     recording.request.headers = requestHeaders;
     recording.response.cookies = [];
-    recording.response.content.text = JSON.stringify(filteredResponseJson);
     recording.response.headers = responseHeaders;
   });
 

--- a/apps/saleor-app-checkout/test-utils.ts
+++ b/apps/saleor-app-checkout/test-utils.ts
@@ -14,8 +14,6 @@ declare module "next" {
   } & NextApiResponse;
 }
 
-export const IS_TEST = typeof jest !== "undefined";
-
 export const mockRequest = (method: RequestMethod = "GET") => {
   const { req, res } = createMocks({ method });
   req.headers = {


### PR DESCRIPTION
Reopened PR from https://github.com/saleor/saleor-checkout/pull/189

This PR fixes saleor/react-storefront#307 issue with invariant errors caused by missing TEST_* env vars - a module that imported fixtures was used in non-testing code which caused this error
