### PR TITLE
Trim whitespaces when reading Saleor app token from `.auth_token`

### DIFF
--- a/apps/saleor-app-checkout/backend/environment.ts
+++ b/apps/saleor-app-checkout/backend/environment.ts
@@ -13,7 +13,7 @@ export const getAuthToken = () => {
   }
 
   if (!token && process.env.VERCEL !== "1" && fs.existsSync(".auth_token")) {
-    token = fs.readFileSync(".auth_token", "utf-8");
+    token = fs.readFileSync(".auth_token", "utf-8").trim();
   }
 
   if (!token) {


### PR DESCRIPTION
This PR fixes an issue where an editor adds `\n` to the file causing errors while making requests to Saleor
