### PR TITLE
Speedup monorepo Next.js compilation with a few hacks

### DIFF
--- a/apps/saleor-app-checkout/next.config.js
+++ b/apps/saleor-app-checkout/next.config.js
@@ -37,6 +37,7 @@ const config = withTM({
   experimental: {
     // https://nextjs.org/docs/messages/import-esm-externals
     esmExternals: "loose",
+    externalDir: true,
   },
   eslint: {
     ignoreDuringBuilds: true,

--- a/apps/saleor-app-checkout/tsconfig.json
+++ b/apps/saleor-app-checkout/tsconfig.json
@@ -6,6 +6,14 @@
     "allowJs": true,
     "paths": {
       "@/saleor-app-checkout/*": ["./*"],
+
+      // https://github.com/belgattitude/nextjs-monorepo-example
+      "@saleor/checkout-storefront/*": ["../../packages/checkout-storefront/*"],
+      "@saleor/checkout-storefront": ["../../packages/checkout-storefront/src/index.tsx"],
+      "@/checkout-storefront/icons": ["../../packages/checkout-storefront/src/assets/icons"],
+      "@/checkout-storefront/images": ["../../packages/checkout-storefront/src/assets/images"],
+      "@/checkout-storefront/*": ["../../packages/checkout-storefront/src/*"],
+
       // https://github.com/facebook/react/issues/24304.
       // Remove when this gets updated to React 18"
       "react": ["./node_modules/@types/react"],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run generate --cache-dir=.turbo",
     "dev": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback pnpm run _dev",
     "/*": "https://github.com/vercel/turborepo/issues/460",
-    "_dev": "turbo run build --filter=@saleor/checkout-storefront --cache-dir=.turbo && turbo run dev --parallel --cache-dir=.turbo",
+    "_dev": "turbo run build --filter=@saleor/checkout-storefront --cache-dir=.turbo && turbo run dev --parallel --cache-dir=.turbo --filter=!checkout",
     "lint": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run lint --cache-dir=.turbo",
     "lint:staged": "env-cmd --no-override -f .env env-cmd --no-override -f .env.local --fallback turbo run lint:staged",
     "check-types": "turbo run check-types --cache-dir=.turbo",
@@ -24,7 +24,7 @@
     "format": "prettier --write .",
     "prepare": "husky install",
     "clean-deps": "turbo run clean && rm -rf node_modules **/node_modules pnpm-lock.yaml",
-    "clean": "rm -rf .turbo || turbo run clean",
+    "clean": "rm -rf .turbo; turbo run clean",
     "cy:run": "cypress run",
     "cy:open": "cypress open"
   },

--- a/packages/checkout-storefront/rollup.config.js
+++ b/packages/checkout-storefront/rollup.config.js
@@ -14,6 +14,9 @@ const isProd = process.env.NODE_ENV === "production";
 
 const __ = (arr) => arr.filter((x) => !!x);
 
+/**
+ * @type {import('rollup').RollupOptions[]}
+ */
 export default [
   {
     input: "src/index.tsx",

--- a/packages/checkout-storefront/src/lib/svgSrc.ts
+++ b/packages/checkout-storefront/src/lib/svgSrc.ts
@@ -1,1 +1,2 @@
-export const getSvgSrc = (svg: typeof import("*.svg")) => (typeof svg === "string" ? svg : svg.src);
+export const getSvgSrc = (svg: string | { src: string }) =>
+  typeof svg === "string" ? svg : svg.src;

--- a/packages/checkout-storefront/src/views/Checkout/Checkout.tsx
+++ b/packages/checkout-storefront/src/views/Checkout/Checkout.tsx
@@ -5,8 +5,9 @@ import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useAuthState } from "@saleor/sdk";
 import { useCheckout } from "@/checkout-storefront/hooks";
-import { EmptyCartPage, PageNotFound } from "@/checkout-storefront/views";
 import { CheckoutSkeleton } from "./CheckoutSkeleton";
+import { EmptyCartPage } from "../EmptyCartPage";
+import { PageNotFound } from "../PageNotFound";
 
 export const Checkout = () => {
   const { checkout, loading } = useCheckout();

--- a/packages/checkout-storefront/src/views/index.tsx
+++ b/packages/checkout-storefront/src/views/index.tsx
@@ -1,4 +1,0 @@
-export * from "./Checkout";
-export * from "./OrderConfirmation";
-export * from "./EmptyCartPage";
-export * from "./PageNotFound";


### PR DESCRIPTION
Now modifying `packages/checkout-storefront` results in almost instant change in `apps/saleor-app-checkout`:

https://user-images.githubusercontent.com/1338731/196049167-2906ad37-8795-4829-8c5c-e187bce0beee.mp4

See https://github.com/belgattitude/nextjs-monorepo-example

