### PR TITLE
Redirect users to order confirmation if checkout was created

### DIFF
--- a/packages/checkout-storefront/src/fetch/types.ts
+++ b/packages/checkout-storefront/src/fetch/types.ts
@@ -5,6 +5,7 @@ export type PayResult = PaySuccessResult | PayErrorResult | null;
 export interface PayErrorResult {
   ok: false;
   errors: ErrorCode[];
+  orderId?: string;
 }
 
 export interface PaySuccessResult {

--- a/packages/checkout-storefront/src/hooks/usePay.ts
+++ b/packages/checkout-storefront/src/hooks/usePay.ts
@@ -1,4 +1,4 @@
-import { pay as payRequest, PaySuccessResult } from "@/checkout-storefront/fetch";
+import { pay as payRequest, PaySuccessResult, PayErrorResult } from "@/checkout-storefront/fetch";
 import { useFetch } from "@/checkout-storefront/hooks/useFetch";
 import { OrderBody, CheckoutBody } from "checkout-common";
 import { useAppConfig } from "../providers/AppConfigProvider";
@@ -48,6 +48,12 @@ export const usePay = () => {
 
       window.history.replaceState({ ...window.history.state, as: newUrl, url: newUrl }, "", newUrl);
       window.location.href = paymentUrl;
+    }
+
+    if (!result?.ok && result?.orderId) {
+      // Order created, payment creation failed, checkout doesn't exist
+      const newUrl = `?order=${result.orderId}`;
+      window.location.href = newUrl;
     }
 
     return result;


### PR DESCRIPTION
This PR adds redirection to order confirmation page if order was created from checkout (checkout is deleted) but payment creation failed for some reason.
This gives an option to the user to retry the payment and prevents the dreaded "Checkout doesn't exist" error.
