### PR TITLE
Remove fragment from GraphQL subscription due to validation issues

### DIFF
--- a/apps/saleor-app-checkout/graphql.schema.json
+++ b/apps/saleor-app-checkout/graphql.schema.json
@@ -1394,6 +1394,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AddressCreated",
+        "description": "Event sent when new address is created.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "address",
+            "description": "The address the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Address",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AddressDelete",
         "description": "Deletes an address. \n\nRequires one of the following permissions: MANAGE_USERS.",
         "fields": [
@@ -1472,6 +1549,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AddressDeleted",
+        "description": "Event sent when address is deleted.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "address",
+            "description": "The address the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Address",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1792,6 +1946,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AddressUpdated",
+        "description": "Event sent when address is updated.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "address",
+            "description": "The address the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Address",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -2238,7 +2469,7 @@
           },
           {
             "name": "appUrl",
-            "description": "Url to iframe with the app.",
+            "description": "URL to iframe with the app.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2250,15 +2481,15 @@
           },
           {
             "name": "configurationUrl",
-            "description": "Url to iframe with the configuration for the app.",
+            "description": "URL to iframe with the configuration for the app.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `appUrl` instead."
           },
           {
             "name": "created",
@@ -2281,12 +2512,12 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `dataPrivacyUrl` instead."
           },
           {
             "name": "dataPrivacyUrl",
-            "description": "Url to details about the privacy policy on the app owner page.",
+            "description": "URL to details about the privacy policy on the app owner page.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2355,6 +2586,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "manifestUrl",
+            "description": "URL to manifest used during app's installation.\n\nAdded in Saleor 3.5.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -3133,11 +3376,11 @@
       {
         "kind": "OBJECT",
         "name": "AppDeleted",
-        "description": null,
+        "description": "Event sent when app is deleted.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "app",
-            "description": "The application the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The application the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3674,6 +3917,24 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "CUSTOMER_DETAILS_MORE_ACTIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOMER_OVERVIEW_CREATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOMER_OVERVIEW_MORE_ACTIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "NAVIGATION_CATALOG",
             "description": null,
             "isDeprecated": false,
@@ -4203,11 +4464,11 @@
       {
         "kind": "OBJECT",
         "name": "AppInstalled",
-        "description": null,
+        "description": "Event sent when new app is installed.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "app",
-            "description": "The application the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The application the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -4378,6 +4639,105 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppManifestWebhook",
+        "description": null,
+        "fields": [
+          {
+            "name": "asyncEvents",
+            "description": "The asynchronous events that webhook wants to subscribe.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WebhookEventTypeAsyncEnum",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the webhook.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "query",
+            "description": "Subscription query of a webhook",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "syncEvents",
+            "description": "The synchronous events that webhook wants to subscribe.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WebhookEventTypeSyncEnum",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetUrl",
+            "description": "The url to receive the payload.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppRetryInstall",
         "description": "Retry failed installation of new app. \n\nRequires one of the following permissions: MANAGE_APPS.",
         "fields": [
@@ -4516,11 +4876,11 @@
       {
         "kind": "OBJECT",
         "name": "AppStatusChanged",
-        "description": null,
+        "description": "Event sent when app status has changed.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "app",
-            "description": "The application the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The application the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -5012,11 +5372,11 @@
       {
         "kind": "OBJECT",
         "name": "AppUpdated",
-        "description": null,
+        "description": "Event sent when app is updated.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "app",
-            "description": "The application the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The application the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -6400,6 +6760,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AttributeCreated",
+        "description": "Event sent when new attribute is created.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "attribute",
+            "description": "The attribute the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Attribute",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AttributeDelete",
         "description": "Deletes an attribute. \n\nRequires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.",
         "fields": [
@@ -6466,6 +6903,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AttributeDeleted",
+        "description": "Event sent when attribute is deleted.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "attribute",
+            "description": "The attribute the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Attribute",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -6914,6 +7428,12 @@
           },
           {
             "name": "NUMERIC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PLAIN_TEXT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -7611,6 +8131,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AttributeUpdated",
+        "description": "Event sent when attribute is updated.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "attribute",
+            "description": "The attribute the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Attribute",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AttributeValue",
         "description": "Represents a value of an attribute.",
         "fields": [
@@ -7693,6 +8290,18 @@
           {
             "name": "name",
             "description": "Name of a value displayed in the interface.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "plainText",
+            "description": "Represents the text of the attribute value, plain text without formating.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8102,6 +8711,18 @@
             "deprecationReason": null
           },
           {
+            "name": "plainText",
+            "description": "Represents the text of the attribute value, plain text without formating.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "richText",
             "description": "Represents the text of the attribute value, includes formatting.\n\nRich text format. For reference see https://editorjs.io/",
             "type": {
@@ -8127,6 +8748,83 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AttributeValueCreated",
+        "description": "Event sent when new attribute value is created.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "attributeValue",
+            "description": "The attribute value the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AttributeValue",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8210,6 +8908,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AttributeValueDeleted",
+        "description": "Event sent when attribute value is deleted.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "attributeValue",
+            "description": "The attribute value the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AttributeValue",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8335,6 +9110,18 @@
             "deprecationReason": null
           },
           {
+            "name": "plainText",
+            "description": "Plain text content.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "references",
             "description": "List of entity IDs that will be used as references.",
             "type": {
@@ -8436,6 +9223,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "plainText",
+            "description": "Attribute plain text value.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8618,6 +9417,18 @@
             "deprecationReason": null
           },
           {
+            "name": "plainText",
+            "description": "Attribute plain text value.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "richText",
             "description": "Attribute value.\n\nRich text format. For reference see https://editorjs.io/",
             "args": [],
@@ -8650,6 +9461,18 @@
           {
             "name": "name",
             "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "plainText",
+            "description": "Translated text.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8802,6 +9625,18 @@
             "deprecationReason": null
           },
           {
+            "name": "plainText",
+            "description": "Represents the text of the attribute value, plain text without formating.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "richText",
             "description": "Represents the text of the attribute value, includes formatting.\n\nRich text format. For reference see https://editorjs.io/",
             "type": {
@@ -8827,6 +9662,83 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AttributeValueUpdated",
+        "description": "Event sent when attribute value is updated.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "attributeValue",
+            "description": "The attribute value the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AttributeValue",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -9358,8 +10270,20 @@
             "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of the image.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -10109,11 +11033,11 @@
       {
         "kind": "OBJECT",
         "name": "CategoryCreated",
-        "description": null,
+        "description": "Event sent when new category is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "category",
-            "description": "The category the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The category the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -10257,11 +11181,11 @@
       {
         "kind": "OBJECT",
         "name": "CategoryDeleted",
-        "description": null,
+        "description": "Event sent when category is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "category",
-            "description": "The category the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The category the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -10953,11 +11877,11 @@
       {
         "kind": "OBJECT",
         "name": "CategoryUpdated",
-        "description": null,
+        "description": "Event sent when category is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "category",
-            "description": "The category the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The category the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -11033,8 +11957,69 @@
         "description": "Represents channel.",
         "fields": [
           {
+            "name": "availableShippingMethodsPerCountry",
+            "description": "Shipping methods that are available for the channel.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "countries",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "CountryCode",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingMethodsPerCountry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countries",
+            "description": "List of shippable countries for the channel.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CountryDisplay",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currencyCode",
-            "description": null,
+            "description": "A currency that is assigned to the channel.\n\nRequires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11050,7 +12035,7 @@
           },
           {
             "name": "defaultCountry",
-            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.\n\nAdded in Saleor 3.1.",
+            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.\n\nAdded in Saleor 3.1.\n\nRequires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11098,7 +12083,7 @@
           },
           {
             "name": "isActive",
-            "description": null,
+            "description": "Whether the channel is active.\n\nRequires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11114,7 +12099,7 @@
           },
           {
             "name": "name",
-            "description": null,
+            "description": "Name of the channel.\n\nRequires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11130,7 +12115,7 @@
           },
           {
             "name": "slug",
-            "description": null,
+            "description": "Slug of the channel.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11139,6 +12124,30 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "warehouses",
+            "description": "List of warehouses assigned to this channel.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.\n\nRequires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Warehouse",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -11325,6 +12334,26 @@
             "deprecationReason": null
           },
           {
+            "name": "addWarehouses",
+            "description": "List of warehouses to assign to the channel.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currencyCode",
             "description": "Currency of the channel.",
             "type": {
@@ -11342,7 +12371,7 @@
           },
           {
             "name": "defaultCountry",
-            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.\n\nAdded in Saleor 3.1.",
+            "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.\n\nAdded in Saleor 3.1.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11408,11 +12437,11 @@
       {
         "kind": "OBJECT",
         "name": "ChannelCreated",
-        "description": null,
+        "description": "Event sent when new channel is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "channel",
-            "description": "The channel the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The channel the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -11654,11 +12683,11 @@
       {
         "kind": "OBJECT",
         "name": "ChannelDeleted",
-        "description": null,
+        "description": "Event sent when channel is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "channel",
-            "description": "The channel the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The channel the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -11792,6 +12821,26 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "warehouses",
+            "description": "List of warehouses IDs which causes the error.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -11867,11 +12916,11 @@
       {
         "kind": "OBJECT",
         "name": "ChannelStatusChanged",
-        "description": null,
+        "description": "Event sent when channel status has changed.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "channel",
-            "description": "The channel the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The channel the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -12039,6 +13088,26 @@
             "deprecationReason": null
           },
           {
+            "name": "addWarehouses",
+            "description": "List of warehouses to assign to the channel.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "defaultCountry",
             "description": "Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.\n\nAdded in Saleor 3.1.",
             "type": {
@@ -12095,6 +13164,26 @@
             "deprecationReason": null
           },
           {
+            "name": "removeWarehouses",
+            "description": "List of warehouses to unassign from the channel.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "slug",
             "description": "Slug of the channel.",
             "type": {
@@ -12114,11 +13203,11 @@
       {
         "kind": "OBJECT",
         "name": "ChannelUpdated",
-        "description": null,
+        "description": "Event sent when channel is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "channel",
-            "description": "The channel the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The channel the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -12942,6 +14031,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutAddressValidationRules",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "checkFieldsFormat",
+            "description": "Determines if an error should be raised when the provided address doesn't match the expected format. Example: using letters for postal code when the numbers are expected.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "true",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "checkRequiredFields",
+            "description": "Determines if an error should be raised when the provided address doesn't have all the required fields. The list of required fields is dynamic and depends on the country code (use the `addressValidationRules` query to fetch them). Note: country code is mandatory for all addresses regardless of the rules provided in this input.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "true",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enableFieldsNormalization",
+            "description": "Determines if Saleor should apply normalization on address fields. Example: converting city field to uppercase letters.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "true",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "CheckoutBillingAddressUpdate",
         "description": "Update billing address in the existing checkout.",
@@ -13389,6 +14525,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "validationRules",
+            "description": "The checkout validation rules that can be changed.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutValidationRules",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -13398,11 +14546,11 @@
       {
         "kind": "OBJECT",
         "name": "CheckoutCreated",
-        "description": null,
+        "description": "Event sent when new checkout is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "checkout",
-            "description": "The checkout the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The checkout the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -14097,6 +15245,103 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CheckoutFilterShippingMethods",
+        "description": "Filter shipping methods for checkout.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "checkout",
+            "description": "The checkout the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Checkout",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingMethods",
+            "description": "Shipping methods that can be used with this checkout.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingMethod",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CheckoutLanguageCodeUpdate",
         "description": "Update language code in the existing checkout.",
         "fields": [
@@ -14183,6 +15428,178 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": "List of public metadata items. Can be accessed without permissions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MetadataItem",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metafield",
+            "description": "A single key from public metadata.\n\nTip: Use GraphQL aliases to fetch multiple keys.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "key",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metafields",
+            "description": "Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "keys",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Metadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetadata",
+            "description": "List of private metadata items. Requires staff permissions to access.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MetadataItem",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetafield",
+            "description": "A single key from private metadata. Requires staff permissions to access.\n\nTip: Use GraphQL aliases to fetch multiple keys.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "key",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetafields",
+            "description": "Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "keys",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Metadata",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14305,6 +15722,11 @@
           {
             "kind": "INTERFACE",
             "name": "Node",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "ObjectWithMetadata",
             "ofType": null
           }
         ],
@@ -14495,6 +15917,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "forceNewLine",
+            "description": "Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. \n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "false",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "price",
             "description": "Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.\n\nAdded in Saleor 3.1.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
             "type": {
@@ -14550,6 +15984,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "lineId",
+            "description": "ID of the line.\n\nAdded in Saleor 3.6.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "price",
             "description": "Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.\n\nAdded in Saleor 3.1.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
             "type": {
@@ -14575,15 +16021,11 @@
           },
           {
             "name": "variantId",
-            "description": "ID of the product variant.",
+            "description": "ID of the product variant. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use `lineId` instead.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -15154,11 +16596,11 @@
       {
         "kind": "OBJECT",
         "name": "CheckoutUpdated",
-        "description": null,
+        "description": "Event sent when checkout is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "checkout",
-            "description": "The checkout the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The checkout the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -15229,6 +16671,41 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutValidationRules",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "billingAddress",
+            "description": "The validation rules that can be applied to provided billing address data.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutAddressValidationRules",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingAddress",
+            "description": "The validation rules that can be applied to provided shipping address data.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutAddressValidationRules",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "ChoiceValue",
         "description": null,
@@ -15273,8 +16750,20 @@
             "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of the image.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -16499,11 +17988,11 @@
       {
         "kind": "OBJECT",
         "name": "CollectionCreated",
-        "description": null,
+        "description": "Event sent when new collection is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "collection",
-            "description": "The collection the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The collection the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -16660,11 +18149,11 @@
       {
         "kind": "OBJECT",
         "name": "CollectionDeleted",
-        "description": null,
+        "description": "Event sent when collection is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "collection",
-            "description": "The collection the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The collection the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -17718,11 +19207,11 @@
       {
         "kind": "OBJECT",
         "name": "CollectionUpdated",
-        "description": null,
+        "description": "Event sent when collection is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "collection",
-            "description": "The collection the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The collection the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -20038,7 +21527,7 @@
       {
         "kind": "OBJECT",
         "name": "CustomerCreated",
-        "description": null,
+        "description": "Event sent when new customer user is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -20078,7 +21567,7 @@
           },
           {
             "name": "user",
-            "description": "The user the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The user the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -20321,7 +21810,19 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "ACCOUNT_ACTIVATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ACCOUNT_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ACCOUNT_DEACTIVATED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -20673,7 +22174,7 @@
       {
         "kind": "OBJECT",
         "name": "CustomerUpdated",
-        "description": null,
+        "description": "Event sent when customer user is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -20713,7 +22214,7 @@
           },
           {
             "name": "user",
-            "description": "The user the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The user the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -22748,7 +24249,7 @@
       {
         "kind": "OBJECT",
         "name": "DraftOrderCreated",
-        "description": null,
+        "description": "Event sent when new draft order is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -22776,7 +24277,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -22896,7 +24397,7 @@
       {
         "kind": "OBJECT",
         "name": "DraftOrderDeleted",
-        "description": null,
+        "description": "Event sent when draft order is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -22924,7 +24425,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -23250,7 +24751,7 @@
       {
         "kind": "OBJECT",
         "name": "DraftOrderUpdated",
-        "description": null,
+        "description": "Event sent when draft order is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -23278,7 +24779,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -23384,6 +24885,21 @@
         "possibleTypes": [
           {
             "kind": "OBJECT",
+            "name": "AddressCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AddressDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AddressUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "AppDeleted",
             "ofType": null
           },
@@ -23400,6 +24916,36 @@
           {
             "kind": "OBJECT",
             "name": "AppUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AttributeCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AttributeDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AttributeUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AttributeValueCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AttributeValueDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AttributeValueUpdated",
             "ofType": null
           },
           {
@@ -23440,6 +24986,11 @@
           {
             "kind": "OBJECT",
             "name": "CheckoutCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CheckoutFilterShippingMethods",
             "ofType": null
           },
           {
@@ -23579,6 +25130,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "OrderFilterShippingMethods",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "OrderFulfilled",
             "ofType": null
           },
@@ -23604,7 +25160,72 @@
           },
           {
             "kind": "OBJECT",
+            "name": "PageTypeCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PageTypeDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PageTypeUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "PageUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentAuthorize",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentCaptureEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentConfirmEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentListGateways",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentProcessEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentRefundEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PaymentVoidEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PermissionGroupCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PermissionGroupDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PermissionGroupUpdated",
             "ofType": null
           },
           {
@@ -23659,7 +25280,17 @@
           },
           {
             "kind": "OBJECT",
+            "name": "SaleToggle",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "SaleUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ShippingListMethodsForCheckout",
             "ofType": null
           },
           {
@@ -23690,6 +25321,21 @@
           {
             "kind": "OBJECT",
             "name": "ShippingZoneUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StaffCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StaffDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StaffUpdated",
             "ofType": null
           },
           {
@@ -26863,11 +28509,11 @@
       {
         "kind": "OBJECT",
         "name": "FulfillmentCanceled",
-        "description": null,
+        "description": "Event sent when fulfillment is canceled.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "fulfillment",
-            "description": "The fulfillment the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The fulfillment the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -26903,7 +28549,7 @@
           },
           {
             "name": "order",
-            "description": "The order the fulfillment belongs to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the fulfillment belongs to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -26952,11 +28598,11 @@
       {
         "kind": "OBJECT",
         "name": "FulfillmentCreated",
-        "description": null,
+        "description": "Event sent when new fulfillment is created.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "fulfillment",
-            "description": "The fulfillment the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The fulfillment the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -26992,7 +28638,7 @@
           },
           {
             "name": "order",
-            "description": "The order the fulfillment belongs to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the fulfillment belongs to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -27599,9 +29245,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "Money",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -27704,9 +29354,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "Money",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -28831,11 +30485,11 @@
       {
         "kind": "OBJECT",
         "name": "GiftCardCreated",
-        "description": null,
+        "description": "Event sent when new gift card is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "giftCard",
-            "description": "The gift card the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The gift card the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -29050,11 +30704,11 @@
       {
         "kind": "OBJECT",
         "name": "GiftCardDeleted",
-        "description": null,
+        "description": "Event sent when gift card is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "giftCard",
-            "description": "The gift card the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The gift card the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -30212,11 +31866,11 @@
       {
         "kind": "OBJECT",
         "name": "GiftCardStatusChanged",
-        "description": null,
+        "description": "Event sent when gift card status has changed.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "giftCard",
-            "description": "The gift card the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The gift card the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -30637,11 +32291,11 @@
       {
         "kind": "OBJECT",
         "name": "GiftCardUpdated",
-        "description": null,
+        "description": "Event sent when gift card is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "giftCard",
-            "description": "The gift card the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The gift card the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -31515,11 +33169,11 @@
       {
         "kind": "OBJECT",
         "name": "InvoiceDeleted",
-        "description": null,
+        "description": "Event sent when invoice is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "invoice",
-            "description": "The invoice the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The invoice the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -31856,11 +33510,11 @@
       {
         "kind": "OBJECT",
         "name": "InvoiceRequested",
-        "description": null,
+        "description": "Event sent when invoice is requested.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "invoice",
-            "description": "The invoice the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The invoice the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -32004,11 +33658,11 @@
       {
         "kind": "OBJECT",
         "name": "InvoiceSent",
-        "description": null,
+        "description": "Event sent when invoice is sent.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "invoice",
-            "description": "The invoice the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The invoice the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -37175,27 +38829,27 @@
           },
           {
             "name": "configurationUrl",
-            "description": null,
+            "description": "URL to iframe with the configuration for the app.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `appUrl` instead."
           },
           {
             "name": "dataPrivacy",
-            "description": null,
+            "description": "Description of the data privacy defined for this app.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `dataPrivacyUrl` instead."
           },
           {
             "name": "dataPrivacyUrl",
@@ -37332,6 +38986,30 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhooks",
+            "description": "List of the app's webhooks.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppManifestWebhook",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -38145,7 +39823,7 @@
       {
         "kind": "OBJECT",
         "name": "MenuCreated",
-        "description": null,
+        "description": "Event sent when new menu is created.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -38173,7 +39851,7 @@
           },
           {
             "name": "menu",
-            "description": "The menu the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The menu the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -38306,7 +39984,7 @@
       {
         "kind": "OBJECT",
         "name": "MenuDeleted",
-        "description": null,
+        "description": "Event sent when menu is deleted.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -38334,7 +40012,7 @@
           },
           {
             "name": "menu",
-            "description": "The menu the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The menu the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -39332,7 +41010,7 @@
       {
         "kind": "OBJECT",
         "name": "MenuItemCreated",
-        "description": null,
+        "description": "Event sent when new menu item is created.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -39360,7 +41038,7 @@
           },
           {
             "name": "menuItem",
-            "description": "The menu item the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The menu item the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -39493,7 +41171,7 @@
       {
         "kind": "OBJECT",
         "name": "MenuItemDeleted",
-        "description": null,
+        "description": "Event sent when menu item is deleted.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -39521,7 +41199,7 @@
           },
           {
             "name": "menuItem",
-            "description": "The menu item the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The menu item the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -40159,7 +41837,7 @@
       {
         "kind": "OBJECT",
         "name": "MenuItemUpdated",
-        "description": null,
+        "description": "Event sent when menu item is updated.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -40187,7 +41865,7 @@
           },
           {
             "name": "menuItem",
-            "description": "The menu item the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The menu item the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -40403,7 +42081,7 @@
       {
         "kind": "OBJECT",
         "name": "MenuUpdated",
-        "description": null,
+        "description": "Event sent when menu is updated.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -40431,7 +42109,7 @@
           },
           {
             "name": "menu",
-            "description": "The menu the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The menu the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -42797,6 +44475,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "validationRules",
+                "description": "The rules for changing validation for received billing address data.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CheckoutAddressValidationRules",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -43269,7 +44959,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "DEPRECATED: Will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead."
+            "deprecationReason": "This field will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead."
           },
           {
             "name": "checkoutLinesAdd",
@@ -43666,6 +45356,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "UUID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "validationRules",
+                "description": "The rules for changing validation for received shipping address data.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CheckoutAddressValidationRules",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -48221,7 +49923,7 @@
           },
           {
             "name": "permissionGroupCreate",
-            "description": "Create new permission group. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Create new permission group. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "input",
@@ -48250,7 +49952,7 @@
           },
           {
             "name": "permissionGroupDelete",
-            "description": "Delete permission group. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Delete permission group. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "id",
@@ -48279,7 +49981,7 @@
           },
           {
             "name": "permissionGroupUpdate",
-            "description": "Update permission group. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Update permission group. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "id",
@@ -51062,7 +52764,7 @@
           },
           {
             "name": "staffBulkDelete",
-            "description": "Deletes staff users. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Deletes staff users. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "ids",
@@ -51099,7 +52801,7 @@
           },
           {
             "name": "staffCreate",
-            "description": "Creates a new staff user. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Creates a new staff user. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "input",
@@ -51128,7 +52830,7 @@
           },
           {
             "name": "staffDelete",
-            "description": "Deletes a staff user. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Deletes a staff user. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "id",
@@ -51260,7 +52962,7 @@
           },
           {
             "name": "staffUpdate",
-            "description": "Updates an existing staff user. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+            "description": "Updates an existing staff user. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
             "args": [
               {
                 "name": "id",
@@ -53119,6 +54821,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "CheckoutLine",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Collection",
             "ofType": null
           },
@@ -53155,6 +54862,11 @@
           {
             "kind": "OBJECT",
             "name": "Order",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "OrderLine",
             "ofType": null
           },
           {
@@ -54702,7 +56414,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderCancelled",
-        "description": null,
+        "description": "Event sent when order is canceled.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -54730,7 +56442,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -54956,7 +56668,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderConfirmed",
-        "description": null,
+        "description": "Event sent when order is confirmed.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -54984,7 +56696,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -55372,7 +57084,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderCreated",
-        "description": null,
+        "description": "Event sent when new order is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -55400,7 +57112,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -57532,6 +59244,103 @@
       },
       {
         "kind": "OBJECT",
+        "name": "OrderFilterShippingMethods",
+        "description": "Filter shipping methods for order.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "order",
+            "description": "The order the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Order",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingMethods",
+            "description": "Shipping methods that can be used with this checkout.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingMethod",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "OrderFulfill",
         "description": "Creates new fulfillments for an order. \n\nRequires one of the following permissions: MANAGE_ORDERS.",
         "fields": [
@@ -57674,6 +59483,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "trackingNumber",
+            "description": "Fulfillment tracking number.\n\nAdded in Saleor 3.6.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -57773,7 +59594,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderFulfilled",
-        "description": null,
+        "description": "Event sent when order is fulfilled.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -57801,7 +59622,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -57850,7 +59671,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderFullyPaid",
-        "description": null,
+        "description": "Event sent when order is fully paid.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -57878,7 +59699,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -57994,6 +59815,178 @@
             "deprecationReason": null
           },
           {
+            "name": "metadata",
+            "description": "List of public metadata items. Can be accessed without permissions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MetadataItem",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metafield",
+            "description": "A single key from public metadata.\n\nTip: Use GraphQL aliases to fetch multiple keys.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "key",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metafields",
+            "description": "Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "keys",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Metadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetadata",
+            "description": "List of private metadata items. Requires staff permissions to access.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MetadataItem",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetafield",
+            "description": "A single key from private metadata. Requires staff permissions to access.\n\nTip: Use GraphQL aliases to fetch multiple keys.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "key",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateMetafields",
+            "description": "Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.\n\nAdded in Saleor 3.3.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "keys",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Metadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "productName",
             "description": null,
             "args": [],
@@ -58099,11 +60092,23 @@
           },
           {
             "name": "thumbnail",
-            "description": "The main thumbnail for the ordered product.",
+            "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of thumbnail.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -58293,6 +60298,11 @@
             "kind": "INTERFACE",
             "name": "Node",
             "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "ObjectWithMetadata",
+            "ofType": null
           }
         ],
         "enumValues": null,
@@ -58304,6 +60314,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "forceNewLine",
+            "description": "Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. \n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "false",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "quantity",
             "description": "Number of variant items ordered.",
@@ -59586,6 +61608,12 @@
             "description": "Sort orders by payment.",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "RANK",
+            "description": "Sort orders by rank. Note: This option is available only with the `search` filter.",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -59960,7 +61988,7 @@
       {
         "kind": "OBJECT",
         "name": "OrderUpdated",
-        "description": null,
+        "description": "Event sent when order is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -59988,7 +62016,7 @@
           },
           {
             "name": "order",
-            "description": "The order the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The order the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -61127,7 +63155,7 @@
       {
         "kind": "OBJECT",
         "name": "PageCreated",
-        "description": null,
+        "description": "Event sent when new page is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -61155,7 +63183,7 @@
           },
           {
             "name": "page",
-            "description": "The page the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The page the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -61275,7 +63303,7 @@
       {
         "kind": "OBJECT",
         "name": "PageDeleted",
-        "description": null,
+        "description": "Event sent when page is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -61303,7 +63331,7 @@
           },
           {
             "name": "page",
-            "description": "The page the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The page the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -62976,6 +65004,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PageTypeCreated",
+        "description": "Event sent when new page type is created.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageType",
+            "description": "The page type the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PageType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PageTypeDelete",
         "description": "Delete a page type. \n\nRequires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.",
         "fields": [
@@ -63042,6 +65147,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PageTypeDeleted",
+        "description": "Event sent when page type is deleted.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageType",
+            "description": "The page type the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PageType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -63353,6 +65535,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PageTypeUpdated",
+        "description": "Event sent when page type is updated.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageType",
+            "description": "The page type the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PageType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PageUpdate",
         "description": "Updates an existing page. \n\nRequires one of the following permissions: MANAGE_PAGES.",
         "fields": [
@@ -63425,7 +65684,7 @@
       {
         "kind": "OBJECT",
         "name": "PageUpdated",
-        "description": null,
+        "description": "Event sent when page is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -63453,7 +65712,7 @@
           },
           {
             "name": "page",
-            "description": "The page the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The page the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -64034,6 +66293,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PaymentAuthorize",
+        "description": "Authorize payment.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment",
+            "description": "Look up a payment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PaymentCapture",
         "description": "Captures the authorized payment amount. \n\nRequires one of the following permissions: MANAGE_ORDERS.",
         "fields": [
@@ -64100,6 +66436,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PaymentCaptureEvent",
+        "description": "Capture payment.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment",
+            "description": "Look up a payment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -64305,6 +66718,83 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PaymentConfirmEvent",
+        "description": "Confirm payment.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment",
+            "description": "Look up a payment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -64943,6 +67433,160 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PaymentListGateways",
+        "description": "List payment gateways.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "checkout",
+            "description": "The checkout the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Checkout",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PaymentProcessEvent",
+        "description": "Process payment.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment",
+            "description": "Look up a payment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PaymentRefund",
         "description": "Refunds the captured payment amount. \n\nRequires one of the following permissions: MANAGE_ORDERS.",
         "fields": [
@@ -65009,6 +67653,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PaymentRefundEvent",
+        "description": "Refund payment.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment",
+            "description": "Look up a payment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -65160,6 +67881,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PaymentVoidEvent",
+        "description": "Void payment.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment",
+            "description": "Look up a payment.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Permission",
         "description": "Represents a permission object in a friendly form.",
         "fields": [
@@ -65217,6 +68015,12 @@
           },
           {
             "name": "HANDLE_PAYMENTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HANDLE_TAXES",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -65341,7 +68145,7 @@
       {
         "kind": "OBJECT",
         "name": "PermissionGroupCreate",
-        "description": "Create new permission group. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Create new permission group. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "errors",
@@ -65478,8 +68282,85 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PermissionGroupCreated",
+        "description": "Event sent when new permission group is created.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissionGroup",
+            "description": "The permission group the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Group",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PermissionGroupDelete",
-        "description": "Delete permission group. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Delete permission group. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "errors",
@@ -65544,6 +68425,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PermissionGroupDeleted",
+        "description": "Event sent when permission group is deleted.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissionGroup",
+            "description": "The permission group the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Group",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -65803,7 +68761,7 @@
       {
         "kind": "OBJECT",
         "name": "PermissionGroupUpdate",
-        "description": "Update permission group. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Update permission group. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "errors",
@@ -65971,6 +68929,83 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PermissionGroupUpdated",
+        "description": "Event sent when permission group is updated.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissionGroup",
+            "description": "The permission group the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Group",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -67492,11 +70527,23 @@
           },
           {
             "name": "thumbnail",
-            "description": "The main thumbnail for a product.",
+            "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of thumbnail.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -68979,11 +72026,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductCreated",
-        "description": null,
+        "description": "Event sent when new product is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "category",
-            "description": "The category of the product.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The category of the product.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -69019,7 +72066,7 @@
           },
           {
             "name": "product",
-            "description": "The product the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -69152,11 +72199,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductDeleted",
-        "description": null,
+        "description": "Event sent when product is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "category",
-            "description": "The category of the product.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The category of the product.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -69192,7 +72239,7 @@
           },
           {
             "name": "product",
-            "description": "The product the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -69630,7 +72677,7 @@
           },
           {
             "name": "giftCard",
-            "description": null,
+            "description": "Filter on whether product is a gift card or not.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -69718,7 +72765,7 @@
           },
           {
             "name": "minimalPrice",
-            "description": null,
+            "description": "Filter by the lowest variant price after discounts.",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "PriceRangeInput",
@@ -69774,7 +72821,7 @@
           },
           {
             "name": "stockAvailability",
-            "description": null,
+            "description": "Filter by variants having specific stock status.",
             "type": {
               "kind": "ENUM",
               "name": "StockAvailability",
@@ -69798,7 +72845,7 @@
           },
           {
             "name": "updatedAt",
-            "description": null,
+            "description": "Filter by when was the most recent update.",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "DateTimeRangeInput",
@@ -69860,11 +72907,23 @@
           },
           {
             "name": "url",
-            "description": "The URL of the image.",
+            "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of the image.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -70135,11 +73194,23 @@
           },
           {
             "name": "url",
-            "description": "The URL of the media.",
+            "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of the image.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -72877,11 +75948,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductUpdated",
-        "description": null,
+        "description": "Event sent when product is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "category",
-            "description": "The category of the product.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The category of the product.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -72917,7 +75988,7 @@
           },
           {
             "name": "product",
-            "description": "The product the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -73623,7 +76694,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductVariantBackInStock",
-        "description": null,
+        "description": "Event sent when product variant is back in stock.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -73651,7 +76722,7 @@
           },
           {
             "name": "productVariant",
-            "description": "The product variant the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product variant the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -73700,7 +76771,7 @@
           },
           {
             "name": "warehouse",
-            "description": "Look up a warehouse.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "Look up a warehouse.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -74577,7 +77648,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductVariantCreated",
-        "description": null,
+        "description": "Event sent when new product variant is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -74605,7 +77676,7 @@
           },
           {
             "name": "productVariant",
-            "description": "The product variant the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product variant the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -74738,7 +77809,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductVariantDeleted",
-        "description": null,
+        "description": "Event sent when product variant is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -74766,7 +77837,7 @@
           },
           {
             "name": "productVariant",
-            "description": "The product variant the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product variant the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -75006,7 +78077,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductVariantOutOfStock",
-        "description": null,
+        "description": "Event sent when product variant is out of stock.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -75034,7 +78105,7 @@
           },
           {
             "name": "productVariant",
-            "description": "The product variant the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product variant the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -75083,7 +78154,7 @@
           },
           {
             "name": "warehouse",
-            "description": "Look up a warehouse.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "Look up a warehouse.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -75962,7 +79033,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductVariantUpdated",
-        "description": null,
+        "description": "Event sent when product variant is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -75990,7 +79061,7 @@
           },
           {
             "name": "productVariant",
-            "description": "The product variant the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The product variant the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -76762,7 +79833,7 @@
           },
           {
             "name": "channel",
-            "description": "Look up a channel by ID.\n\nRequires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.",
+            "description": "Look up a channel by ID or slug.",
             "args": [
               {
                 "name": "id",
@@ -76770,6 +79841,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "slug",
+                "description": "Slug of the channel.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -79905,6 +82988,35 @@
             "deprecationReason": null
           },
           {
+            "name": "transaction",
+            "description": "Look up a transaction by ID.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.\n\nRequires one of the following permissions: HANDLE_PAYMENTS.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of a transaction.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "TransactionItem",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "translation",
             "description": "Lookup a translatable item by ID.\n\nRequires one of the following permissions: MANAGE_TRANSLATIONS.",
             "args": [
@@ -81920,7 +85032,7 @@
       {
         "kind": "OBJECT",
         "name": "SaleCreated",
-        "description": null,
+        "description": "Event sent when new sale is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -81960,7 +85072,7 @@
           },
           {
             "name": "sale",
-            "description": "The sale the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The sale the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -82081,7 +85193,7 @@
       {
         "kind": "OBJECT",
         "name": "SaleDeleted",
-        "description": null,
+        "description": "Event sent when sale is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -82121,7 +85233,7 @@
           },
           {
             "name": "sale",
-            "description": "The sale the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The sale the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -82599,6 +85711,96 @@
       },
       {
         "kind": "OBJECT",
+        "name": "SaleToggle",
+        "description": "The event informs about the start or end of the sale.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sale",
+            "description": "The sale the event relates to.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [
+              {
+                "name": "channel",
+                "description": "Slug of a channel for which the data should be returned.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Sale",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "SaleTranslatableContent",
         "description": null,
         "fields": [
@@ -82916,7 +86118,7 @@
       {
         "kind": "OBJECT",
         "name": "SaleUpdated",
-        "description": null,
+        "description": "Event sent when sale is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -82956,7 +86158,7 @@
           },
           {
             "name": "sale",
-            "description": "The sale the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The sale the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -83344,6 +86546,103 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ShippingListMethodsForCheckout",
+        "description": "List shipping methods for checkout.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "checkout",
+            "description": "The checkout the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Checkout",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingMethods",
+            "description": "Shipping methods that can be used with this checkout.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingMethod",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -84731,6 +88030,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "ShippingMethodsPerCountry",
+        "description": "List of shipping methods available for the country.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "countryCode",
+            "description": "The country code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CountryCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingMethods",
+            "description": "List of available shipping methods.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingMethod",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "ShippingPostalCodeRulesCreateInputRange",
         "description": null,
@@ -84930,7 +88276,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingPriceCreated",
-        "description": null,
+        "description": "Event sent when new shipping price is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -84970,7 +88316,7 @@
           },
           {
             "name": "shippingMethod",
-            "description": "The shipping method the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping method the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -84995,7 +88341,7 @@
           },
           {
             "name": "shippingZone",
-            "description": "The shipping zone the shipping method belongs to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping zone the shipping method belongs to.",
             "args": [
               {
                 "name": "channel",
@@ -85128,7 +88474,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingPriceDeleted",
-        "description": null,
+        "description": "Event sent when shipping price is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -85168,7 +88514,7 @@
           },
           {
             "name": "shippingMethod",
-            "description": "The shipping method the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping method the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -85193,7 +88539,7 @@
           },
           {
             "name": "shippingZone",
-            "description": "The shipping zone the shipping method belongs to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping zone the shipping method belongs to.",
             "args": [
               {
                 "name": "channel",
@@ -85768,7 +89114,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingPriceUpdated",
-        "description": null,
+        "description": "Event sent when shipping price is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -85808,7 +89154,7 @@
           },
           {
             "name": "shippingMethod",
-            "description": "The shipping method the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping method the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -85833,7 +89179,7 @@
           },
           {
             "name": "shippingZone",
-            "description": "The shipping zone the shipping method belongs to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping zone the shipping method belongs to.",
             "args": [
               {
                 "name": "channel",
@@ -86600,7 +89946,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingZoneCreated",
-        "description": null,
+        "description": "Event sent when new shipping zone is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -86640,7 +89986,7 @@
           },
           {
             "name": "shippingZone",
-            "description": "The shipping zone the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping zone the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -86761,7 +90107,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingZoneDeleted",
-        "description": null,
+        "description": "Event sent when shipping zone is deleted.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -86801,7 +90147,7 @@
           },
           {
             "name": "shippingZone",
-            "description": "The shipping zone the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping zone the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -87112,7 +90458,7 @@
       {
         "kind": "OBJECT",
         "name": "ShippingZoneUpdated",
-        "description": null,
+        "description": "Event sent when shipping zone is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -87152,7 +90498,7 @@
           },
           {
             "name": "shippingZone",
-            "description": "The shipping zone the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The shipping zone the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -88690,7 +92036,7 @@
       {
         "kind": "OBJECT",
         "name": "StaffBulkDelete",
-        "description": "Deletes staff users. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Deletes staff users. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "count",
@@ -88765,7 +92111,7 @@
       {
         "kind": "OBJECT",
         "name": "StaffCreate",
-        "description": "Creates a new staff user. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Creates a new staff user. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "errors",
@@ -88938,8 +92284,85 @@
       },
       {
         "kind": "OBJECT",
+        "name": "StaffCreated",
+        "description": "Event sent when new staff user is created.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "The user the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "StaffDelete",
-        "description": "Deletes a staff user. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Deletes a staff user. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "errors",
@@ -89004,6 +92427,83 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffDeleted",
+        "description": "Event sent when staff user is deleted.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "The user the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -89485,7 +92985,7 @@
       {
         "kind": "OBJECT",
         "name": "StaffUpdate",
-        "description": "Updates an existing staff user. \n\nRequires one of the following permissions: MANAGE_STAFF.",
+        "description": "Updates an existing staff user. Apps are not allowed to perform this mutation. \n\nRequires one of the following permissions: MANAGE_STAFF.",
         "fields": [
           {
             "name": "errors",
@@ -89661,6 +93161,83 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffUpdated",
+        "description": "Event sent when staff user is updated.\n\nAdded in Saleor 3.5.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "The user the event relates to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -90067,7 +93644,7 @@
         "inputFields": [
           {
             "name": "quantity",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Float",
@@ -90342,6 +93919,23 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ThumbnailFormatEnum",
+        "description": "An enumeration.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "WEBP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -90689,7 +94283,7 @@
       {
         "kind": "OBJECT",
         "name": "TransactionActionRequest",
-        "description": null,
+        "description": "Event sent when transaction action is requested.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "action",
@@ -91440,6 +95034,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "order",
+            "description": "The related order.\n\nAdded in Saleor 3.6.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Order",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -92406,7 +96012,7 @@
       {
         "kind": "OBJECT",
         "name": "TranslationCreated",
-        "description": null,
+        "description": "Event sent when new translation is created.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -92446,7 +96052,7 @@
           },
           {
             "name": "translation",
-            "description": "The translation the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The translation the event relates to.",
             "args": [],
             "type": {
               "kind": "UNION",
@@ -92694,7 +96300,7 @@
       {
         "kind": "OBJECT",
         "name": "TranslationUpdated",
-        "description": null,
+        "description": "Event sent when translation is updated.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -92734,7 +96340,7 @@
           },
           {
             "name": "translation",
-            "description": "The translation the event relates to.\n\nAdded in Saleor 3.2.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The translation the event relates to.",
             "args": [],
             "type": {
               "kind": "UNION",
@@ -93043,15 +96649,19 @@
             "description": "List of all user's addresses.",
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Address",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Address",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -93063,8 +96673,20 @@
             "description": null,
             "args": [
               {
+                "name": "format",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ThumbnailFormatEnum",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "size",
-                "description": "Size of the avatar.",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -96257,7 +99879,7 @@
       {
         "kind": "OBJECT",
         "name": "VoucherCreated",
-        "description": null,
+        "description": "Event sent when new voucher is created.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -96309,7 +99931,7 @@
           },
           {
             "name": "voucher",
-            "description": "The voucher the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The voucher the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -96418,7 +100040,7 @@
       {
         "kind": "OBJECT",
         "name": "VoucherDeleted",
-        "description": null,
+        "description": "Event sent when voucher is deleted.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -96470,7 +100092,7 @@
           },
           {
             "name": "voucher",
-            "description": "The voucher the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The voucher the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -96552,6 +100174,26 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "VoucherDiscountType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ids",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               }
@@ -97384,7 +101026,7 @@
       {
         "kind": "OBJECT",
         "name": "VoucherUpdated",
-        "description": null,
+        "description": "Event sent when voucher is updated.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -97436,7 +101078,7 @@
           },
           {
             "name": "voucher",
-            "description": "The voucher the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The voucher the event relates to.",
             "args": [
               {
                 "name": "channel",
@@ -98154,7 +101796,7 @@
       {
         "kind": "OBJECT",
         "name": "WarehouseCreated",
-        "description": null,
+        "description": "Event sent when new warehouse is created.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -98206,7 +101848,7 @@
           },
           {
             "name": "warehouse",
-            "description": "The warehouse the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The warehouse the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -98302,7 +101944,7 @@
       {
         "kind": "OBJECT",
         "name": "WarehouseDeleted",
-        "description": null,
+        "description": "Event sent when warehouse is deleted.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -98354,7 +101996,7 @@
           },
           {
             "name": "warehouse",
-            "description": "The warehouse the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The warehouse the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -98480,6 +102122,26 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "channels",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "clickAndCollectOption",
             "description": null,
@@ -98900,7 +102562,7 @@
       {
         "kind": "OBJECT",
         "name": "WarehouseUpdated",
-        "description": null,
+        "description": "Event sent when warehouse is updated.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
         "fields": [
           {
             "name": "issuedAt",
@@ -98952,7 +102614,7 @@
           },
           {
             "name": "warehouse",
-            "description": "The warehouse the event relates to.\n\nAdded in Saleor 3.4.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The warehouse the event relates to.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -99178,7 +102840,7 @@
           },
           {
             "name": "secretKey",
-            "description": "Used to create a hash signature with each payload.",
+            "description": "Used to create a hash signature with each payload.\n\nIf not set, since Saleor 3.5, your payload will be signed using private key used also to sign JWT tokens.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -99767,6 +103429,24 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "ADDRESS_CREATED",
+            "description": "A new address created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADDRESS_DELETED",
+            "description": "An address deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADDRESS_UPDATED",
+            "description": "An address updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ANY_EVENTS",
             "description": "All the events.",
             "isDeprecated": false,
@@ -99793,6 +103473,42 @@
           {
             "name": "APP_UPDATED",
             "description": "An app updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_CREATED",
+            "description": "A new attribute is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_DELETED",
+            "description": "An attribute is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_UPDATED",
+            "description": "An attribute is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_CREATED",
+            "description": "A new attribute value is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_DELETED",
+            "description": "An attribute value is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_UPDATED",
+            "description": "An attribute value is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -99875,6 +103591,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CUSTOMER_DELETED",
+            "description": "A customer account is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CUSTOMER_UPDATED",
             "description": "A customer account is updated.",
             "isDeprecated": false,
@@ -99882,19 +103604,19 @@
           },
           {
             "name": "DRAFT_ORDER_CREATED",
-            "description": null,
+            "description": "A draft order is created.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DRAFT_ORDER_DELETED",
-            "description": null,
+            "description": "A draft order is deleted.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DRAFT_ORDER_UPDATED",
-            "description": null,
+            "description": "A draft order is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100049,8 +103771,44 @@
             "deprecationReason": null
           },
           {
+            "name": "PAGE_TYPE_CREATED",
+            "description": "A new page type is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_TYPE_DELETED",
+            "description": "A page type is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_TYPE_UPDATED",
+            "description": "A page type is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PAGE_UPDATED",
             "description": "A page is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_CREATED",
+            "description": "A new permission group is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_DELETED",
+            "description": "A permission group is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_UPDATED",
+            "description": "A permission group is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100074,7 +103832,7 @@
           },
           {
             "name": "PRODUCT_VARIANT_BACK_IN_STOCK",
-            "description": null,
+            "description": "A product variant is back in stock.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100092,7 +103850,7 @@
           },
           {
             "name": "PRODUCT_VARIANT_OUT_OF_STOCK",
-            "description": null,
+            "description": "A product variant is out of stock.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100104,19 +103862,25 @@
           },
           {
             "name": "SALE_CREATED",
-            "description": null,
+            "description": "A sale is created.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SALE_DELETED",
-            "description": null,
+            "description": "A sale is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_TOGGLE",
+            "description": "A sale is activated or deactivated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SALE_UPDATED",
-            "description": null,
+            "description": "A sale is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100157,20 +103921,38 @@
             "deprecationReason": null
           },
           {
+            "name": "STAFF_CREATED",
+            "description": "A new staff user is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_DELETED",
+            "description": "A staff user is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_UPDATED",
+            "description": "A staff user is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "TRANSACTION_ACTION_REQUEST",
-            "description": null,
+            "description": "An action requested for transaction.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "TRANSLATION_CREATED",
-            "description": null,
+            "description": "A new translation is created.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "TRANSLATION_UPDATED",
-            "description": null,
+            "description": "A translation is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100222,6 +104004,24 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "ADDRESS_CREATED",
+            "description": "A new address created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADDRESS_DELETED",
+            "description": "An address deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADDRESS_UPDATED",
+            "description": "An address updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ANY_EVENTS",
             "description": "All the events.",
             "isDeprecated": false,
@@ -100248,6 +104048,42 @@
           {
             "name": "APP_UPDATED",
             "description": "An app updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_CREATED",
+            "description": "A new attribute is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_DELETED",
+            "description": "An attribute is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_UPDATED",
+            "description": "An attribute is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_CREATED",
+            "description": "A new attribute value is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_DELETED",
+            "description": "An attribute value is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_UPDATED",
+            "description": "An attribute value is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100294,6 +104130,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CHECKOUT_CALCULATE_TAXES",
+            "description": "Event called for checkout tax calculation.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CHECKOUT_CREATED",
             "description": "A new checkout is created.",
             "isDeprecated": false,
@@ -100301,7 +104143,7 @@
           },
           {
             "name": "CHECKOUT_FILTER_SHIPPING_METHODS",
-            "description": null,
+            "description": "Filter shipping methods for checkout.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100336,6 +104178,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CUSTOMER_DELETED",
+            "description": "A customer account is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CUSTOMER_UPDATED",
             "description": "A customer account is updated.",
             "isDeprecated": false,
@@ -100343,19 +104191,19 @@
           },
           {
             "name": "DRAFT_ORDER_CREATED",
-            "description": null,
+            "description": "A draft order is created.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DRAFT_ORDER_DELETED",
-            "description": null,
+            "description": "A draft order is deleted.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DRAFT_ORDER_UPDATED",
-            "description": null,
+            "description": "A draft order is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100462,6 +104310,12 @@
             "deprecationReason": null
           },
           {
+            "name": "ORDER_CALCULATE_TAXES",
+            "description": "Event called for order tax calculation.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ORDER_CANCELLED",
             "description": "An order is cancelled.",
             "isDeprecated": false,
@@ -100481,7 +104335,7 @@
           },
           {
             "name": "ORDER_FILTER_SHIPPING_METHODS",
-            "description": null,
+            "description": "Filter shipping methods for order.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100516,6 +104370,24 @@
             "deprecationReason": null
           },
           {
+            "name": "PAGE_TYPE_CREATED",
+            "description": "A new page type is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_TYPE_DELETED",
+            "description": "A page type is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_TYPE_UPDATED",
+            "description": "A page type is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PAGE_UPDATED",
             "description": "A page is updated.",
             "isDeprecated": false,
@@ -100523,43 +104395,61 @@
           },
           {
             "name": "PAYMENT_AUTHORIZE",
-            "description": null,
+            "description": "Authorize payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_CAPTURE",
-            "description": null,
+            "description": "Capture payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_CONFIRM",
-            "description": null,
+            "description": "Confirm payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_LIST_GATEWAYS",
-            "description": null,
+            "description": "Listing available payment gateways.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_PROCESS",
-            "description": null,
+            "description": "Process payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_REFUND",
-            "description": null,
+            "description": "Refund payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_VOID",
-            "description": null,
+            "description": "Void payment.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_CREATED",
+            "description": "A new permission group is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_DELETED",
+            "description": "A permission group is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_UPDATED",
+            "description": "A permission group is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100583,7 +104473,7 @@
           },
           {
             "name": "PRODUCT_VARIANT_BACK_IN_STOCK",
-            "description": null,
+            "description": "A product variant is back in stock.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100601,7 +104491,7 @@
           },
           {
             "name": "PRODUCT_VARIANT_OUT_OF_STOCK",
-            "description": null,
+            "description": "A product variant is out of stock.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100613,25 +104503,31 @@
           },
           {
             "name": "SALE_CREATED",
-            "description": null,
+            "description": "A sale is created.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SALE_DELETED",
-            "description": null,
+            "description": "A sale is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SALE_TOGGLE",
+            "description": "A sale is activated or deactivated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SALE_UPDATED",
-            "description": null,
+            "description": "A sale is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SHIPPING_LIST_METHODS_FOR_CHECKOUT",
-            "description": null,
+            "description": "Fetch external shipping methods for checkout.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100672,20 +104568,38 @@
             "deprecationReason": null
           },
           {
+            "name": "STAFF_CREATED",
+            "description": "A new staff user is created.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_DELETED",
+            "description": "A staff user is deleted.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_UPDATED",
+            "description": "A staff user is updated.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "TRANSACTION_ACTION_REQUEST",
-            "description": null,
+            "description": "An action requested for transaction.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "TRANSLATION_CREATED",
-            "description": null,
+            "description": "A new translation is created.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "TRANSLATION_UPDATED",
-            "description": null,
+            "description": "A translation is updated.",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -100737,62 +104651,74 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "CHECKOUT_CALCULATE_TAXES",
+            "description": "Event called for checkout tax calculation.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CHECKOUT_FILTER_SHIPPING_METHODS",
-            "description": null,
+            "description": "Filter shipping methods for checkout.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ORDER_CALCULATE_TAXES",
+            "description": "Event called for order tax calculation.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "ORDER_FILTER_SHIPPING_METHODS",
-            "description": null,
+            "description": "Filter shipping methods for order.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_AUTHORIZE",
-            "description": null,
+            "description": "Authorize payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_CAPTURE",
-            "description": null,
+            "description": "Capture payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_CONFIRM",
-            "description": null,
+            "description": "Confirm payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_LIST_GATEWAYS",
-            "description": null,
+            "description": "Listing available payment gateways.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_PROCESS",
-            "description": null,
+            "description": "Process payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_REFUND",
-            "description": null,
+            "description": "Refund payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PAYMENT_VOID",
-            "description": null,
+            "description": "Void payment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SHIPPING_LIST_METHODS_FOR_CHECKOUT",
-            "description": null,
+            "description": "Fetch external shipping methods for checkout.",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -100807,6 +104733,24 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
+          {
+            "name": "ADDRESS_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADDRESS_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADDRESS_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "APP_DELETED",
             "description": null,
@@ -100827,6 +104771,42 @@
           },
           {
             "name": "APP_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ATTRIBUTE_VALUE_UPDATED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -100905,6 +104885,12 @@
           },
           {
             "name": "CUSTOMER_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOMER_DELETED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -101084,7 +105070,43 @@
             "deprecationReason": null
           },
           {
+            "name": "PAGE_TYPE_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_TYPE_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PAGE_TYPE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PAGE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERMISSION_GROUP_UPDATED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -101150,6 +105172,12 @@
             "deprecationReason": null
           },
           {
+            "name": "SALE_TOGGLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "SALE_UPDATED",
             "description": null,
             "isDeprecated": false,
@@ -101187,6 +105215,24 @@
           },
           {
             "name": "SHIPPING_ZONE_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_CREATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STAFF_UPDATED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/apps/saleor-app-checkout/graphql/index.ts
+++ b/apps/saleor-app-checkout/graphql/index.ts
@@ -244,6 +244,27 @@ export type AddressCreate = {
 };
 
 /**
+ * Event sent when new address is created.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AddressCreated = Event & {
+  __typename?: "AddressCreated";
+  /** The address the event relates to. */
+  address?: Maybe<Address>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Deletes an address.
  *
  * Requires one of the following permissions: MANAGE_USERS.
@@ -256,6 +277,27 @@ export type AddressDelete = {
   errors: Array<AccountError>;
   /** A user instance for which the address was deleted. */
   user?: Maybe<User>;
+};
+
+/**
+ * Event sent when address is deleted.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AddressDeleted = Event & {
+  __typename?: "AddressDeleted";
+  /** The address the event relates to. */
+  address?: Maybe<Address>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type AddressInput = {
@@ -315,6 +357,27 @@ export type AddressUpdate = {
   user?: Maybe<User>;
 };
 
+/**
+ * Event sent when address is updated.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AddressUpdated = Event & {
+  __typename?: "AddressUpdated";
+  /** The address the event relates to. */
+  address?: Maybe<Address>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
 export type AddressValidationData = {
   __typename?: "AddressValidationData";
   addressFormat: Scalars["String"];
@@ -362,15 +425,21 @@ export type App = Node &
     aboutApp?: Maybe<Scalars["String"]>;
     /** JWT token used to authenticate by thridparty app. */
     accessToken?: Maybe<Scalars["String"]>;
-    /** Url to iframe with the app. */
+    /** URL to iframe with the app. */
     appUrl?: Maybe<Scalars["String"]>;
-    /** Url to iframe with the configuration for the app. */
+    /**
+     * URL to iframe with the configuration for the app.
+     * @deprecated This field will be removed in Saleor 4.0. Use `appUrl` instead.
+     */
     configurationUrl?: Maybe<Scalars["String"]>;
     /** The date and time when the app was created. */
     created?: Maybe<Scalars["DateTime"]>;
-    /** Description of the data privacy defined for this app. */
+    /**
+     * Description of the data privacy defined for this app.
+     * @deprecated This field will be removed in Saleor 4.0. Use `dataPrivacyUrl` instead.
+     */
     dataPrivacy?: Maybe<Scalars["String"]>;
-    /** Url to details about the privacy policy on the app owner page. */
+    /** URL to details about the privacy policy on the app owner page. */
     dataPrivacyUrl?: Maybe<Scalars["String"]>;
     /**
      * App's dashboard extensions.
@@ -385,6 +454,12 @@ export type App = Node &
     id: Scalars["ID"];
     /** Determine if app will be set active or not. */
     isActive?: Maybe<Scalars["Boolean"]>;
+    /**
+     * URL to manifest used during app's installation.
+     *
+     * Added in Saleor 3.5.
+     */
+    manifestUrl?: Maybe<Scalars["String"]>;
     /** List of public metadata items. Can be accessed without permissions. */
     metadata: Array<MetadataItem>;
     /**
@@ -549,15 +624,16 @@ export type AppDeleteFailedInstallation = {
   errors: Array<AppError>;
 };
 
+/**
+ * Event sent when app is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type AppDeleted = Event & {
   __typename?: "AppDeleted";
-  /**
-   * The application the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The application the event relates to. */
   app?: Maybe<App>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -640,6 +716,9 @@ export type AppExtensionFilterInput = {
 
 /** All places where app extension can be mounted. */
 export type AppExtensionMountEnum =
+  | "CUSTOMER_DETAILS_MORE_ACTIONS"
+  | "CUSTOMER_OVERVIEW_CREATE"
+  | "CUSTOMER_OVERVIEW_MORE_ACTIONS"
   | "NAVIGATION_CATALOG"
   | "NAVIGATION_CUSTOMERS"
   | "NAVIGATION_DISCOUNTS"
@@ -725,15 +804,16 @@ export type AppInstallation = Job &
     updatedAt: Scalars["DateTime"];
   };
 
+/**
+ * Event sent when new app is installed.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type AppInstalled = Event & {
   __typename?: "AppInstalled";
-  /**
-   * The application the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The application the event relates to. */
   app?: Maybe<App>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -757,6 +837,20 @@ export type AppManifestExtension = {
   target: AppExtensionTargetEnum;
   /** URL of a view where extension's iframe is placed. */
   url: Scalars["String"];
+};
+
+export type AppManifestWebhook = {
+  __typename?: "AppManifestWebhook";
+  /** The asynchronous events that webhook wants to subscribe. */
+  asyncEvents?: Maybe<Array<WebhookEventTypeAsyncEnum>>;
+  /** The name of the webhook. */
+  name: Scalars["String"];
+  /** Subscription query of a webhook */
+  query: Scalars["String"];
+  /** The synchronous events that webhook wants to subscribe. */
+  syncEvents?: Maybe<Array<WebhookEventTypeSyncEnum>>;
+  /** The url to receive the payload. */
+  targetUrl: Scalars["String"];
 };
 
 /**
@@ -785,15 +879,16 @@ export type AppSortingInput = {
   field: AppSortField;
 };
 
+/**
+ * Event sent when app status has changed.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type AppStatusChanged = Event & {
   __typename?: "AppStatusChanged";
-  /**
-   * The application the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The application the event relates to. */
   app?: Maybe<App>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -880,15 +975,16 @@ export type AppUpdate = {
   errors: Array<AppError>;
 };
 
+/**
+ * Event sent when app is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type AppUpdated = Event & {
   __typename?: "AppUpdated";
-  /**
-   * The application the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The application the event relates to. */
   app?: Maybe<App>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -1145,6 +1241,27 @@ export type AttributeCreateInput = {
 };
 
 /**
+ * Event sent when new attribute is created.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AttributeCreated = Event & {
+  __typename?: "AttributeCreated";
+  /** The attribute the event relates to. */
+  attribute?: Maybe<Attribute>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Deletes an attribute.
  *
  * Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
@@ -1155,6 +1272,27 @@ export type AttributeDelete = {
   /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   attributeErrors: Array<AttributeError>;
   errors: Array<AttributeError>;
+};
+
+/**
+ * Event sent when attribute is deleted.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AttributeDeleted = Event & {
+  __typename?: "AttributeDeleted";
+  /** The attribute the event relates to. */
+  attribute?: Maybe<Attribute>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 /** An enumeration. */
@@ -1224,6 +1362,7 @@ export type AttributeInputTypeEnum =
   | "FILE"
   | "MULTISELECT"
   | "NUMERIC"
+  | "PLAIN_TEXT"
   | "REFERENCE"
   | "RICH_TEXT"
   | "SWATCH";
@@ -1350,6 +1489,27 @@ export type AttributeUpdateInput = {
   visibleInStorefront?: InputMaybe<Scalars["Boolean"]>;
 };
 
+/**
+ * Event sent when attribute is updated.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AttributeUpdated = Event & {
+  __typename?: "AttributeUpdated";
+  /** The attribute the event relates to. */
+  attribute?: Maybe<Attribute>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
 /** Represents a value of an attribute. */
 export type AttributeValue = Node & {
   __typename?: "AttributeValue";
@@ -1366,6 +1526,8 @@ export type AttributeValue = Node & {
   inputType?: Maybe<AttributeInputTypeEnum>;
   /** Name of a value displayed in the interface. */
   name?: Maybe<Scalars["String"]>;
+  /** Represents the text of the attribute value, plain text without formating. */
+  plainText?: Maybe<Scalars["String"]>;
   /** The ID of the attribute reference. */
   reference?: Maybe<Scalars["ID"]>;
   /**
@@ -1440,6 +1602,8 @@ export type AttributeValueCreateInput = {
   fileUrl?: InputMaybe<Scalars["String"]>;
   /** Name of a value displayed in the interface. */
   name: Scalars["String"];
+  /** Represents the text of the attribute value, plain text without formating. */
+  plainText?: InputMaybe<Scalars["String"]>;
   /**
    * Represents the text of the attribute value, includes formatting.
    *
@@ -1448,6 +1612,27 @@ export type AttributeValueCreateInput = {
   richText?: InputMaybe<Scalars["JSONString"]>;
   /** Represent value of the attribute value (e.g. color values for swatch attributes). */
   value?: InputMaybe<Scalars["String"]>;
+};
+
+/**
+ * Event sent when new attribute value is created.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AttributeValueCreated = Event & {
+  __typename?: "AttributeValueCreated";
+  /** The attribute value the event relates to. */
+  attributeValue?: Maybe<AttributeValue>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 /**
@@ -1463,6 +1648,27 @@ export type AttributeValueDelete = {
   attributeErrors: Array<AttributeError>;
   attributeValue?: Maybe<AttributeValue>;
   errors: Array<AttributeError>;
+};
+
+/**
+ * Event sent when attribute value is deleted.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AttributeValueDeleted = Event & {
+  __typename?: "AttributeValueDeleted";
+  /** The attribute value the event relates to. */
+  attributeValue?: Maybe<AttributeValue>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type AttributeValueFilterInput = {
@@ -1483,6 +1689,8 @@ export type AttributeValueInput = {
   file?: InputMaybe<Scalars["String"]>;
   /** ID of the selected attribute. */
   id?: InputMaybe<Scalars["ID"]>;
+  /** Plain text content. */
+  plainText?: InputMaybe<Scalars["String"]>;
   /** List of entity IDs that will be used as references. */
   references?: InputMaybe<Array<Scalars["ID"]>>;
   /** Text content in JSON format. */
@@ -1500,6 +1708,8 @@ export type AttributeValueTranslatableContent = Node & {
   attributeValue?: Maybe<AttributeValue>;
   id: Scalars["ID"];
   name: Scalars["String"];
+  /** Attribute plain text value. */
+  plainText?: Maybe<Scalars["String"]>;
   /**
    * Attribute value.
    *
@@ -1533,6 +1743,8 @@ export type AttributeValueTranslation = Node & {
   /** Translation language. */
   language: LanguageDisplay;
   name: Scalars["String"];
+  /** Attribute plain text value. */
+  plainText?: Maybe<Scalars["String"]>;
   /**
    * Attribute value.
    *
@@ -1543,6 +1755,8 @@ export type AttributeValueTranslation = Node & {
 
 export type AttributeValueTranslationInput = {
   name?: InputMaybe<Scalars["String"]>;
+  /** Translated text. */
+  plainText?: InputMaybe<Scalars["String"]>;
   /**
    * Translated text.
    *
@@ -1573,6 +1787,8 @@ export type AttributeValueUpdateInput = {
   fileUrl?: InputMaybe<Scalars["String"]>;
   /** Name of a value displayed in the interface. */
   name?: InputMaybe<Scalars["String"]>;
+  /** Represents the text of the attribute value, plain text without formating. */
+  plainText?: InputMaybe<Scalars["String"]>;
   /**
    * Represents the text of the attribute value, includes formatting.
    *
@@ -1581,6 +1797,27 @@ export type AttributeValueUpdateInput = {
   richText?: InputMaybe<Scalars["JSONString"]>;
   /** Represent value of the attribute value (e.g. color values for swatch attributes). */
   value?: InputMaybe<Scalars["String"]>;
+};
+
+/**
+ * Event sent when attribute value is updated.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type AttributeValueUpdated = Event & {
+  __typename?: "AttributeValueUpdated";
+  /** The attribute value the event relates to. */
+  attributeValue?: Maybe<AttributeValue>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type BulkAttributeValueInput = {
@@ -1737,6 +1974,7 @@ export type CategoryAncestorsArgs = {
 
 /** Represents a single category of products. Categories allow to organize products in a tree-hierarchies which can be used for navigation in the storefront. */
 export type CategoryBackgroundImageArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
@@ -1826,15 +2064,16 @@ export type CategoryCreate = {
   productErrors: Array<ProductError>;
 };
 
+/**
+ * Event sent when new category is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CategoryCreated = Event & {
   __typename?: "CategoryCreated";
-  /**
-   * The category the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The category the event relates to. */
   category?: Maybe<Category>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -1859,15 +2098,16 @@ export type CategoryDelete = {
   productErrors: Array<ProductError>;
 };
 
+/**
+ * Event sent when category is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CategoryDeleted = Event & {
   __typename?: "CategoryDeleted";
-  /**
-   * The category the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The category the event relates to. */
   category?: Maybe<Category>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2006,15 +2246,16 @@ export type CategoryUpdate = {
   productErrors: Array<ProductError>;
 };
 
+/**
+ * Event sent when category is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CategoryUpdated = Event & {
   __typename?: "CategoryUpdated";
-  /**
-   * The category the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The category the event relates to. */
   category?: Maybe<Category>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2029,11 +2270,34 @@ export type CategoryUpdated = Event & {
 /** Represents channel. */
 export type Channel = Node & {
   __typename?: "Channel";
+  /**
+   * Shipping methods that are available for the channel.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  availableShippingMethodsPerCountry?: Maybe<Array<ShippingMethodsPerCountry>>;
+  /**
+   * List of shippable countries for the channel.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  countries?: Maybe<Array<CountryDisplay>>;
+  /**
+   * A currency that is assigned to the channel.
+   *
+   * Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+   */
   currencyCode: Scalars["String"];
   /**
    * Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
    *
    * Added in Saleor 3.1.
+   *
+   * Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
    */
   defaultCountry: CountryDisplay;
   /**
@@ -2043,9 +2307,35 @@ export type Channel = Node & {
    */
   hasOrders: Scalars["Boolean"];
   id: Scalars["ID"];
+  /**
+   * Whether the channel is active.
+   *
+   * Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+   */
   isActive: Scalars["Boolean"];
+  /**
+   * Name of the channel.
+   *
+   * Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+   */
   name: Scalars["String"];
+  /** Slug of the channel. */
   slug: Scalars["String"];
+  /**
+   * List of warehouses assigned to this channel.
+   *
+   * Added in Saleor 3.5.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   *
+   * Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+   */
+  warehouses: Array<Warehouse>;
+};
+
+/** Represents channel. */
+export type ChannelAvailableShippingMethodsPerCountryArgs = {
+  countries?: InputMaybe<Array<CountryCode>>;
 };
 
 /**
@@ -2078,12 +2368,22 @@ export type ChannelCreate = {
 export type ChannelCreateInput = {
   /** List of shipping zones to assign to the channel. */
   addShippingZones?: InputMaybe<Array<Scalars["ID"]>>;
+  /**
+   * List of warehouses to assign to the channel.
+   *
+   * Added in Saleor 3.5.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  addWarehouses?: InputMaybe<Array<Scalars["ID"]>>;
   /** Currency of the channel. */
   currencyCode: Scalars["String"];
   /**
    * Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
    *
    * Added in Saleor 3.1.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
    */
   defaultCountry: CountryCode;
   /** isActive flag. */
@@ -2094,15 +2394,16 @@ export type ChannelCreateInput = {
   slug: Scalars["String"];
 };
 
+/**
+ * Event sent when new channel is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ChannelCreated = Event & {
   __typename?: "ChannelCreated";
-  /**
-   * The channel the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The channel the event relates to. */
   channel?: Maybe<Channel>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2146,15 +2447,16 @@ export type ChannelDeleteInput = {
   channelId: Scalars["ID"];
 };
 
+/**
+ * Event sent when channel is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ChannelDeleted = Event & {
   __typename?: "ChannelDeleted";
-  /**
-   * The channel the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The channel the event relates to. */
   channel?: Maybe<Channel>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2176,6 +2478,8 @@ export type ChannelError = {
   message?: Maybe<Scalars["String"]>;
   /** List of shipping zone IDs which causes the error. */
   shippingZones?: Maybe<Array<Scalars["ID"]>>;
+  /** List of warehouses IDs which causes the error. */
+  warehouses?: Maybe<Array<Scalars["ID"]>>;
 };
 
 /** An enumeration. */
@@ -2190,15 +2494,16 @@ export type ChannelErrorCode =
   | "REQUIRED"
   | "UNIQUE";
 
+/**
+ * Event sent when channel status has changed.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ChannelStatusChanged = Event & {
   __typename?: "ChannelStatusChanged";
-  /**
-   * The channel the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The channel the event relates to. */
   channel?: Maybe<Channel>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2227,6 +2532,14 @@ export type ChannelUpdateInput = {
   /** List of shipping zones to assign to the channel. */
   addShippingZones?: InputMaybe<Array<Scalars["ID"]>>;
   /**
+   * List of warehouses to assign to the channel.
+   *
+   * Added in Saleor 3.5.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  addWarehouses?: InputMaybe<Array<Scalars["ID"]>>;
+  /**
    * Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
    *
    * Added in Saleor 3.1.
@@ -2238,19 +2551,28 @@ export type ChannelUpdateInput = {
   name?: InputMaybe<Scalars["String"]>;
   /** List of shipping zones to unassign from the channel. */
   removeShippingZones?: InputMaybe<Array<Scalars["ID"]>>;
+  /**
+   * List of warehouses to unassign from the channel.
+   *
+   * Added in Saleor 3.5.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  removeWarehouses?: InputMaybe<Array<Scalars["ID"]>>;
   /** Slug of the channel. */
   slug?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when channel is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ChannelUpdated = Event & {
   __typename?: "ChannelUpdated";
-  /**
-   * The channel the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The channel the event relates to. */
   channel?: Maybe<Channel>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2414,6 +2736,15 @@ export type CheckoutAddPromoCode = {
   errors: Array<CheckoutError>;
 };
 
+export type CheckoutAddressValidationRules = {
+  /** Determines if an error should be raised when the provided address doesn't match the expected format. Example: using letters for postal code when the numbers are expected. */
+  checkFieldsFormat?: InputMaybe<Scalars["Boolean"]>;
+  /** Determines if an error should be raised when the provided address doesn't have all the required fields. The list of required fields is dynamic and depends on the country code (use the `addressValidationRules` query to fetch them). Note: country code is mandatory for all addresses regardless of the rules provided in this input. */
+  checkRequiredFields?: InputMaybe<Scalars["Boolean"]>;
+  /** Determines if Saleor should apply normalization on address fields. Example: converting city field to uppercase letters. */
+  enableFieldsNormalization?: InputMaybe<Scalars["Boolean"]>;
+};
+
 /** Update billing address in the existing checkout. */
 export type CheckoutBillingAddressUpdate = {
   __typename?: "CheckoutBillingAddressUpdate";
@@ -2482,17 +2813,26 @@ export type CheckoutCreateInput = {
   lines: Array<CheckoutLineInput>;
   /** The mailing address to where the checkout will be shipped. Note: the address will be ignored if the checkout doesn't contain shippable items. */
   shippingAddress?: InputMaybe<AddressInput>;
-};
-
-export type CheckoutCreated = Event & {
-  __typename?: "CheckoutCreated";
   /**
-   * The checkout the event relates to.
+   * The checkout validation rules that can be changed.
    *
-   * Added in Saleor 3.2.
+   * Added in Saleor 3.5.
    *
    * Note: this API is currently in Feature Preview and can be subject to changes at later point.
    */
+  validationRules?: InputMaybe<CheckoutValidationRules>;
+};
+
+/**
+ * Event sent when new checkout is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type CheckoutCreated = Event & {
+  __typename?: "CheckoutCreated";
+  /** The checkout the event relates to. */
   checkout?: Maybe<Checkout>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2610,6 +2950,35 @@ export type CheckoutFilterInput = {
   search?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Filter shipping methods for checkout.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type CheckoutFilterShippingMethods = Event & {
+  __typename?: "CheckoutFilterShippingMethods";
+  /** The checkout the event relates to. */
+  checkout?: Maybe<Checkout>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /**
+   * Shipping methods that can be used with this checkout.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  shippingMethods?: Maybe<Array<ShippingMethod>>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
 /** Update language code in the existing checkout. */
 export type CheckoutLanguageCodeUpdate = {
   __typename?: "CheckoutLanguageCodeUpdate";
@@ -2621,21 +2990,82 @@ export type CheckoutLanguageCodeUpdate = {
 };
 
 /** Represents an item in the checkout. */
-export type CheckoutLine = Node & {
-  __typename?: "CheckoutLine";
-  id: Scalars["ID"];
-  quantity: Scalars["Int"];
-  /** Indicates whether the item need to be delivered. */
-  requiresShipping: Scalars["Boolean"];
-  /** The sum of the checkout line price, taxes and discounts. */
-  totalPrice: TaxedMoney;
-  /** The sum of the checkout line price, without discounts. */
-  undiscountedTotalPrice: Money;
-  /** The unit price of the checkout line, without discounts. */
-  undiscountedUnitPrice: Money;
-  /** The unit price of the checkout line, with taxes and discounts. */
-  unitPrice: TaxedMoney;
-  variant: ProductVariant;
+export type CheckoutLine = Node &
+  ObjectWithMetadata & {
+    __typename?: "CheckoutLine";
+    id: Scalars["ID"];
+    /** List of public metadata items. Can be accessed without permissions. */
+    metadata: Array<MetadataItem>;
+    /**
+     * A single key from public metadata.
+     *
+     * Tip: Use GraphQL aliases to fetch multiple keys.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    metafield?: Maybe<Scalars["String"]>;
+    /**
+     * Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    metafields?: Maybe<Scalars["Metadata"]>;
+    /** List of private metadata items. Requires staff permissions to access. */
+    privateMetadata: Array<MetadataItem>;
+    /**
+     * A single key from private metadata. Requires staff permissions to access.
+     *
+     * Tip: Use GraphQL aliases to fetch multiple keys.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    privateMetafield?: Maybe<Scalars["String"]>;
+    /**
+     * Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    privateMetafields?: Maybe<Scalars["Metadata"]>;
+    quantity: Scalars["Int"];
+    /** Indicates whether the item need to be delivered. */
+    requiresShipping: Scalars["Boolean"];
+    /** The sum of the checkout line price, taxes and discounts. */
+    totalPrice: TaxedMoney;
+    /** The sum of the checkout line price, without discounts. */
+    undiscountedTotalPrice: Money;
+    /** The unit price of the checkout line, without discounts. */
+    undiscountedUnitPrice: Money;
+    /** The unit price of the checkout line, with taxes and discounts. */
+    unitPrice: TaxedMoney;
+    variant: ProductVariant;
+  };
+
+/** Represents an item in the checkout. */
+export type CheckoutLineMetafieldArgs = {
+  key: Scalars["String"];
+};
+
+/** Represents an item in the checkout. */
+export type CheckoutLineMetafieldsArgs = {
+  keys?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+/** Represents an item in the checkout. */
+export type CheckoutLinePrivateMetafieldArgs = {
+  key: Scalars["String"];
+};
+
+/** Represents an item in the checkout. */
+export type CheckoutLinePrivateMetafieldsArgs = {
+  keys?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type CheckoutLineCountableConnection = {
@@ -2667,6 +3097,14 @@ export type CheckoutLineDelete = {
 
 export type CheckoutLineInput = {
   /**
+   * Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  forceNewLine?: InputMaybe<Scalars["Boolean"]>;
+  /**
    * Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
    *
    * Added in Saleor 3.1.
@@ -2682,6 +3120,12 @@ export type CheckoutLineInput = {
 
 export type CheckoutLineUpdateInput = {
   /**
+   * ID of the line.
+   *
+   * Added in Saleor 3.6.
+   */
+  lineId?: InputMaybe<Scalars["ID"]>;
+  /**
    * Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
    *
    * Added in Saleor 3.1.
@@ -2691,8 +3135,12 @@ export type CheckoutLineUpdateInput = {
   price?: InputMaybe<Scalars["PositiveDecimal"]>;
   /** The number of items purchased. Optional for apps, required for any other users. */
   quantity?: InputMaybe<Scalars["Int"]>;
-  /** ID of the product variant. */
-  variantId: Scalars["ID"];
+  /**
+   * ID of the product variant.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use `lineId` instead.
+   */
+  variantId?: InputMaybe<Scalars["ID"]>;
 };
 
 /** Adds a checkout line to the existing checkout.If line was already in checkout, its quantity will be increased. */
@@ -2780,15 +3228,16 @@ export type CheckoutSortingInput = {
   field: CheckoutSortField;
 };
 
+/**
+ * Event sent when checkout is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CheckoutUpdated = Event & {
   __typename?: "CheckoutUpdated";
-  /**
-   * The checkout the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The checkout the event relates to. */
   checkout?: Maybe<Checkout>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -2798,6 +3247,13 @@ export type CheckoutUpdated = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
+};
+
+export type CheckoutValidationRules = {
+  /** The validation rules that can be applied to provided billing address data. */
+  billingAddress?: InputMaybe<CheckoutAddressValidationRules>;
+  /** The validation rules that can be applied to provided shipping address data. */
+  shippingAddress?: InputMaybe<CheckoutAddressValidationRules>;
 };
 
 export type ChoiceValue = {
@@ -2885,6 +3341,7 @@ export type Collection = Node &
 
 /** Represents a collection of products. */
 export type CollectionBackgroundImageArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
@@ -3063,15 +3520,16 @@ export type CollectionCreateInput = {
   slug?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new collection is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CollectionCreated = Event & {
   __typename?: "CollectionCreated";
-  /**
-   * The collection the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The collection the event relates to. */
   collection?: Maybe<Collection>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -3083,6 +3541,13 @@ export type CollectionCreated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new collection is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CollectionCreatedCollectionArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -3100,15 +3565,16 @@ export type CollectionDelete = {
   errors: Array<CollectionError>;
 };
 
+/**
+ * Event sent when collection is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CollectionDeleted = Event & {
   __typename?: "CollectionDeleted";
-  /**
-   * The collection the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The collection the event relates to. */
   collection?: Maybe<Collection>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -3120,6 +3586,13 @@ export type CollectionDeleted = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when collection is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CollectionDeletedCollectionArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -3334,15 +3807,16 @@ export type CollectionUpdate = {
   errors: Array<CollectionError>;
 };
 
+/**
+ * Event sent when collection is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CollectionUpdated = Event & {
   __typename?: "CollectionUpdated";
-  /**
-   * The collection the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The collection the event relates to. */
   collection?: Maybe<Collection>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -3354,6 +3828,13 @@ export type CollectionUpdated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when collection is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CollectionUpdatedCollectionArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -3739,6 +4220,13 @@ export type CustomerCreate = {
   user?: Maybe<User>;
 };
 
+/**
+ * Event sent when new customer user is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CustomerCreated = Event & {
   __typename?: "CustomerCreated";
   /** Time of the event. */
@@ -3747,13 +4235,7 @@ export type CustomerCreated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The user the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The user the event relates to. */
   user?: Maybe<User>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
@@ -3796,7 +4278,9 @@ export type CustomerEvent = Node & {
 
 /** An enumeration. */
 export type CustomerEventsEnum =
+  | "ACCOUNT_ACTIVATED"
   | "ACCOUNT_CREATED"
+  | "ACCOUNT_DEACTIVATED"
   | "CUSTOMER_DELETED"
   | "DIGITAL_LINK_DOWNLOADED"
   | "EMAIL_ASSIGNED"
@@ -3851,6 +4335,13 @@ export type CustomerUpdate = {
   user?: Maybe<User>;
 };
 
+/**
+ * Event sent when customer user is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type CustomerUpdated = Event & {
   __typename?: "CustomerUpdated";
   /** Time of the event. */
@@ -3859,13 +4350,7 @@ export type CustomerUpdated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The user the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The user the event relates to. */
   user?: Maybe<User>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
@@ -4216,19 +4701,20 @@ export type DraftOrderCreateInput = {
   voucher?: InputMaybe<Scalars["ID"]>;
 };
 
+/**
+ * Event sent when new draft order is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type DraftOrderCreated = Event & {
   __typename?: "DraftOrderCreated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -4249,19 +4735,20 @@ export type DraftOrderDelete = {
   orderErrors: Array<OrderError>;
 };
 
+/**
+ * Event sent when draft order is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type DraftOrderDeleted = Event & {
   __typename?: "DraftOrderDeleted";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -4319,19 +4806,20 @@ export type DraftOrderUpdate = {
   orderErrors: Array<OrderError>;
 };
 
+/**
+ * Event sent when draft order is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type DraftOrderUpdated = Event & {
   __typename?: "DraftOrderUpdated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -4888,27 +5376,22 @@ export type FulfillmentCancelInput = {
   warehouseId?: InputMaybe<Scalars["ID"]>;
 };
 
+/**
+ * Event sent when fulfillment is canceled.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type FulfillmentCanceled = Event & {
   __typename?: "FulfillmentCanceled";
-  /**
-   * The fulfillment the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The fulfillment the event relates to. */
   fulfillment?: Maybe<Fulfillment>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the fulfillment belongs to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the fulfillment belongs to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -4916,27 +5399,22 @@ export type FulfillmentCanceled = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new fulfillment is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type FulfillmentCreated = Event & {
   __typename?: "FulfillmentCreated";
-  /**
-   * The fulfillment the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The fulfillment the event relates to. */
   fulfillment?: Maybe<Fulfillment>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the fulfillment belongs to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the fulfillment belongs to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -5073,7 +5551,7 @@ export type GiftCard = Node &
      * Requires one of the following permissions: MANAGE_USERS, OWNER.
      */
     createdByEmail?: Maybe<Scalars["String"]>;
-    currentBalance?: Maybe<Money>;
+    currentBalance: Money;
     /** Code in format which allows displaying in a user interface. */
     displayCode: Scalars["String"];
     /**
@@ -5093,7 +5571,7 @@ export type GiftCard = Node &
     events: Array<GiftCardEvent>;
     expiryDate?: Maybe<Scalars["Date"]>;
     id: Scalars["ID"];
-    initialBalance?: Maybe<Money>;
+    initialBalance: Money;
     isActive: Scalars["Boolean"];
     /** Last 4 characters of gift card code. */
     last4CodeChars: Scalars["String"];
@@ -5420,15 +5898,16 @@ export type GiftCardCreateInput = {
   userEmail?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new gift card is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type GiftCardCreated = Event & {
   __typename?: "GiftCardCreated";
-  /**
-   * The gift card the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The gift card the event relates to. */
   giftCard?: Maybe<GiftCard>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -5471,15 +5950,16 @@ export type GiftCardDelete = {
   giftCardErrors: Array<GiftCardError>;
 };
 
+/**
+ * Event sent when gift card is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type GiftCardDeleted = Event & {
   __typename?: "GiftCardDeleted";
-  /**
-   * The gift card the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The gift card the event relates to. */
   giftCard?: Maybe<GiftCard>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -5681,15 +6161,16 @@ export type GiftCardSortingInput = {
   field: GiftCardSortField;
 };
 
+/**
+ * Event sent when gift card status has changed.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type GiftCardStatusChanged = Event & {
   __typename?: "GiftCardStatusChanged";
-  /**
-   * The gift card the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The gift card the event relates to. */
   giftCard?: Maybe<GiftCard>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -5795,15 +6276,16 @@ export type GiftCardUpdateInput = {
   startDate?: InputMaybe<Scalars["Date"]>;
 };
 
+/**
+ * Event sent when gift card is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type GiftCardUpdated = Event & {
   __typename?: "GiftCardUpdated";
-  /**
-   * The gift card the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The gift card the event relates to. */
   giftCard?: Maybe<GiftCard>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -5976,15 +6458,16 @@ export type InvoiceDelete = {
   invoiceErrors: Array<InvoiceError>;
 };
 
+/**
+ * Event sent when invoice is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type InvoiceDeleted = Event & {
   __typename?: "InvoiceDeleted";
-  /**
-   * The invoice the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The invoice the event relates to. */
   invoice?: Maybe<Invoice>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -6045,15 +6528,16 @@ export type InvoiceRequestDelete = {
   invoiceErrors: Array<InvoiceError>;
 };
 
+/**
+ * Event sent when invoice is requested.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type InvoiceRequested = Event & {
   __typename?: "InvoiceRequested";
-  /**
-   * The invoice the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The invoice the event relates to. */
   invoice?: Maybe<Invoice>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -6078,15 +6562,16 @@ export type InvoiceSendNotification = {
   invoiceErrors: Array<InvoiceError>;
 };
 
+/**
+ * Event sent when invoice is sent.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type InvoiceSent = Event & {
   __typename?: "InvoiceSent";
-  /**
-   * The invoice the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The invoice the event relates to. */
   invoice?: Maybe<Invoice>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
@@ -6939,7 +7424,15 @@ export type Manifest = {
   __typename?: "Manifest";
   about?: Maybe<Scalars["String"]>;
   appUrl?: Maybe<Scalars["String"]>;
+  /**
+   * URL to iframe with the configuration for the app.
+   * @deprecated This field will be removed in Saleor 4.0. Use `appUrl` instead.
+   */
   configurationUrl?: Maybe<Scalars["String"]>;
+  /**
+   * Description of the data privacy defined for this app.
+   * @deprecated This field will be removed in Saleor 4.0. Use `dataPrivacyUrl` instead.
+   */
   dataPrivacy?: Maybe<Scalars["String"]>;
   dataPrivacyUrl?: Maybe<Scalars["String"]>;
   extensions: Array<AppManifestExtension>;
@@ -6950,6 +7443,14 @@ export type Manifest = {
   supportUrl?: Maybe<Scalars["String"]>;
   tokenTargetUrl?: Maybe<Scalars["String"]>;
   version: Scalars["String"];
+  /**
+   * List of the app's webhooks.
+   *
+   * Added in Saleor 3.5.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  webhooks: Array<AppManifestWebhook>;
 };
 
 export type Margin = {
@@ -7114,19 +7615,20 @@ export type MenuCreateInput = {
   slug?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new menu is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuCreated = Event & {
   __typename?: "MenuCreated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The menu the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The menu the event relates to. */
   menu?: Maybe<Menu>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -7134,6 +7636,13 @@ export type MenuCreated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new menu is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuCreatedMenuArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -7151,19 +7660,20 @@ export type MenuDelete = {
   menuErrors: Array<MenuError>;
 };
 
+/**
+ * Event sent when menu is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuDeleted = Event & {
   __typename?: "MenuDeleted";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The menu the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The menu the event relates to. */
   menu?: Maybe<Menu>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -7171,6 +7681,13 @@ export type MenuDeleted = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when menu is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuDeletedMenuArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -7357,19 +7874,20 @@ export type MenuItemCreateInput = {
   url?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new menu item is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuItemCreated = Event & {
   __typename?: "MenuItemCreated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The menu item the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The menu item the event relates to. */
   menuItem?: Maybe<MenuItem>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -7377,6 +7895,13 @@ export type MenuItemCreated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new menu item is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuItemCreatedMenuItemArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -7394,19 +7919,20 @@ export type MenuItemDelete = {
   menuItem?: Maybe<MenuItem>;
 };
 
+/**
+ * Event sent when menu item is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuItemDeleted = Event & {
   __typename?: "MenuItemDeleted";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The menu item the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The menu item the event relates to. */
   menuItem?: Maybe<MenuItem>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -7414,6 +7940,13 @@ export type MenuItemDeleted = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when menu item is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuItemDeletedMenuItemArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -7517,19 +8050,20 @@ export type MenuItemUpdate = {
   menuItem?: Maybe<MenuItem>;
 };
 
+/**
+ * Event sent when menu item is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuItemUpdated = Event & {
   __typename?: "MenuItemUpdated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The menu item the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The menu item the event relates to. */
   menuItem?: Maybe<MenuItem>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -7537,6 +8071,13 @@ export type MenuItemUpdated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when menu item is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuItemUpdatedMenuItemArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -7571,19 +8112,20 @@ export type MenuUpdate = {
   menuErrors: Array<MenuError>;
 };
 
+/**
+ * Event sent when menu is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuUpdated = Event & {
   __typename?: "MenuUpdated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The menu the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The menu the event relates to. */
   menu?: Maybe<Menu>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -7591,6 +8133,13 @@ export type MenuUpdated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when menu is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type MenuUpdatedMenuArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -7957,7 +8506,7 @@ export type Mutation = {
   checkoutLanguageCodeUpdate?: Maybe<CheckoutLanguageCodeUpdate>;
   /**
    * Deletes a CheckoutLine.
-   * @deprecated DEPRECATED: Will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead.
+   * @deprecated This field will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead.
    */
   checkoutLineDelete?: Maybe<CheckoutLineDelete>;
   /** Adds a checkout line to the existing checkout.If line was already in checkout, its quantity will be increased. */
@@ -8653,19 +9202,19 @@ export type Mutation = {
    */
   paymentVoid?: Maybe<PaymentVoid>;
   /**
-   * Create new permission group.
+   * Create new permission group. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
   permissionGroupCreate?: Maybe<PermissionGroupCreate>;
   /**
-   * Delete permission group.
+   * Delete permission group. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
   permissionGroupDelete?: Maybe<PermissionGroupDelete>;
   /**
-   * Update permission group.
+   * Update permission group. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
@@ -9047,19 +9596,19 @@ export type Mutation = {
    */
   shopSettingsUpdate?: Maybe<ShopSettingsUpdate>;
   /**
-   * Deletes staff users.
+   * Deletes staff users. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
   staffBulkDelete?: Maybe<StaffBulkDelete>;
   /**
-   * Creates a new staff user.
+   * Creates a new staff user. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
   staffCreate?: Maybe<StaffCreate>;
   /**
-   * Deletes a staff user.
+   * Deletes a staff user. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
@@ -9083,7 +9632,7 @@ export type Mutation = {
    */
   staffNotificationRecipientUpdate?: Maybe<StaffNotificationRecipientUpdate>;
   /**
-   * Updates an existing staff user.
+   * Updates an existing staff user. Apps are not allowed to perform this mutation.
    *
    * Requires one of the following permissions: MANAGE_STAFF.
    */
@@ -9466,6 +10015,7 @@ export type MutationCheckoutBillingAddressUpdateArgs = {
   checkoutId?: InputMaybe<Scalars["ID"]>;
   id?: InputMaybe<Scalars["ID"]>;
   token?: InputMaybe<Scalars["UUID"]>;
+  validationRules?: InputMaybe<CheckoutAddressValidationRules>;
 };
 
 export type MutationCheckoutCompleteArgs = {
@@ -9561,6 +10111,7 @@ export type MutationCheckoutShippingAddressUpdateArgs = {
   id?: InputMaybe<Scalars["ID"]>;
   shippingAddress: AddressInput;
   token?: InputMaybe<Scalars["UUID"]>;
+  validationRules?: InputMaybe<CheckoutAddressValidationRules>;
 };
 
 export type MutationCheckoutShippingMethodUpdateArgs = {
@@ -10917,19 +11468,20 @@ export type OrderCancel = {
   orderErrors: Array<OrderError>;
 };
 
+/**
+ * Event sent when order is canceled.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type OrderCancelled = Event & {
   __typename?: "OrderCancelled";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -10980,19 +11532,20 @@ export type OrderConfirm = {
   orderErrors: Array<OrderError>;
 };
 
+/**
+ * Event sent when order is confirmed.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type OrderConfirmed = Event & {
   __typename?: "OrderConfirmed";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -11062,19 +11615,20 @@ export type OrderCreateFromCheckoutErrorCode =
   | "UNAVAILABLE_VARIANT_IN_CHANNEL"
   | "VOUCHER_NOT_APPLICABLE";
 
+/**
+ * Event sent when new order is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type OrderCreated = Event & {
   __typename?: "OrderCreated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -11406,6 +11960,35 @@ export type OrderFilterInput = {
 };
 
 /**
+ * Filter shipping methods for order.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type OrderFilterShippingMethods = Event & {
+  __typename?: "OrderFilterShippingMethods";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The order the event relates to. */
+  order?: Maybe<Order>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /**
+   * Shipping methods that can be used with this checkout.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  shippingMethods?: Maybe<Array<ShippingMethod>>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Creates new fulfillments for an order.
  *
  * Requires one of the following permissions: MANAGE_ORDERS.
@@ -11428,6 +12011,12 @@ export type OrderFulfillInput = {
   lines: Array<OrderFulfillLineInput>;
   /** If true, send an email notification to the customer. */
   notifyCustomer?: InputMaybe<Scalars["Boolean"]>;
+  /**
+   * Fulfillment tracking number.
+   *
+   * Added in Saleor 3.6.
+   */
+  trackingNumber?: InputMaybe<Scalars["String"]>;
 };
 
 export type OrderFulfillLineInput = {
@@ -11444,19 +12033,20 @@ export type OrderFulfillStockInput = {
   warehouse: Scalars["ID"];
 };
 
+/**
+ * Event sent when order is fulfilled.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type OrderFulfilled = Event & {
   __typename?: "OrderFulfilled";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -11464,19 +12054,20 @@ export type OrderFulfilled = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when order is fully paid.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type OrderFullyPaid = Event & {
   __typename?: "OrderFullyPaid";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -11485,59 +12076,128 @@ export type OrderFullyPaid = Event & {
 };
 
 /** Represents order line of particular order. */
-export type OrderLine = Node & {
-  __typename?: "OrderLine";
-  /**
-   * List of allocations across warehouses.
-   *
-   * Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
-   */
-  allocations?: Maybe<Array<Allocation>>;
-  digitalContentUrl?: Maybe<DigitalContentUrl>;
-  id: Scalars["ID"];
-  isShippingRequired: Scalars["Boolean"];
-  productName: Scalars["String"];
-  productSku?: Maybe<Scalars["String"]>;
-  productVariantId?: Maybe<Scalars["String"]>;
-  quantity: Scalars["Int"];
-  quantityFulfilled: Scalars["Int"];
-  /**
-   * A quantity of items remaining to be fulfilled.
-   *
-   * Added in Saleor 3.1.
-   */
-  quantityToFulfill: Scalars["Int"];
-  taxRate: Scalars["Float"];
-  /** The main thumbnail for the ordered product. */
-  thumbnail?: Maybe<Image>;
-  /** Price of the order line. */
-  totalPrice: TaxedMoney;
-  /** Product name in the customer's language */
-  translatedProductName: Scalars["String"];
-  /** Variant name in the customer's language */
-  translatedVariantName: Scalars["String"];
-  /** Price of the single item in the order line without applied an order line discount. */
-  undiscountedUnitPrice: TaxedMoney;
-  /** The discount applied to the single order line. */
-  unitDiscount: Money;
-  unitDiscountReason?: Maybe<Scalars["String"]>;
-  /** Type of the discount: fixed or percent */
-  unitDiscountType?: Maybe<DiscountValueTypeEnum>;
-  /** Value of the discount. Can store fixed value or percent value */
-  unitDiscountValue: Scalars["PositiveDecimal"];
-  /** Price of the single item in the order line. */
-  unitPrice: TaxedMoney;
-  /** A purchased product variant. Note: this field may be null if the variant has been removed from stock at all. Requires one of the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS. */
-  variant?: Maybe<ProductVariant>;
-  variantName: Scalars["String"];
+export type OrderLine = Node &
+  ObjectWithMetadata & {
+    __typename?: "OrderLine";
+    /**
+     * List of allocations across warehouses.
+     *
+     * Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
+     */
+    allocations?: Maybe<Array<Allocation>>;
+    digitalContentUrl?: Maybe<DigitalContentUrl>;
+    id: Scalars["ID"];
+    isShippingRequired: Scalars["Boolean"];
+    /** List of public metadata items. Can be accessed without permissions. */
+    metadata: Array<MetadataItem>;
+    /**
+     * A single key from public metadata.
+     *
+     * Tip: Use GraphQL aliases to fetch multiple keys.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    metafield?: Maybe<Scalars["String"]>;
+    /**
+     * Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    metafields?: Maybe<Scalars["Metadata"]>;
+    /** List of private metadata items. Requires staff permissions to access. */
+    privateMetadata: Array<MetadataItem>;
+    /**
+     * A single key from private metadata. Requires staff permissions to access.
+     *
+     * Tip: Use GraphQL aliases to fetch multiple keys.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    privateMetafield?: Maybe<Scalars["String"]>;
+    /**
+     * Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+     *
+     * Added in Saleor 3.3.
+     *
+     * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+     */
+    privateMetafields?: Maybe<Scalars["Metadata"]>;
+    productName: Scalars["String"];
+    productSku?: Maybe<Scalars["String"]>;
+    productVariantId?: Maybe<Scalars["String"]>;
+    quantity: Scalars["Int"];
+    quantityFulfilled: Scalars["Int"];
+    /**
+     * A quantity of items remaining to be fulfilled.
+     *
+     * Added in Saleor 3.1.
+     */
+    quantityToFulfill: Scalars["Int"];
+    taxRate: Scalars["Float"];
+    thumbnail?: Maybe<Image>;
+    /** Price of the order line. */
+    totalPrice: TaxedMoney;
+    /** Product name in the customer's language */
+    translatedProductName: Scalars["String"];
+    /** Variant name in the customer's language */
+    translatedVariantName: Scalars["String"];
+    /** Price of the single item in the order line without applied an order line discount. */
+    undiscountedUnitPrice: TaxedMoney;
+    /** The discount applied to the single order line. */
+    unitDiscount: Money;
+    unitDiscountReason?: Maybe<Scalars["String"]>;
+    /** Type of the discount: fixed or percent */
+    unitDiscountType?: Maybe<DiscountValueTypeEnum>;
+    /** Value of the discount. Can store fixed value or percent value */
+    unitDiscountValue: Scalars["PositiveDecimal"];
+    /** Price of the single item in the order line. */
+    unitPrice: TaxedMoney;
+    /** A purchased product variant. Note: this field may be null if the variant has been removed from stock at all. Requires one of the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS. */
+    variant?: Maybe<ProductVariant>;
+    variantName: Scalars["String"];
+  };
+
+/** Represents order line of particular order. */
+export type OrderLineMetafieldArgs = {
+  key: Scalars["String"];
+};
+
+/** Represents order line of particular order. */
+export type OrderLineMetafieldsArgs = {
+  keys?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+/** Represents order line of particular order. */
+export type OrderLinePrivateMetafieldArgs = {
+  key: Scalars["String"];
+};
+
+/** Represents order line of particular order. */
+export type OrderLinePrivateMetafieldsArgs = {
+  keys?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 /** Represents order line of particular order. */
 export type OrderLineThumbnailArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
 export type OrderLineCreateInput = {
+  /**
+   * Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  forceNewLine?: InputMaybe<Scalars["Boolean"]>;
   /** Number of variant items ordered. */
   quantity: Scalars["Int"];
   /** Product variant ID. */
@@ -11778,7 +12438,9 @@ export type OrderSortField =
   /** Sort orders by number. */
   | "NUMBER"
   /** Sort orders by payment. */
-  | "PAYMENT";
+  | "PAYMENT"
+  /** Sort orders by rank. Note: This option is available only with the `search` filter. */
+  | "RANK";
 
 export type OrderSortingInput = {
   /** Specifies the direction in which to sort products. */
@@ -11848,19 +12510,20 @@ export type OrderUpdateShippingInput = {
   shippingMethod?: InputMaybe<Scalars["ID"]>;
 };
 
+/**
+ * Event sent when order is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type OrderUpdated = Event & {
   __typename?: "OrderUpdated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The order the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The order the event relates to. */
   order?: Maybe<Order>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -12105,19 +12768,20 @@ export type PageCreateInput = {
   title?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new page is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type PageCreated = Event & {
   __typename?: "PageCreated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The page the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The page the event relates to. */
   page?: Maybe<Page>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -12138,19 +12802,20 @@ export type PageDelete = {
   pageErrors: Array<PageError>;
 };
 
+/**
+ * Event sent when page is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type PageDeleted = Event & {
   __typename?: "PageDeleted";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The page the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The page the event relates to. */
   page?: Maybe<Page>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -12504,6 +13169,27 @@ export type PageTypeCreateInput = {
 };
 
 /**
+ * Event sent when new page type is created.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PageTypeCreated = Event & {
+  __typename?: "PageTypeCreated";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The page type the event relates to. */
+  pageType?: Maybe<PageType>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Delete a page type.
  *
  * Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
@@ -12514,6 +13200,27 @@ export type PageTypeDelete = {
   /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   pageErrors: Array<PageError>;
   pageType?: Maybe<PageType>;
+};
+
+/**
+ * Event sent when page type is deleted.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PageTypeDeleted = Event & {
+  __typename?: "PageTypeDeleted";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The page type the event relates to. */
+  pageType?: Maybe<PageType>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type PageTypeFilterInput = {
@@ -12572,6 +13279,27 @@ export type PageTypeUpdateInput = {
 };
 
 /**
+ * Event sent when page type is updated.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PageTypeUpdated = Event & {
+  __typename?: "PageTypeUpdated";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The page type the event relates to. */
+  pageType?: Maybe<PageType>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Updates an existing page.
  *
  * Requires one of the following permissions: MANAGE_PAGES.
@@ -12584,19 +13312,20 @@ export type PageUpdate = {
   pageErrors: Array<PageError>;
 };
 
+/**
+ * Event sent when page is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type PageUpdated = Event & {
   __typename?: "PageUpdated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The page the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The page the event relates to. */
   page?: Maybe<Page>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -12732,6 +13461,27 @@ export type PaymentPrivateMetafieldsArgs = {
 };
 
 /**
+ * Authorize payment.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentAuthorize = Event & {
+  __typename?: "PaymentAuthorize";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** Look up a payment. */
+  payment?: Maybe<Payment>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Captures the authorized payment amount.
  *
  * Requires one of the following permissions: MANAGE_ORDERS.
@@ -12743,6 +13493,27 @@ export type PaymentCapture = {
   payment?: Maybe<Payment>;
   /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
+};
+
+/**
+ * Capture payment.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentCaptureEvent = Event & {
+  __typename?: "PaymentCaptureEvent";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** Look up a payment. */
+  payment?: Maybe<Payment>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 /** An enumeration. */
@@ -12775,6 +13546,27 @@ export type PaymentCheckBalanceInput = {
   gatewayId: Scalars["String"];
   /** Payment method name. */
   method: Scalars["String"];
+};
+
+/**
+ * Confirm payment.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentConfirmEvent = Event & {
+  __typename?: "PaymentConfirmEvent";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** Look up a payment. */
+  payment?: Maybe<Payment>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type PaymentCountableConnection = {
@@ -12887,6 +13679,48 @@ export type PaymentInput = {
 };
 
 /**
+ * List payment gateways.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentListGateways = Event & {
+  __typename?: "PaymentListGateways";
+  /** The checkout the event relates to. */
+  checkout?: Maybe<Checkout>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
+ * Process payment.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentProcessEvent = Event & {
+  __typename?: "PaymentProcessEvent";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** Look up a payment. */
+  payment?: Maybe<Payment>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
  * Refunds the captured payment amount.
  *
  * Requires one of the following permissions: MANAGE_ORDERS.
@@ -12898,6 +13732,27 @@ export type PaymentRefund = {
   payment?: Maybe<Payment>;
   /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   paymentErrors: Array<PaymentError>;
+};
+
+/**
+ * Refund payment.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentRefundEvent = Event & {
+  __typename?: "PaymentRefundEvent";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** Look up a payment. */
+  payment?: Maybe<Payment>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 /** Represents a payment source stored for user in payment gateway, such as credit card. */
@@ -12933,6 +13788,27 @@ export type PaymentVoid = {
   paymentErrors: Array<PaymentError>;
 };
 
+/**
+ * Void payment.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PaymentVoidEvent = Event & {
+  __typename?: "PaymentVoidEvent";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** Look up a payment. */
+  payment?: Maybe<Payment>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
 /** Represents a permission object in a friendly form. */
 export type Permission = {
   __typename?: "Permission";
@@ -12946,6 +13822,7 @@ export type Permission = {
 export type PermissionEnum =
   | "HANDLE_CHECKOUTS"
   | "HANDLE_PAYMENTS"
+  | "HANDLE_TAXES"
   | "IMPERSONATE_USER"
   | "MANAGE_APPS"
   | "MANAGE_CHANNELS"
@@ -12967,7 +13844,7 @@ export type PermissionEnum =
   | "MANAGE_USERS";
 
 /**
- * Create new permission group.
+ * Create new permission group. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -12989,7 +13866,28 @@ export type PermissionGroupCreateInput = {
 };
 
 /**
- * Delete permission group.
+ * Event sent when new permission group is created.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PermissionGroupCreated = Event & {
+  __typename?: "PermissionGroupCreated";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The permission group the event relates to. */
+  permissionGroup?: Maybe<Group>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
+ * Delete permission group. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -12999,6 +13897,27 @@ export type PermissionGroupDelete = {
   group?: Maybe<Group>;
   /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   permissionGroupErrors: Array<PermissionGroupError>;
+};
+
+/**
+ * Event sent when permission group is deleted.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PermissionGroupDeleted = Event & {
+  __typename?: "PermissionGroupDeleted";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The permission group the event relates to. */
+  permissionGroup?: Maybe<Group>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type PermissionGroupError = {
@@ -13043,7 +13962,7 @@ export type PermissionGroupSortingInput = {
 };
 
 /**
- * Update permission group.
+ * Update permission group. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -13066,6 +13985,27 @@ export type PermissionGroupUpdateInput = {
   removePermissions?: InputMaybe<Array<PermissionEnum>>;
   /** List of users to unassign from this group. */
   removeUsers?: InputMaybe<Array<Scalars["ID"]>>;
+};
+
+/**
+ * Event sent when permission group is updated.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type PermissionGroupUpdated = Event & {
+  __typename?: "PermissionGroupUpdated";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The permission group the event relates to. */
+  permissionGroup?: Maybe<Group>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 /** Plugin. */
@@ -13333,7 +14273,6 @@ export type Product = Node &
     slug: Scalars["String"];
     /** A type of tax. Assigned by enabled tax gateway */
     taxType?: Maybe<TaxType>;
-    /** The main thumbnail for a product. */
     thumbnail?: Maybe<Image>;
     /** Returns translated product fields for the given language code. */
     translation?: Maybe<ProductTranslation>;
@@ -13385,6 +14324,7 @@ export type ProductPrivateMetafieldsArgs = {
 
 /** Represents an individual item for sale in the storefront. */
 export type ProductThumbnailArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
@@ -13664,27 +14604,22 @@ export type ProductCreateInput = {
   weight?: InputMaybe<Scalars["WeightScalar"]>;
 };
 
+/**
+ * Event sent when new product is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductCreated = Event & {
   __typename?: "ProductCreated";
-  /**
-   * The category of the product.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The category of the product. */
   category?: Maybe<Category>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product the event relates to. */
   product?: Maybe<Product>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -13692,6 +14627,13 @@ export type ProductCreated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new product is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductCreatedProductArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -13709,27 +14651,22 @@ export type ProductDelete = {
   productErrors: Array<ProductError>;
 };
 
+/**
+ * Event sent when product is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductDeleted = Event & {
   __typename?: "ProductDeleted";
-  /**
-   * The category of the product.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The category of the product. */
   category?: Maybe<Category>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product the event relates to. */
   product?: Maybe<Product>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -13737,6 +14674,13 @@ export type ProductDeleted = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when product is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductDeletedProductArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -13801,18 +14745,22 @@ export type ProductFilterInput = {
    */
   channel?: InputMaybe<Scalars["String"]>;
   collections?: InputMaybe<Array<Scalars["ID"]>>;
+  /** Filter on whether product is a gift card or not. */
   giftCard?: InputMaybe<Scalars["Boolean"]>;
   hasCategory?: InputMaybe<Scalars["Boolean"]>;
   hasPreorderedVariants?: InputMaybe<Scalars["Boolean"]>;
   ids?: InputMaybe<Array<Scalars["ID"]>>;
   isPublished?: InputMaybe<Scalars["Boolean"]>;
   metadata?: InputMaybe<Array<MetadataFilter>>;
+  /** Filter by the lowest variant price after discounts. */
   minimalPrice?: InputMaybe<PriceRangeInput>;
   price?: InputMaybe<PriceRangeInput>;
   productTypes?: InputMaybe<Array<Scalars["ID"]>>;
   search?: InputMaybe<Scalars["String"]>;
+  /** Filter by variants having specific stock status. */
   stockAvailability?: InputMaybe<StockAvailability>;
   stocks?: InputMaybe<ProductStockFilterInput>;
+  /** Filter by when was the most recent update. */
   updatedAt?: InputMaybe<DateTimeRangeInput>;
 };
 
@@ -13825,12 +14773,12 @@ export type ProductImage = {
   id: Scalars["ID"];
   /** The new relative sorting position of the item (from -inf to +inf). 1 moves the item one position forward, -1 moves the item one position backward, 0 leaves the item unchanged. */
   sortOrder?: Maybe<Scalars["Int"]>;
-  /** The URL of the image. */
   url: Scalars["String"];
 };
 
 /** Represents a product image. */
 export type ProductImageUrlArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
@@ -13871,12 +14819,12 @@ export type ProductMedia = Node & {
   oembedData: Scalars["JSONString"];
   sortOrder?: Maybe<Scalars["Int"]>;
   type: ProductMediaType;
-  /** The URL of the media. */
   url: Scalars["String"];
 };
 
 /** Represents a product media. */
 export type ProductMediaUrlArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
@@ -14425,27 +15373,22 @@ export type ProductUpdate = {
   productErrors: Array<ProductError>;
 };
 
+/**
+ * Event sent when product is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductUpdated = Event & {
   __typename?: "ProductUpdated";
-  /**
-   * The category of the product.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The category of the product. */
   category?: Maybe<Category>;
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product the event relates to. */
   product?: Maybe<Product>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -14453,6 +15396,13 @@ export type ProductUpdated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when product is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductUpdatedProductArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -14621,34 +15571,36 @@ export type ProductVariantTranslationArgs = {
   languageCode: LanguageCodeEnum;
 };
 
+/**
+ * Event sent when product variant is back in stock.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantBackInStock = Event & {
   __typename?: "ProductVariantBackInStock";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product variant the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product variant the event relates to. */
   productVariant?: Maybe<ProductVariant>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * Look up a warehouse.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** Look up a warehouse. */
   warehouse?: Maybe<Warehouse>;
 };
 
+/**
+ * Event sent when product variant is back in stock.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantBackInStockProductVariantArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -14830,19 +15782,20 @@ export type ProductVariantCreateInput = {
   weight?: InputMaybe<Scalars["WeightScalar"]>;
 };
 
+/**
+ * Event sent when new product variant is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantCreated = Event & {
   __typename?: "ProductVariantCreated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product variant the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product variant the event relates to. */
   productVariant?: Maybe<ProductVariant>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -14850,6 +15803,13 @@ export type ProductVariantCreated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new product variant is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantCreatedProductVariantArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -14867,19 +15827,20 @@ export type ProductVariantDelete = {
   productVariant?: Maybe<ProductVariant>;
 };
 
+/**
+ * Event sent when product variant is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantDeleted = Event & {
   __typename?: "ProductVariantDeleted";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product variant the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product variant the event relates to. */
   productVariant?: Maybe<ProductVariant>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -14887,6 +15848,13 @@ export type ProductVariantDeleted = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when product variant is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantDeletedProductVariantArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -14926,34 +15894,36 @@ export type ProductVariantInput = {
   weight?: InputMaybe<Scalars["WeightScalar"]>;
 };
 
+/**
+ * Event sent when product variant is out of stock.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantOutOfStock = Event & {
   __typename?: "ProductVariantOutOfStock";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product variant the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product variant the event relates to. */
   productVariant?: Maybe<ProductVariant>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * Look up a warehouse.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** Look up a warehouse. */
   warehouse?: Maybe<Warehouse>;
 };
 
+/**
+ * Event sent when product variant is out of stock.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantOutOfStockProductVariantArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -15120,19 +16090,20 @@ export type ProductVariantUpdate = {
   productVariant?: Maybe<ProductVariant>;
 };
 
+/**
+ * Event sent when product variant is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantUpdated = Event & {
   __typename?: "ProductVariantUpdated";
   /** Time of the event. */
   issuedAt?: Maybe<Scalars["DateTime"]>;
   /** The user or application that triggered the event. */
   issuingPrincipal?: Maybe<IssuingPrincipal>;
-  /**
-   * The product variant the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The product variant the event relates to. */
   productVariant?: Maybe<ProductVariant>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
@@ -15140,6 +16111,13 @@ export type ProductVariantUpdated = Event & {
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when product variant is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ProductVariantUpdatedProductVariantArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -15217,11 +16195,7 @@ export type Query = {
   categories?: Maybe<CategoryCountableConnection>;
   /** Look up a category by ID or slug. */
   category?: Maybe<Category>;
-  /**
-   * Look up a channel by ID.
-   *
-   * Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-   */
+  /** Look up a channel by ID or slug. */
   channel?: Maybe<Channel>;
   /**
    * List of all channels.
@@ -15471,6 +16445,16 @@ export type Query = {
   /** List of all tax rates available from tax gateway. */
   taxTypes?: Maybe<Array<TaxType>>;
   /**
+   * Look up a transaction by ID.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   *
+   * Requires one of the following permissions: HANDLE_PAYMENTS.
+   */
+  transaction?: Maybe<TransactionItem>;
+  /**
    * Lookup a translatable item by ID.
    *
    * Requires one of the following permissions: MANAGE_TRANSLATIONS.
@@ -15597,6 +16581,7 @@ export type QueryCategoryArgs = {
 
 export type QueryChannelArgs = {
   id?: InputMaybe<Scalars["ID"]>;
+  slug?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryCheckoutArgs = {
@@ -15931,6 +16916,10 @@ export type QueryStocksArgs = {
   filter?: InputMaybe<StockFilterInput>;
   first?: InputMaybe<Scalars["Int"]>;
   last?: InputMaybe<Scalars["Int"]>;
+};
+
+export type QueryTransactionArgs = {
+  id: Scalars["ID"];
 };
 
 export type QueryTranslationArgs = {
@@ -16279,6 +17268,13 @@ export type SaleCreate = {
   sale?: Maybe<Sale>;
 };
 
+/**
+ * Event sent when new sale is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type SaleCreated = Event & {
   __typename?: "SaleCreated";
   /** Time of the event. */
@@ -16287,18 +17283,19 @@ export type SaleCreated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The sale the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The sale the event relates to. */
   sale?: Maybe<Sale>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new sale is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type SaleCreatedSaleArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -16316,6 +17313,13 @@ export type SaleDelete = {
   sale?: Maybe<Sale>;
 };
 
+/**
+ * Event sent when sale is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type SaleDeleted = Event & {
   __typename?: "SaleDeleted";
   /** Time of the event. */
@@ -16324,18 +17328,19 @@ export type SaleDeleted = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The sale the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The sale the event relates to. */
   sale?: Maybe<Sale>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when sale is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type SaleDeletedSaleArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -16416,6 +17421,44 @@ export type SaleSortingInput = {
   field: SaleSortField;
 };
 
+/**
+ * The event informs about the start or end of the sale.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type SaleToggle = Event & {
+  __typename?: "SaleToggle";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /**
+   * The sale the event relates to.
+   *
+   * Added in Saleor 3.5.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  sale?: Maybe<Sale>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
+ * The event informs about the start or end of the sale.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type SaleToggleSaleArgs = {
+  channel?: InputMaybe<Scalars["String"]>;
+};
+
 export type SaleTranslatableContent = Node & {
   __typename?: "SaleTranslatableContent";
   id: Scalars["ID"];
@@ -16471,6 +17514,13 @@ export type SaleUpdate = {
   sale?: Maybe<Sale>;
 };
 
+/**
+ * Event sent when sale is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type SaleUpdated = Event & {
   __typename?: "SaleUpdated";
   /** Time of the event. */
@@ -16479,18 +17529,19 @@ export type SaleUpdated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The sale the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The sale the event relates to. */
   sale?: Maybe<Sale>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when sale is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type SaleUpdatedSaleArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -16551,6 +17602,35 @@ export type ShippingErrorCode =
   | "NOT_FOUND"
   | "REQUIRED"
   | "UNIQUE";
+
+/**
+ * List shipping methods for checkout.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type ShippingListMethodsForCheckout = Event & {
+  __typename?: "ShippingListMethodsForCheckout";
+  /** The checkout the event relates to. */
+  checkout?: Maybe<Checkout>;
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /**
+   * Shipping methods that can be used with this checkout.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  shippingMethods?: Maybe<Array<ShippingMethod>>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
 
 /** Shipping methods that can be used as means of shipping for orders and checkouts. */
 export type ShippingMethod = Node &
@@ -16880,6 +17960,21 @@ export type ShippingMethodTypeTranslationArgs = {
 /** An enumeration. */
 export type ShippingMethodTypeEnum = "PRICE" | "WEIGHT";
 
+/**
+ * List of shipping methods available for the country.
+ *
+ * Added in Saleor 3.6.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type ShippingMethodsPerCountry = {
+  __typename?: "ShippingMethodsPerCountry";
+  /** The country code. */
+  countryCode: CountryCode;
+  /** List of available shipping methods. */
+  shippingMethods?: Maybe<Array<ShippingMethod>>;
+};
+
 export type ShippingPostalCodeRulesCreateInputRange = {
   /** End range of the postal code. */
   end?: InputMaybe<Scalars["String"]>;
@@ -16916,6 +18011,13 @@ export type ShippingPriceCreate = {
   shippingZone?: Maybe<ShippingZone>;
 };
 
+/**
+ * Event sent when new shipping price is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceCreated = Event & {
   __typename?: "ShippingPriceCreated";
   /** Time of the event. */
@@ -16924,30 +18026,32 @@ export type ShippingPriceCreated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The shipping method the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping method the event relates to. */
   shippingMethod?: Maybe<ShippingMethodType>;
-  /**
-   * The shipping zone the shipping method belongs to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping zone the shipping method belongs to. */
   shippingZone?: Maybe<ShippingZone>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new shipping price is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceCreatedShippingMethodArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new shipping price is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceCreatedShippingZoneArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -16968,6 +18072,13 @@ export type ShippingPriceDelete = {
   shippingZone?: Maybe<ShippingZone>;
 };
 
+/**
+ * Event sent when shipping price is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceDeleted = Event & {
   __typename?: "ShippingPriceDeleted";
   /** Time of the event. */
@@ -16976,30 +18087,32 @@ export type ShippingPriceDeleted = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The shipping method the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping method the event relates to. */
   shippingMethod?: Maybe<ShippingMethodType>;
-  /**
-   * The shipping zone the shipping method belongs to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping zone the shipping method belongs to. */
   shippingZone?: Maybe<ShippingZone>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when shipping price is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceDeletedShippingMethodArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when shipping price is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceDeletedShippingZoneArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -17100,6 +18213,13 @@ export type ShippingPriceUpdate = {
   shippingZone?: Maybe<ShippingZone>;
 };
 
+/**
+ * Event sent when shipping price is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceUpdated = Event & {
   __typename?: "ShippingPriceUpdated";
   /** Time of the event. */
@@ -17108,30 +18228,32 @@ export type ShippingPriceUpdated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The shipping method the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping method the event relates to. */
   shippingMethod?: Maybe<ShippingMethodType>;
-  /**
-   * The shipping zone the shipping method belongs to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping zone the shipping method belongs to. */
   shippingZone?: Maybe<ShippingZone>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when shipping price is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceUpdatedShippingMethodArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when shipping price is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingPriceUpdatedShippingZoneArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -17276,6 +18398,13 @@ export type ShippingZoneCreateInput = {
   name?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new shipping zone is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingZoneCreated = Event & {
   __typename?: "ShippingZoneCreated";
   /** Time of the event. */
@@ -17284,18 +18413,19 @@ export type ShippingZoneCreated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The shipping zone the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping zone the event relates to. */
   shippingZone?: Maybe<ShippingZone>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new shipping zone is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingZoneCreatedShippingZoneArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -17313,6 +18443,13 @@ export type ShippingZoneDelete = {
   shippingZone?: Maybe<ShippingZone>;
 };
 
+/**
+ * Event sent when shipping zone is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingZoneDeleted = Event & {
   __typename?: "ShippingZoneDeleted";
   /** Time of the event. */
@@ -17321,18 +18458,19 @@ export type ShippingZoneDeleted = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The shipping zone the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping zone the event relates to. */
   shippingZone?: Maybe<ShippingZone>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when shipping zone is deleted.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingZoneDeletedShippingZoneArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -17374,6 +18512,13 @@ export type ShippingZoneUpdateInput = {
   removeWarehouses?: InputMaybe<Array<Scalars["ID"]>>;
 };
 
+/**
+ * Event sent when shipping zone is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingZoneUpdated = Event & {
   __typename?: "ShippingZoneUpdated";
   /** Time of the event. */
@@ -17382,18 +18527,19 @@ export type ShippingZoneUpdated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The shipping zone the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The shipping zone the event relates to. */
   shippingZone?: Maybe<ShippingZone>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when shipping zone is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type ShippingZoneUpdatedShippingZoneArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -17733,7 +18879,7 @@ export type SiteDomainInput = {
 };
 
 /**
- * Deletes staff users.
+ * Deletes staff users. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -17747,7 +18893,7 @@ export type StaffBulkDelete = {
 };
 
 /**
- * Creates a new staff user.
+ * Creates a new staff user. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -17777,7 +18923,28 @@ export type StaffCreateInput = {
 };
 
 /**
- * Deletes a staff user.
+ * Event sent when new staff user is created.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type StaffCreated = Event & {
+  __typename?: "StaffCreated";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** The user the event relates to. */
+  user?: Maybe<User>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
+};
+
+/**
+ * Deletes a staff user. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -17787,6 +18954,27 @@ export type StaffDelete = {
   /** @deprecated This field will be removed in Saleor 4.0. Use `errors` field instead. */
   staffErrors: Array<StaffError>;
   user?: Maybe<User>;
+};
+
+/**
+ * Event sent when staff user is deleted.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type StaffDeleted = Event & {
+  __typename?: "StaffDeleted";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** The user the event relates to. */
+  user?: Maybe<User>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type StaffError = {
@@ -17874,7 +19062,7 @@ export type StaffNotificationRecipientUpdate = {
 };
 
 /**
- * Updates an existing staff user.
+ * Updates an existing staff user. Apps are not allowed to perform this mutation.
  *
  * Requires one of the following permissions: MANAGE_STAFF.
  */
@@ -17901,6 +19089,27 @@ export type StaffUpdateInput = {
   note?: InputMaybe<Scalars["String"]>;
   /** List of permission group IDs from which user should be unassigned. */
   removeGroups?: InputMaybe<Array<Scalars["ID"]>>;
+};
+
+/**
+ * Event sent when staff user is updated.
+ *
+ * Added in Saleor 3.5.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
+export type StaffUpdated = Event & {
+  __typename?: "StaffUpdated";
+  /** Time of the event. */
+  issuedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user or application that triggered the event. */
+  issuingPrincipal?: Maybe<IssuingPrincipal>;
+  /** The application receiving the webhook. */
+  recipient?: Maybe<App>;
+  /** The user the event relates to. */
+  user?: Maybe<User>;
+  /** Saleor version that triggered the event. */
+  version?: Maybe<Scalars["String"]>;
 };
 
 export type StaffUserInput = {
@@ -18037,6 +19246,9 @@ export type TaxedMoneyRange = {
   stop?: Maybe<TaxedMoney>;
 };
 
+/** An enumeration. */
+export type ThumbnailFormatEnum = "WEBP";
+
 export type TimePeriod = {
   __typename?: "TimePeriod";
   /** The length of the period. */
@@ -18089,6 +19301,13 @@ export type TransactionAction = {
  */
 export type TransactionActionEnum = "CHARGE" | "REFUND" | "VOID";
 
+/**
+ * Event sent when transaction action is requested.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type TransactionActionRequest = Event & {
   __typename?: "TransactionActionRequest";
   /**
@@ -18236,6 +19455,12 @@ export type TransactionItem = Node &
      */
     metafields?: Maybe<Scalars["Metadata"]>;
     modifiedAt: Scalars["DateTime"];
+    /**
+     * The related order.
+     *
+     * Added in Saleor 3.6.
+     */
+    order?: Maybe<Order>;
     /** List of private metadata items. Requires staff permissions to access. */
     privateMetadata: Array<MetadataItem>;
     /**
@@ -18457,6 +19682,13 @@ export type TranslatableKinds =
   | "VARIANT"
   | "VOUCHER";
 
+/**
+ * Event sent when new translation is created.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type TranslationCreated = Event & {
   __typename?: "TranslationCreated";
   /** Time of the event. */
@@ -18465,13 +19697,7 @@ export type TranslationCreated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The translation the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The translation the event relates to. */
   translation?: Maybe<TranslationTypes>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
@@ -18515,6 +19741,13 @@ export type TranslationTypes =
   | ShippingMethodTranslation
   | VoucherTranslation;
 
+/**
+ * Event sent when translation is updated.
+ *
+ * Added in Saleor 3.2.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type TranslationUpdated = Event & {
   __typename?: "TranslationUpdated";
   /** Time of the event. */
@@ -18523,13 +19756,7 @@ export type TranslationUpdated = Event & {
   issuingPrincipal?: Maybe<IssuingPrincipal>;
   /** The application receiving the webhook. */
   recipient?: Maybe<App>;
-  /**
-   * The translation the event relates to.
-   *
-   * Added in Saleor 3.2.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The translation the event relates to. */
   translation?: Maybe<TranslationTypes>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
@@ -18578,7 +19805,7 @@ export type User = Node &
   ObjectWithMetadata & {
     __typename?: "User";
     /** List of all user's addresses. */
-    addresses?: Maybe<Array<Address>>;
+    addresses: Array<Address>;
     avatar?: Maybe<Image>;
     /**
      * Returns the last open checkout of this user.
@@ -18673,6 +19900,7 @@ export type User = Node &
 
 /** Represents user data. */
 export type UserAvatarArgs = {
+  format?: InputMaybe<ThumbnailFormatEnum>;
   size?: InputMaybe<Scalars["Int"]>;
 };
 
@@ -19186,6 +20414,13 @@ export type VoucherCreate = {
   voucher?: Maybe<Voucher>;
 };
 
+/**
+ * Event sent when new voucher is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type VoucherCreated = Event & {
   __typename?: "VoucherCreated";
   /** Time of the event. */
@@ -19196,16 +20431,17 @@ export type VoucherCreated = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * The voucher the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The voucher the event relates to. */
   voucher?: Maybe<Voucher>;
 };
 
+/**
+ * Event sent when new voucher is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type VoucherCreatedVoucherArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -19223,6 +20459,13 @@ export type VoucherDelete = {
   voucher?: Maybe<Voucher>;
 };
 
+/**
+ * Event sent when voucher is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type VoucherDeleted = Event & {
   __typename?: "VoucherDeleted";
   /** Time of the event. */
@@ -19233,16 +20476,17 @@ export type VoucherDeleted = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * The voucher the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The voucher the event relates to. */
   voucher?: Maybe<Voucher>;
 };
 
+/**
+ * Event sent when voucher is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type VoucherDeletedVoucherArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -19251,6 +20495,7 @@ export type VoucherDiscountType = "FIXED" | "PERCENTAGE" | "SHIPPING";
 
 export type VoucherFilterInput = {
   discountType?: InputMaybe<Array<VoucherDiscountType>>;
+  ids?: InputMaybe<Array<Scalars["ID"]>>;
   metadata?: InputMaybe<Array<MetadataFilter>>;
   search?: InputMaybe<Scalars["String"]>;
   started?: InputMaybe<DateTimeRangeInput>;
@@ -19403,6 +20648,13 @@ export type VoucherUpdate = {
   voucher?: Maybe<Voucher>;
 };
 
+/**
+ * Event sent when voucher is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type VoucherUpdated = Event & {
   __typename?: "VoucherUpdated";
   /** Time of the event. */
@@ -19413,16 +20665,17 @@ export type VoucherUpdated = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * The voucher the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The voucher the event relates to. */
   voucher?: Maybe<Voucher>;
 };
 
+/**
+ * Event sent when voucher is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type VoucherUpdatedVoucherArgs = {
   channel?: InputMaybe<Scalars["String"]>;
 };
@@ -19567,6 +20820,13 @@ export type WarehouseCreateInput = {
   slug?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when new warehouse is created.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type WarehouseCreated = Event & {
   __typename?: "WarehouseCreated";
   /** Time of the event. */
@@ -19577,13 +20837,7 @@ export type WarehouseCreated = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * The warehouse the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The warehouse the event relates to. */
   warehouse?: Maybe<Warehouse>;
 };
 
@@ -19600,6 +20854,13 @@ export type WarehouseDelete = {
   warehouseErrors: Array<WarehouseError>;
 };
 
+/**
+ * Event sent when warehouse is deleted.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type WarehouseDeleted = Event & {
   __typename?: "WarehouseDeleted";
   /** Time of the event. */
@@ -19610,13 +20871,7 @@ export type WarehouseDeleted = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * The warehouse the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The warehouse the event relates to. */
   warehouse?: Maybe<Warehouse>;
 };
 
@@ -19640,6 +20895,7 @@ export type WarehouseErrorCode =
   | "UNIQUE";
 
 export type WarehouseFilterInput = {
+  channels?: InputMaybe<Array<Scalars["ID"]>>;
   clickAndCollectOption?: InputMaybe<WarehouseClickAndCollectOptionEnum>;
   ids?: InputMaybe<Array<Scalars["ID"]>>;
   isPrivate?: InputMaybe<Scalars["Boolean"]>;
@@ -19723,6 +20979,13 @@ export type WarehouseUpdateInput = {
   slug?: InputMaybe<Scalars["String"]>;
 };
 
+/**
+ * Event sent when warehouse is updated.
+ *
+ * Added in Saleor 3.4.
+ *
+ * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+ */
 export type WarehouseUpdated = Event & {
   __typename?: "WarehouseUpdated";
   /** Time of the event. */
@@ -19733,13 +20996,7 @@ export type WarehouseUpdated = Event & {
   recipient?: Maybe<App>;
   /** Saleor version that triggered the event. */
   version?: Maybe<Scalars["String"]>;
-  /**
-   * The warehouse the event relates to.
-   *
-   * Added in Saleor 3.4.
-   *
-   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
-   */
+  /** The warehouse the event relates to. */
   warehouse?: Maybe<Warehouse>;
 };
 
@@ -19760,7 +21017,11 @@ export type Webhook = Node & {
   /** Informs if webhook is activated. */
   isActive: Scalars["Boolean"];
   name: Scalars["String"];
-  /** Used to create a hash signature with each payload. */
+  /**
+   * Used to create a hash signature with each payload.
+   *
+   * If not set, since Saleor 3.5, your payload will be signed using private key used also to sign JWT tokens.
+   */
   secretKey?: Maybe<Scalars["String"]>;
   /** Used to define payloads for specific events. */
   subscriptionQuery?: Maybe<Scalars["String"]>;
@@ -19879,6 +21140,12 @@ export type WebhookEventSync = {
 
 /** Enum determining type of webhook. */
 export type WebhookEventTypeAsyncEnum =
+  /** A new address created. */
+  | "ADDRESS_CREATED"
+  /** An address deleted. */
+  | "ADDRESS_DELETED"
+  /** An address updated. */
+  | "ADDRESS_UPDATED"
   /** All the events. */
   | "ANY_EVENTS"
   /** An app deleted. */
@@ -19889,6 +21156,18 @@ export type WebhookEventTypeAsyncEnum =
   | "APP_STATUS_CHANGED"
   /** An app updated. */
   | "APP_UPDATED"
+  /** A new attribute is created. */
+  | "ATTRIBUTE_CREATED"
+  /** An attribute is deleted. */
+  | "ATTRIBUTE_DELETED"
+  /** An attribute is updated. */
+  | "ATTRIBUTE_UPDATED"
+  /** A new attribute value is created. */
+  | "ATTRIBUTE_VALUE_CREATED"
+  /** An attribute value is deleted. */
+  | "ATTRIBUTE_VALUE_DELETED"
+  /** An attribute value is updated. */
+  | "ATTRIBUTE_VALUE_UPDATED"
   /** A new category created. */
   | "CATEGORY_CREATED"
   /** A category is deleted. */
@@ -19915,10 +21194,15 @@ export type WebhookEventTypeAsyncEnum =
   | "COLLECTION_UPDATED"
   /** A new customer account is created. */
   | "CUSTOMER_CREATED"
+  /** A customer account is deleted. */
+  | "CUSTOMER_DELETED"
   /** A customer account is updated. */
   | "CUSTOMER_UPDATED"
+  /** A draft order is created. */
   | "DRAFT_ORDER_CREATED"
+  /** A draft order is deleted. */
   | "DRAFT_ORDER_DELETED"
+  /** A draft order is updated. */
   | "DRAFT_ORDER_UPDATED"
   /** A fulfillment is cancelled. */
   | "FULFILLMENT_CANCELED"
@@ -19970,24 +21254,43 @@ export type WebhookEventTypeAsyncEnum =
   | "PAGE_CREATED"
   /** A page is deleted. */
   | "PAGE_DELETED"
+  /** A new page type is created. */
+  | "PAGE_TYPE_CREATED"
+  /** A page type is deleted. */
+  | "PAGE_TYPE_DELETED"
+  /** A page type is updated. */
+  | "PAGE_TYPE_UPDATED"
   /** A page is updated. */
   | "PAGE_UPDATED"
+  /** A new permission group is created. */
+  | "PERMISSION_GROUP_CREATED"
+  /** A permission group is deleted. */
+  | "PERMISSION_GROUP_DELETED"
+  /** A permission group is updated. */
+  | "PERMISSION_GROUP_UPDATED"
   /** A new product is created. */
   | "PRODUCT_CREATED"
   /** A product is deleted. */
   | "PRODUCT_DELETED"
   /** A product is updated. */
   | "PRODUCT_UPDATED"
+  /** A product variant is back in stock. */
   | "PRODUCT_VARIANT_BACK_IN_STOCK"
   /** A new product variant is created. */
   | "PRODUCT_VARIANT_CREATED"
   /** A product variant is deleted. */
   | "PRODUCT_VARIANT_DELETED"
+  /** A product variant is out of stock. */
   | "PRODUCT_VARIANT_OUT_OF_STOCK"
   /** A product variant is updated. */
   | "PRODUCT_VARIANT_UPDATED"
+  /** A sale is created. */
   | "SALE_CREATED"
+  /** A sale is deleted. */
   | "SALE_DELETED"
+  /** A sale is activated or deactivated. */
+  | "SALE_TOGGLE"
+  /** A sale is updated. */
   | "SALE_UPDATED"
   /** A new shipping price is created. */
   | "SHIPPING_PRICE_CREATED"
@@ -20001,8 +21304,17 @@ export type WebhookEventTypeAsyncEnum =
   | "SHIPPING_ZONE_DELETED"
   /** A shipping zone is updated. */
   | "SHIPPING_ZONE_UPDATED"
+  /** A new staff user is created. */
+  | "STAFF_CREATED"
+  /** A staff user is deleted. */
+  | "STAFF_DELETED"
+  /** A staff user is updated. */
+  | "STAFF_UPDATED"
+  /** An action requested for transaction. */
   | "TRANSACTION_ACTION_REQUEST"
+  /** A new translation is created. */
   | "TRANSLATION_CREATED"
+  /** A translation is updated. */
   | "TRANSLATION_UPDATED"
   /** A new voucher created. */
   | "VOUCHER_CREATED"
@@ -20019,6 +21331,12 @@ export type WebhookEventTypeAsyncEnum =
 
 /** Enum determining type of webhook. */
 export type WebhookEventTypeEnum =
+  /** A new address created. */
+  | "ADDRESS_CREATED"
+  /** An address deleted. */
+  | "ADDRESS_DELETED"
+  /** An address updated. */
+  | "ADDRESS_UPDATED"
   /** All the events. */
   | "ANY_EVENTS"
   /** An app deleted. */
@@ -20029,6 +21347,18 @@ export type WebhookEventTypeEnum =
   | "APP_STATUS_CHANGED"
   /** An app updated. */
   | "APP_UPDATED"
+  /** A new attribute is created. */
+  | "ATTRIBUTE_CREATED"
+  /** An attribute is deleted. */
+  | "ATTRIBUTE_DELETED"
+  /** An attribute is updated. */
+  | "ATTRIBUTE_UPDATED"
+  /** A new attribute value is created. */
+  | "ATTRIBUTE_VALUE_CREATED"
+  /** An attribute value is deleted. */
+  | "ATTRIBUTE_VALUE_DELETED"
+  /** An attribute value is updated. */
+  | "ATTRIBUTE_VALUE_UPDATED"
   /** A new category created. */
   | "CATEGORY_CREATED"
   /** A category is deleted. */
@@ -20043,8 +21373,17 @@ export type WebhookEventTypeEnum =
   | "CHANNEL_STATUS_CHANGED"
   /** A channel is updated. */
   | "CHANNEL_UPDATED"
+  /**
+   * Event called for checkout tax calculation.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  | "CHECKOUT_CALCULATE_TAXES"
   /** A new checkout is created. */
   | "CHECKOUT_CREATED"
+  /** Filter shipping methods for checkout. */
   | "CHECKOUT_FILTER_SHIPPING_METHODS"
   /** A checkout is updated. It also triggers all updates related to the checkout. */
   | "CHECKOUT_UPDATED"
@@ -20056,10 +21395,15 @@ export type WebhookEventTypeEnum =
   | "COLLECTION_UPDATED"
   /** A new customer account is created. */
   | "CUSTOMER_CREATED"
+  /** A customer account is deleted. */
+  | "CUSTOMER_DELETED"
   /** A customer account is updated. */
   | "CUSTOMER_UPDATED"
+  /** A draft order is created. */
   | "DRAFT_ORDER_CREATED"
+  /** A draft order is deleted. */
   | "DRAFT_ORDER_DELETED"
+  /** A draft order is updated. */
   | "DRAFT_ORDER_UPDATED"
   /** A fulfillment is cancelled. */
   | "FULFILLMENT_CANCELED"
@@ -20095,12 +21439,21 @@ export type WebhookEventTypeEnum =
   | "NOTIFY_USER"
   /** An observability event is created. */
   | "OBSERVABILITY"
+  /**
+   * Event called for order tax calculation.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  | "ORDER_CALCULATE_TAXES"
   /** An order is cancelled. */
   | "ORDER_CANCELLED"
   /** An order is confirmed (status change unconfirmed -> unfulfilled) by a staff user using the OrderConfirm mutation. It also triggers when the user completes the checkout and the shop setting `automatically_confirm_all_new_orders` is enabled. */
   | "ORDER_CONFIRMED"
   /** A new order is placed. */
   | "ORDER_CREATED"
+  /** Filter shipping methods for order. */
   | "ORDER_FILTER_SHIPPING_METHODS"
   /** An order is fulfilled. */
   | "ORDER_FULFILLED"
@@ -20112,32 +21465,59 @@ export type WebhookEventTypeEnum =
   | "PAGE_CREATED"
   /** A page is deleted. */
   | "PAGE_DELETED"
+  /** A new page type is created. */
+  | "PAGE_TYPE_CREATED"
+  /** A page type is deleted. */
+  | "PAGE_TYPE_DELETED"
+  /** A page type is updated. */
+  | "PAGE_TYPE_UPDATED"
   /** A page is updated. */
   | "PAGE_UPDATED"
+  /** Authorize payment. */
   | "PAYMENT_AUTHORIZE"
+  /** Capture payment. */
   | "PAYMENT_CAPTURE"
+  /** Confirm payment. */
   | "PAYMENT_CONFIRM"
+  /** Listing available payment gateways. */
   | "PAYMENT_LIST_GATEWAYS"
+  /** Process payment. */
   | "PAYMENT_PROCESS"
+  /** Refund payment. */
   | "PAYMENT_REFUND"
+  /** Void payment. */
   | "PAYMENT_VOID"
+  /** A new permission group is created. */
+  | "PERMISSION_GROUP_CREATED"
+  /** A permission group is deleted. */
+  | "PERMISSION_GROUP_DELETED"
+  /** A permission group is updated. */
+  | "PERMISSION_GROUP_UPDATED"
   /** A new product is created. */
   | "PRODUCT_CREATED"
   /** A product is deleted. */
   | "PRODUCT_DELETED"
   /** A product is updated. */
   | "PRODUCT_UPDATED"
+  /** A product variant is back in stock. */
   | "PRODUCT_VARIANT_BACK_IN_STOCK"
   /** A new product variant is created. */
   | "PRODUCT_VARIANT_CREATED"
   /** A product variant is deleted. */
   | "PRODUCT_VARIANT_DELETED"
+  /** A product variant is out of stock. */
   | "PRODUCT_VARIANT_OUT_OF_STOCK"
   /** A product variant is updated. */
   | "PRODUCT_VARIANT_UPDATED"
+  /** A sale is created. */
   | "SALE_CREATED"
+  /** A sale is deleted. */
   | "SALE_DELETED"
+  /** A sale is activated or deactivated. */
+  | "SALE_TOGGLE"
+  /** A sale is updated. */
   | "SALE_UPDATED"
+  /** Fetch external shipping methods for checkout. */
   | "SHIPPING_LIST_METHODS_FOR_CHECKOUT"
   /** A new shipping price is created. */
   | "SHIPPING_PRICE_CREATED"
@@ -20151,8 +21531,17 @@ export type WebhookEventTypeEnum =
   | "SHIPPING_ZONE_DELETED"
   /** A shipping zone is updated. */
   | "SHIPPING_ZONE_UPDATED"
+  /** A new staff user is created. */
+  | "STAFF_CREATED"
+  /** A staff user is deleted. */
+  | "STAFF_DELETED"
+  /** A staff user is updated. */
+  | "STAFF_UPDATED"
+  /** An action requested for transaction. */
   | "TRANSACTION_ACTION_REQUEST"
+  /** A new translation is created. */
   | "TRANSLATION_CREATED"
+  /** A translation is updated. */
   | "TRANSLATION_UPDATED"
   /** A new voucher created. */
   | "VOUCHER_CREATED"
@@ -20169,23 +21558,58 @@ export type WebhookEventTypeEnum =
 
 /** Enum determining type of webhook. */
 export type WebhookEventTypeSyncEnum =
+  /**
+   * Event called for checkout tax calculation.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  | "CHECKOUT_CALCULATE_TAXES"
+  /** Filter shipping methods for checkout. */
   | "CHECKOUT_FILTER_SHIPPING_METHODS"
+  /**
+   * Event called for order tax calculation.
+   *
+   * Added in Saleor 3.6.
+   *
+   * Note: this API is currently in Feature Preview and can be subject to changes at later point.
+   */
+  | "ORDER_CALCULATE_TAXES"
+  /** Filter shipping methods for order. */
   | "ORDER_FILTER_SHIPPING_METHODS"
+  /** Authorize payment. */
   | "PAYMENT_AUTHORIZE"
+  /** Capture payment. */
   | "PAYMENT_CAPTURE"
+  /** Confirm payment. */
   | "PAYMENT_CONFIRM"
+  /** Listing available payment gateways. */
   | "PAYMENT_LIST_GATEWAYS"
+  /** Process payment. */
   | "PAYMENT_PROCESS"
+  /** Refund payment. */
   | "PAYMENT_REFUND"
+  /** Void payment. */
   | "PAYMENT_VOID"
+  /** Fetch external shipping methods for checkout. */
   | "SHIPPING_LIST_METHODS_FOR_CHECKOUT";
 
 /** An enumeration. */
 export type WebhookSampleEventTypeEnum =
+  | "ADDRESS_CREATED"
+  | "ADDRESS_DELETED"
+  | "ADDRESS_UPDATED"
   | "APP_DELETED"
   | "APP_INSTALLED"
   | "APP_STATUS_CHANGED"
   | "APP_UPDATED"
+  | "ATTRIBUTE_CREATED"
+  | "ATTRIBUTE_DELETED"
+  | "ATTRIBUTE_UPDATED"
+  | "ATTRIBUTE_VALUE_CREATED"
+  | "ATTRIBUTE_VALUE_DELETED"
+  | "ATTRIBUTE_VALUE_UPDATED"
   | "CATEGORY_CREATED"
   | "CATEGORY_DELETED"
   | "CATEGORY_UPDATED"
@@ -20199,6 +21623,7 @@ export type WebhookSampleEventTypeEnum =
   | "COLLECTION_DELETED"
   | "COLLECTION_UPDATED"
   | "CUSTOMER_CREATED"
+  | "CUSTOMER_DELETED"
   | "CUSTOMER_UPDATED"
   | "DRAFT_ORDER_CREATED"
   | "DRAFT_ORDER_DELETED"
@@ -20228,7 +21653,13 @@ export type WebhookSampleEventTypeEnum =
   | "ORDER_UPDATED"
   | "PAGE_CREATED"
   | "PAGE_DELETED"
+  | "PAGE_TYPE_CREATED"
+  | "PAGE_TYPE_DELETED"
+  | "PAGE_TYPE_UPDATED"
   | "PAGE_UPDATED"
+  | "PERMISSION_GROUP_CREATED"
+  | "PERMISSION_GROUP_DELETED"
+  | "PERMISSION_GROUP_UPDATED"
   | "PRODUCT_CREATED"
   | "PRODUCT_DELETED"
   | "PRODUCT_UPDATED"
@@ -20239,6 +21670,7 @@ export type WebhookSampleEventTypeEnum =
   | "PRODUCT_VARIANT_UPDATED"
   | "SALE_CREATED"
   | "SALE_DELETED"
+  | "SALE_TOGGLE"
   | "SALE_UPDATED"
   | "SHIPPING_PRICE_CREATED"
   | "SHIPPING_PRICE_DELETED"
@@ -20246,6 +21678,9 @@ export type WebhookSampleEventTypeEnum =
   | "SHIPPING_ZONE_CREATED"
   | "SHIPPING_ZONE_DELETED"
   | "SHIPPING_ZONE_UPDATED"
+  | "STAFF_CREATED"
+  | "STAFF_DELETED"
+  | "STAFF_UPDATED"
   | "TRANSACTION_ACTION_REQUEST"
   | "TRANSLATION_CREATED"
   | "TRANSLATION_UPDATED"
@@ -20455,6 +21890,7 @@ export type UpdatePublicMetadataMutation = {
       | { __typename?: "Attribute"; metafields?: any | null }
       | { __typename?: "Category"; metafields?: any | null }
       | { __typename?: "Checkout"; metafields?: any | null }
+      | { __typename?: "CheckoutLine"; metafields?: any | null }
       | { __typename?: "Collection"; metafields?: any | null }
       | { __typename?: "DigitalContent"; metafields?: any | null }
       | { __typename?: "Fulfillment"; metafields?: any | null }
@@ -20463,6 +21899,7 @@ export type UpdatePublicMetadataMutation = {
       | { __typename?: "Menu"; metafields?: any | null }
       | { __typename?: "MenuItem"; metafields?: any | null }
       | { __typename?: "Order"; metafields?: any | null }
+      | { __typename?: "OrderLine"; metafields?: any | null }
       | { __typename?: "Page"; metafields?: any | null }
       | { __typename?: "PageType"; metafields?: any | null }
       | { __typename?: "Payment"; metafields?: any | null }
@@ -20502,6 +21939,7 @@ export type UpdatePrivateMetadataMutation = {
       | { __typename?: "Attribute"; privateMetafields?: any | null }
       | { __typename?: "Category"; privateMetafields?: any | null }
       | { __typename?: "Checkout"; privateMetafields?: any | null }
+      | { __typename?: "CheckoutLine"; privateMetafields?: any | null }
       | { __typename?: "Collection"; privateMetafields?: any | null }
       | { __typename?: "DigitalContent"; privateMetafields?: any | null }
       | { __typename?: "Fulfillment"; privateMetafields?: any | null }
@@ -20510,6 +21948,7 @@ export type UpdatePrivateMetadataMutation = {
       | { __typename?: "Menu"; privateMetafields?: any | null }
       | { __typename?: "MenuItem"; privateMetafields?: any | null }
       | { __typename?: "Order"; privateMetafields?: any | null }
+      | { __typename?: "OrderLine"; privateMetafields?: any | null }
       | { __typename?: "Page"; privateMetafields?: any | null }
       | { __typename?: "PageType"; privateMetafields?: any | null }
       | { __typename?: "Payment"; privateMetafields?: any | null }
@@ -20949,10 +22388,19 @@ export type TransactionActionRequestSubscriptionVariables = Exact<{ [key: string
 export type TransactionActionRequestSubscription = {
   __typename?: "Subscription";
   event?:
+    | { __typename?: "AddressCreated" }
+    | { __typename?: "AddressDeleted" }
+    | { __typename?: "AddressUpdated" }
     | { __typename?: "AppDeleted" }
     | { __typename?: "AppInstalled" }
     | { __typename?: "AppStatusChanged" }
     | { __typename?: "AppUpdated" }
+    | { __typename?: "AttributeCreated" }
+    | { __typename?: "AttributeDeleted" }
+    | { __typename?: "AttributeUpdated" }
+    | { __typename?: "AttributeValueCreated" }
+    | { __typename?: "AttributeValueDeleted" }
+    | { __typename?: "AttributeValueUpdated" }
     | { __typename?: "CategoryCreated" }
     | { __typename?: "CategoryDeleted" }
     | { __typename?: "CategoryUpdated" }
@@ -20961,6 +22409,7 @@ export type TransactionActionRequestSubscription = {
     | { __typename?: "ChannelStatusChanged" }
     | { __typename?: "ChannelUpdated" }
     | { __typename?: "CheckoutCreated" }
+    | { __typename?: "CheckoutFilterShippingMethods" }
     | { __typename?: "CheckoutUpdated" }
     | { __typename?: "CollectionCreated" }
     | { __typename?: "CollectionDeleted" }
@@ -20988,12 +22437,26 @@ export type TransactionActionRequestSubscription = {
     | { __typename?: "OrderCancelled" }
     | { __typename?: "OrderConfirmed" }
     | { __typename?: "OrderCreated" }
+    | { __typename?: "OrderFilterShippingMethods" }
     | { __typename?: "OrderFulfilled" }
     | { __typename?: "OrderFullyPaid" }
     | { __typename?: "OrderUpdated" }
     | { __typename?: "PageCreated" }
     | { __typename?: "PageDeleted" }
+    | { __typename?: "PageTypeCreated" }
+    | { __typename?: "PageTypeDeleted" }
+    | { __typename?: "PageTypeUpdated" }
     | { __typename?: "PageUpdated" }
+    | { __typename?: "PaymentAuthorize" }
+    | { __typename?: "PaymentCaptureEvent" }
+    | { __typename?: "PaymentConfirmEvent" }
+    | { __typename?: "PaymentListGateways" }
+    | { __typename?: "PaymentProcessEvent" }
+    | { __typename?: "PaymentRefundEvent" }
+    | { __typename?: "PaymentVoidEvent" }
+    | { __typename?: "PermissionGroupCreated" }
+    | { __typename?: "PermissionGroupDeleted" }
+    | { __typename?: "PermissionGroupUpdated" }
     | { __typename?: "ProductCreated" }
     | { __typename?: "ProductDeleted" }
     | { __typename?: "ProductUpdated" }
@@ -21004,13 +22467,18 @@ export type TransactionActionRequestSubscription = {
     | { __typename?: "ProductVariantUpdated" }
     | { __typename?: "SaleCreated" }
     | { __typename?: "SaleDeleted" }
+    | { __typename?: "SaleToggle" }
     | { __typename?: "SaleUpdated" }
+    | { __typename?: "ShippingListMethodsForCheckout" }
     | { __typename?: "ShippingPriceCreated" }
     | { __typename?: "ShippingPriceDeleted" }
     | { __typename?: "ShippingPriceUpdated" }
     | { __typename?: "ShippingZoneCreated" }
     | { __typename?: "ShippingZoneDeleted" }
     | { __typename?: "ShippingZoneUpdated" }
+    | { __typename?: "StaffCreated" }
+    | { __typename?: "StaffDeleted" }
+    | { __typename?: "StaffUpdated" }
     | {
         __typename?: "TransactionActionRequest";
         transaction?: {
@@ -21290,7 +22758,7 @@ export const AppDocument = gql`
 `;
 
 export function useAppQuery(options?: Omit<Urql.UseQueryArgs<AppQueryVariables>, "query">) {
-  return Urql.useQuery<AppQuery>({ query: AppDocument, ...options });
+  return Urql.useQuery<AppQuery, AppQueryVariables>({ query: AppDocument, ...options });
 }
 export const ChannelDocument = gql`
   query Channel($id: ID!) {
@@ -21302,7 +22770,7 @@ export const ChannelDocument = gql`
 `;
 
 export function useChannelQuery(options: Omit<Urql.UseQueryArgs<ChannelQueryVariables>, "query">) {
-  return Urql.useQuery<ChannelQuery>({ query: ChannelDocument, ...options });
+  return Urql.useQuery<ChannelQuery, ChannelQueryVariables>({ query: ChannelDocument, ...options });
 }
 export const ChannelsDocument = gql`
   query Channels {
@@ -21316,7 +22784,10 @@ export const ChannelsDocument = gql`
 export function useChannelsQuery(
   options?: Omit<Urql.UseQueryArgs<ChannelsQueryVariables>, "query">
 ) {
-  return Urql.useQuery<ChannelsQuery>({ query: ChannelsDocument, ...options });
+  return Urql.useQuery<ChannelsQuery, ChannelsQueryVariables>({
+    query: ChannelsDocument,
+    ...options,
+  });
 }
 export const CheckoutDocument = gql`
   query Checkout($id: ID!) {
@@ -21334,7 +22805,10 @@ export const CheckoutDocument = gql`
 export function useCheckoutQuery(
   options: Omit<Urql.UseQueryArgs<CheckoutQueryVariables>, "query">
 ) {
-  return Urql.useQuery<CheckoutQuery>({ query: CheckoutDocument, ...options });
+  return Urql.useQuery<CheckoutQuery, CheckoutQueryVariables>({
+    query: CheckoutDocument,
+    ...options,
+  });
 }
 export const FileUploadDocument = gql`
   mutation FileUpload($file: Upload!) {
@@ -21366,7 +22840,10 @@ export const PublicMetafieldsDocument = gql`
 export function usePublicMetafieldsQuery(
   options: Omit<Urql.UseQueryArgs<PublicMetafieldsQueryVariables>, "query">
 ) {
-  return Urql.useQuery<PublicMetafieldsQuery>({ query: PublicMetafieldsDocument, ...options });
+  return Urql.useQuery<PublicMetafieldsQuery, PublicMetafieldsQueryVariables>({
+    query: PublicMetafieldsDocument,
+    ...options,
+  });
 }
 export const PrivateMetafieldsDocument = gql`
   query PrivateMetafields($id: ID!, $keys: [String!]) {
@@ -21380,7 +22857,10 @@ export const PrivateMetafieldsDocument = gql`
 export function usePrivateMetafieldsQuery(
   options: Omit<Urql.UseQueryArgs<PrivateMetafieldsQueryVariables>, "query">
 ) {
-  return Urql.useQuery<PrivateMetafieldsQuery>({ query: PrivateMetafieldsDocument, ...options });
+  return Urql.useQuery<PrivateMetafieldsQuery, PrivateMetafieldsQueryVariables>({
+    query: PrivateMetafieldsDocument,
+    ...options,
+  });
 }
 export const PublicMetafieldsInferedDocument = gql`
   query PublicMetafieldsInfered($keys: [String!]) {
@@ -21394,7 +22874,7 @@ export const PublicMetafieldsInferedDocument = gql`
 export function usePublicMetafieldsInferedQuery(
   options?: Omit<Urql.UseQueryArgs<PublicMetafieldsInferedQueryVariables>, "query">
 ) {
-  return Urql.useQuery<PublicMetafieldsInferedQuery>({
+  return Urql.useQuery<PublicMetafieldsInferedQuery, PublicMetafieldsInferedQueryVariables>({
     query: PublicMetafieldsInferedDocument,
     ...options,
   });
@@ -21411,7 +22891,7 @@ export const PrivateMetafieldsInferedDocument = gql`
 export function usePrivateMetafieldsInferedQuery(
   options?: Omit<Urql.UseQueryArgs<PrivateMetafieldsInferedQueryVariables>, "query">
 ) {
-  return Urql.useQuery<PrivateMetafieldsInferedQuery>({
+  return Urql.useQuery<PrivateMetafieldsInferedQuery, PrivateMetafieldsInferedQueryVariables>({
     query: PrivateMetafieldsInferedDocument,
     ...options,
   });
@@ -21484,7 +22964,10 @@ export const OrderDetailsDocument = gql`
 export function useOrderDetailsQuery(
   options: Omit<Urql.UseQueryArgs<OrderDetailsQueryVariables>, "query">
 ) {
-  return Urql.useQuery<OrderDetailsQuery>({ query: OrderDetailsDocument, ...options });
+  return Urql.useQuery<OrderDetailsQuery, OrderDetailsQueryVariables>({
+    query: OrderDetailsDocument,
+    ...options,
+  });
 }
 export const OrderPaymentDetailsDocument = gql`
   query OrderPaymentDetails($id: ID!) {
@@ -21501,7 +22984,7 @@ export const OrderPaymentDetailsDocument = gql`
 export function useOrderPaymentDetailsQuery(
   options: Omit<Urql.UseQueryArgs<OrderPaymentDetailsQueryVariables>, "query">
 ) {
-  return Urql.useQuery<OrderPaymentDetailsQuery>({
+  return Urql.useQuery<OrderPaymentDetailsQuery, OrderPaymentDetailsQueryVariables>({
     query: OrderPaymentDetailsDocument,
     ...options,
   });
@@ -21540,7 +23023,10 @@ export const OrderTransactionsDocument = gql`
 export function useOrderTransactionsQuery(
   options: Omit<Urql.UseQueryArgs<OrderTransactionsQueryVariables>, "query">
 ) {
-  return Urql.useQuery<OrderTransactionsQuery>({ query: OrderTransactionsDocument, ...options });
+  return Urql.useQuery<OrderTransactionsQuery, OrderTransactionsQueryVariables>({
+    query: OrderTransactionsDocument,
+    ...options,
+  });
 }
 export const TransactionCreateDocument = gql`
   mutation TransactionCreate(
@@ -21591,10 +23077,32 @@ export function useTransactionUpdateMutation() {
 export const TransactionActionRequestSubscriptionDocument = gql`
   subscription TransactionActionRequestSubscription {
     event {
-      ...TransactionActionPayload
+      ... on TransactionActionRequest {
+        transaction {
+          id
+          reference
+          type
+          authorizedAmount {
+            amount
+            currency
+          }
+          chargedAmount {
+            amount
+          }
+          voidedAmount {
+            amount
+          }
+          refundedAmount {
+            amount
+          }
+        }
+        action {
+          actionType
+          amount
+        }
+      }
     }
   }
-  ${TransactionActionPayloadFragmentDoc}
 `;
 
 export function useTransactionActionRequestSubscription<
@@ -21650,5 +23158,8 @@ export const CheckWebhooksDocument = gql`
 export function useCheckWebhooksQuery(
   options?: Omit<Urql.UseQueryArgs<CheckWebhooksQueryVariables>, "query">
 ) {
-  return Urql.useQuery<CheckWebhooksQuery>({ query: CheckWebhooksDocument, ...options });
+  return Urql.useQuery<CheckWebhooksQuery, CheckWebhooksQueryVariables>({
+    query: CheckWebhooksDocument,
+    ...options,
+  });
 }

--- a/apps/saleor-app-checkout/graphql/subscriptions.graphql
+++ b/apps/saleor-app-checkout/graphql/subscriptions.graphql
@@ -1,6 +1,30 @@
 subscription TransactionActionRequestSubscription {
   event {
-    ...TransactionActionPayload
+    ... on TransactionActionRequest {
+      # temporary paste fragment due to Saleor validation issues
+      transaction {
+        id
+        reference
+        type
+        authorizedAmount {
+          amount
+          currency
+        }
+        chargedAmount {
+          amount
+        }
+        voidedAmount {
+          amount
+        }
+        refundedAmount {
+          amount
+        }
+      }
+      action {
+        actionType
+        amount
+      }
+    }
   }
 }
 

--- a/apps/saleor-app-checkout/pages/api/manifest.ts
+++ b/apps/saleor-app-checkout/pages/api/manifest.ts
@@ -14,7 +14,6 @@ const handler: Handler = (request) => {
     name: appName,
     about: "Saleor checkout app to quickly configure and customize checkout in your store.",
     permissions: ["HANDLE_PAYMENTS", "HANDLE_CHECKOUTS", "MANAGE_ORDERS", "MANAGE_CHECKOUTS"],
-    userPermissions: [],
     appUrl: baseURL,
     dataPrivacyUrl: `${baseURL}/data-privacy`,
     supportUrl: `${baseURL}/support`,


### PR DESCRIPTION
This PR fixes an issue with app registration caused by Saleor's subscription query validation issues.

It removes fragment from the subscription.
