### PR TITLE
Remove auth token from `.env`

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,3 @@ SALEOR_API_URL=https://master.staging.saleor.cloud/graphql/
 STOREFRONT_URL=http://localhost:3000
 CHECKOUT_APP_URL=http://localhost:3001
 CHECKOUT_STOREFRONT_URL=http://localhost:3001/checkout-spa
-SALEOR_APP_TOKEN=


### PR DESCRIPTION
I want to remove `SALEOR_APP_TOKEN` from `.env` because:
- This variable shouldn't be stored inside a file (it's a secret)
- In development this value is taken from `.auth_token` file inside `saleor-app-checkout` after installing in Saleor
