### PR TITLE
Fix Order Confirmation failure and add OrderConfirmationSkeleton

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,10 @@ on: [pull_request]
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
     steps:
       - uses: actions/checkout@v3
 

--- a/packages/checkout-storefront/src/Root.tsx
+++ b/packages/checkout-storefront/src/Root.tsx
@@ -14,6 +14,8 @@ import { alertsContainerProps } from "./hooks/useAlerts/consts";
 import { Suspense, useMemo } from "react";
 import type { AppEnv } from "./providers/AppConfigProvider/types";
 import { CheckoutSkeleton } from "./CheckoutSkeleton";
+import { SummarySkeleton } from "./sections/Summary/SummarySkeleton";
+import { OrderConfirmationSkeleton } from "./sections/OrderConfirmation/OrderConfirmationSkeleton";
 
 export interface RootProps {
   env: AppEnv;
@@ -56,7 +58,9 @@ export const Root = ({ env }: RootProps) => {
               <ToastContainer {...alertsContainerProps} />
               <ErrorBoundary FallbackComponent={PageNotFound}>
                 {orderId ? (
-                  <OrderConfirmation orderId={orderId} />
+                  <Suspense fallback={<OrderConfirmationSkeleton />}>
+                    <OrderConfirmation orderId={orderId} />
+                  </Suspense>
                 ) : (
                   <Suspense fallback={<CheckoutSkeleton />}>
                     <Checkout />

--- a/packages/checkout-storefront/src/components/Skeleton/Skeleton.tsx
+++ b/packages/checkout-storefront/src/components/Skeleton/Skeleton.tsx
@@ -11,13 +11,11 @@ export const Skeleton: React.FC<PropsWithChildren<SkeletonProps>> = ({
   className,
   variant = "paragraph",
 }) => {
-  if (children) return <>{children}</>;
-
   const classes = clsx(
     "skeleton",
     { "h-5 mb-6": variant === "title", "h-3": variant === "paragraph" },
     className
   );
 
-  return <div className={classes} />;
+  return <div className={classes} children={children} />;
 };

--- a/packages/checkout-storefront/src/fetch/types.ts
+++ b/packages/checkout-storefront/src/fetch/types.ts
@@ -1,13 +1,14 @@
 import { ErrorCode } from "@/checkout-storefront/lib/globalTypes";
 
-export type PayResult = PaySuccessResult | PayErrorResult;
+export type PayResult = PaySuccessResult | PayErrorResult | null;
 
 export interface PayErrorResult {
-  ok?: boolean;
+  ok: false;
   errors: ErrorCode[];
 }
 
 export interface PaySuccessResult {
+  ok?: undefined;
   orderId: string;
   data: {
     paymentUrl: string;

--- a/packages/checkout-storefront/src/hooks/usePay.ts
+++ b/packages/checkout-storefront/src/hooks/usePay.ts
@@ -17,7 +17,7 @@ const getRedirectUrl = () => {
 };
 
 export const usePay = () => {
-  const [{ loading }, pay] = useFetch(payRequest, { skip: true });
+  const [{ loading, error, data }, pay] = useFetch(payRequest, { skip: true });
   const {
     env: { checkoutApiUrl },
   } = useAppConfig();
@@ -70,5 +70,5 @@ export const usePay = () => {
     return result;
   };
 
-  return { orderPay, checkoutPay, loading };
+  return { orderPay, checkoutPay, loading, error, data };
 };

--- a/packages/checkout-storefront/src/sections/OrderConfirmation/OrderConfirmationSkeleton.tsx
+++ b/packages/checkout-storefront/src/sections/OrderConfirmation/OrderConfirmationSkeleton.tsx
@@ -1,0 +1,53 @@
+import { Suspense } from "react";
+
+import PageHeader from "@/checkout-storefront/sections/PageHeader";
+import { Title } from "@/checkout-storefront/components/Title";
+import { Text } from "@saleor/ui-kit";
+import { useFormattedMessages } from "@/checkout-storefront/hooks/useFormattedMessages";
+import { Divider } from "@/checkout-storefront/components/Divider";
+import { SummarySkeleton } from "@/checkout-storefront/sections/Summary/SummarySkeleton";
+import { Skeleton } from "@/checkout-storefront/components/Skeleton";
+
+export const OrderConfirmationSkeleton = () => {
+  const formatMessage = useFormattedMessages();
+
+  return (
+    <div className="page">
+      <header className="order-header">
+        <PageHeader />
+        <Title>{formatMessage("orderConfirmationTitle", { number: "" })}</Title>
+        <Text size="md" className="max-w-[692px]">
+          {formatMessage("orderConfirmationSubtitle", {
+            email: "",
+          })}
+        </Text>
+      </header>
+      <Divider />
+      <main className="order-content overflow-hidden">
+        <div className="w-7/12">
+          <Text size="lg" weight="bold">
+            {formatMessage("paymentSection")}
+          </Text>
+          <Skeleton variant="title" className="mt-6" />
+          <Skeleton />
+          <Skeleton variant="title" />
+          <Skeleton />
+          <Skeleton variant="title" />
+          <Skeleton />
+        </div>
+        <div className="order-divider" />
+        <div className="summary px-8 w-[594px]">
+          <Text size="lg" weight="bold">
+            {formatMessage("summary")}
+          </Text>
+          <Skeleton variant="title" className="mt-6" />
+          <Skeleton />
+          <Skeleton variant="title" />
+          <Skeleton />
+          <Skeleton variant="title" />
+          <Skeleton />
+        </div>
+      </main>
+    </div>
+  );
+};

--- a/packages/checkout-storefront/src/sections/PageNotFound.tsx
+++ b/packages/checkout-storefront/src/sections/PageNotFound.tsx
@@ -4,8 +4,10 @@ import { Button } from "@/checkout-storefront/components/Button";
 import { SaleorLogo } from "@/checkout-storefront/images";
 import { Title } from "@/checkout-storefront/components/Title";
 import { getSvgSrc } from "../lib/svgSrc";
+import { FallbackProps } from "react-error-boundary";
 
-export const PageNotFound = () => {
+export const PageNotFound = ({ error }: FallbackProps) => {
+  console.error(error);
   const formatMessage = useFormattedMessages();
 
   // eslint-disable-next-line no-restricted-globals

--- a/packages/checkout-storefront/src/sections/PageNotFound.tsx
+++ b/packages/checkout-storefront/src/sections/PageNotFound.tsx
@@ -6,7 +6,7 @@ import { Title } from "@/checkout-storefront/components/Title";
 import { getSvgSrc } from "../lib/svgSrc";
 import { FallbackProps } from "react-error-boundary";
 
-export const PageNotFound = ({ error }: FallbackProps) => {
+export const PageNotFound = ({ error }: Partial<FallbackProps>) => {
   console.error(error);
   const formatMessage = useFormattedMessages();
 


### PR DESCRIPTION
Fixes #313

- Fix Order Confirmation failing with a cryptic error because of a lack of Suspense
- Add missing OrderConfirmationSkeleton (I just put together something quickly, feel free to adjust during the redesign)
- Enable Turbo cache on GitHub Actions