### PR TITLE
fix: :bug: replace hardcoded default channel

### DIFF
--- a/apps/storefront/lib/const.ts
+++ b/apps/storefront/lib/const.ts
@@ -4,3 +4,4 @@ export const API_URI = process.env.NEXT_PUBLIC_API_URI || "";
 export const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
 export const HOMEPAGE_MENU = process.env.NEXT_PUBLIC_HOMEPAGE_MENU || "";
 export const GEOLOCATION = process.env.NEXT_PUBLIC_GEOLOCATION === "true";
+export const DEFAULT_CHANNEL = process.env.NEXT_PUBLIC_DEFAULT_CHANNEL || "default-channel";

--- a/apps/storefront/lib/regions.ts
+++ b/apps/storefront/lib/regions.ts
@@ -1,6 +1,7 @@
 import { GetStaticPropsContext } from "next";
 
 import { LanguageCodeEnum } from "../saleor/api";
+import { DEFAULT_CHANNEL as CHANNEL_SLUG } from "./const";
 
 export const LOCALES = [
   {
@@ -23,7 +24,7 @@ export interface Channel {
 }
 
 export const DEFAULT_CHANNEL: Channel = {
-  slug: "default-channel",
+  slug: CHANNEL_SLUG,
   name: "United States Dollar",
   currencyCode: "USD",
 };


### PR DESCRIPTION
My store uses a channel called "main". When I tried to set up a storefront for it using `saleor storefront create`, I didn't see my products, even though I changed the URL from `http://localhost:3000/default-channel/en-US` to `http://localhost:3000/main/en-US`.

I thought this is perhaps due to some environment variable being assigned a default value, so I went to `apps/storefront/.env` and I changed `NEXT_PUBLIC_DEFAULT_CHANNEL=default-channel` to `=main`. That also didn't solve it.

Then I noticed that in `apps/storefront/lib/regions.ts` we have an object called `DEFAULT_CHANNEL` that uses a hardcoded value for the default channel slug. I replaced that with the .env value and that solved it.