### PR TITLE
Fix webhook registration errors not being detected

### DIFF
--- a/apps/saleor-app-checkout/pages/api/register.ts
+++ b/apps/saleor-app-checkout/pages/api/register.ts
@@ -65,14 +65,14 @@ Received: ${saleorDomain}`);
   const existingWebhook = webhooks.find((webhook) => webhook.targetUrl === webhookUrl);
 
   if (webhooks.length === 0 && !existingWebhook) {
-    const { error } = await client
+    const { data, error } = await client
       .mutation<CreateWebhooksMutation, CreateWebhooksMutationVariables>(CreateWebhooksDocument, {
         targetUrl: webhookUrl,
         query: print(TransactionActionRequestSubscriptionDocument),
       })
       .toPromise();
-    if (error) {
-      console.error("Error while adding app's webhooks", error);
+    if (error || data?.webhookCreate?.errors) {
+      console.error("Error while adding app's webhooks", error ?? data?.webhookCreate?.errors);
       response.status(500).json({ success: false, message: "Error while adding app's webhooks" });
       return;
     }


### PR DESCRIPTION
I want to merge this because it fixes an issue when webhook registration failed in Saleor but wasn't reported back to users
