### PR TITLE
Fix how .env files are loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "env-cmd -f .env env-cmd -f .env.local --fallback turbo run build --cache-dir=.turbo",
+    "build": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run build --cache-dir=.turbo",
     "build:saleor-app-checkout": "pnpm run build --filter=saleor-app-checkout...",
     "build:storefront": "pnpm run build --filter=storefront...",
-    "generate": "env-cmd -f .env env-cmd -f .env.local --fallback turbo run generate --cache-dir=.turbo",
-    "dev": "env-cmd -f .env env-cmd -f .env.local --fallback turbo run dev --parallel --cache-dir=.turbo",
-    "lint": "env-cmd -f .env env-cmd -f .env.local --fallback turbo run lint --cache-dir=.turbo",
-    "lint:staged": "env-cmd -f .env env-cmd -f .env.local --fallback turbo run lint:staged",
+    "generate": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run generate --cache-dir=.turbo",
+    "dev": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run dev --parallel --cache-dir=.turbo",
+    "lint": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run lint --cache-dir=.turbo",
+    "lint:staged": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run lint:staged",
     "check-types": "turbo run check-types --cache-dir=.turbo",
-    "test": "env-cmd -f .env turbo run test --cache-dir=.turbo",
+    "test": "env-cmd --no-override -f .env turbo run test --cache-dir=.turbo",
+    "start": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run start",
     "format": "prettier --write .",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Do not override actual environmental variables when loading .env files.