### PR TITLE
Workaround for localhost:8000 links in the footer menu

### DIFF
--- a/apps/storefront/components/Footer/Footer.tsx
+++ b/apps/storefront/components/Footer/Footer.tsx
@@ -18,7 +18,7 @@ export type FooterProps = HTMLAttributes<HTMLElement>;
 // Saleor Cloud currently doesn't support relative URLs in the footer.
 // This is a workaround to make the links work.
 // @todo remove this when the issue is fixed.
-const fixMenuItemLocalhostUrl = (url: string) => url.replace(/^http:\/\/localhost:8000\//, "/");
+const fixMenuItemLocalhostUrl = (url: string) => url.replace(/^https?:\/\/localhost:8000\//, "/");
 
 export function Footer({ className, ...rest }: FooterProps) {
   const paths = usePaths();

--- a/apps/storefront/components/Footer/Footer.tsx
+++ b/apps/storefront/components/Footer/Footer.tsx
@@ -15,6 +15,11 @@ import styles from "./Footer.module.css";
 
 export type FooterProps = HTMLAttributes<HTMLElement>;
 
+// Saleor Cloud currently doesn't support relative URLs in the footer.
+// This is a workaround to make the links work.
+// @todo remove this when the issue is fixed.
+const fixMenuItemLocalhostUrl = (url: string) => url.replace(/^http:\/\/localhost:8000\//, "/");
+
 export function Footer({ className, ...rest }: FooterProps) {
   const paths = usePaths();
   const { query, currentChannel, currentLocale } = useRegions();
@@ -62,7 +67,7 @@ export function Footer({ className, ...rest }: FooterProps) {
                     <li key={sub?.id}>
                       {sub?.url ? (
                         <a
-                          href={sub.url}
+                          href={fixMenuItemLocalhostUrl(sub.url)}
                           target="_blank"
                           rel="noreferrer"
                           className={styles["menu-link"]}


### PR DESCRIPTION
Fixes #355

Saleor Cloud currently doesn't support relative URLs in the footer. This is a workaround to make the links work.

<img width="437" alt="Screenshot 2022-08-04 at 19 35 38" src="https://user-images.githubusercontent.com/1338731/182917300-9ce9b2af-c66f-468c-a1b5-64923c0d8a84.png">

