### PR TITLE
Add refunds to dummy payment provider

### DIFF
--- a/apps/saleor-app-checkout/backend/payments/providers/dummy/refunds.ts
+++ b/apps/saleor-app-checkout/backend/payments/providers/dummy/refunds.ts
@@ -1,0 +1,57 @@
+import { TransactionActionPayloadFragment } from "@/saleor-app-checkout/graphql";
+import { TransactionReversal } from "@/saleor-app-checkout/types/refunds";
+import { updateTransaction } from "../../updateTransaction";
+import { getActionsAfterRefund, getTransactionAmountGetter } from "../../utils";
+
+export const DUMMY_PAYMENT_TYPE = "dummy-payment";
+
+export const handleDummyRefund = async (
+  refund: TransactionReversal,
+  transaction: TransactionActionPayloadFragment["transaction"]
+) => {
+  if (!transaction?.id) {
+    throw new Error("Transaction id was not provided");
+  }
+
+  const { amount, currency } = refund;
+
+  const transactionActions = getActionsAfterRefund(transaction, amount);
+  const getAmount = getTransactionAmountGetter({
+    charged: transaction.chargedAmount.amount,
+    refunded: amount,
+    authorized: 0,
+    voided: 0,
+  });
+
+  // Create "pending" event
+  await updateTransaction({
+    id: transaction.id,
+    transaction: {
+      availableActions: transactionActions,
+    },
+    transactionEvent: {
+      status: "PENDING",
+      name: "Refund requested",
+    },
+  });
+
+  // Create "completed" event + update transaction amounts
+  await updateTransaction({
+    id: transaction.id,
+    transaction: {
+      availableActions: transactionActions,
+      amountRefunded: {
+        amount: getAmount("refunded"),
+        currency,
+      },
+      amountCharged: {
+        amount: getAmount("charged"),
+        currency,
+      },
+    },
+    transactionEvent: {
+      status: "SUCCESS",
+      name: "Refund completed",
+    },
+  });
+};

--- a/apps/saleor-app-checkout/backend/payments/utils.ts
+++ b/apps/saleor-app-checkout/backend/payments/utils.ts
@@ -5,6 +5,7 @@ import {
 } from "@/saleor-app-checkout/graphql";
 import currency from "currency.js";
 import { ADYEN_PAYMENT_PREFIX } from "./providers/adyen";
+import { DUMMY_PAYMENT_TYPE } from "./providers/dummy/refunds";
 import { MOLLIE_PAYMENT_PREFIX } from "./providers/mollie";
 
 export const formatRedirectUrl = (redirectUrl: string, orderId: string) => {
@@ -85,6 +86,11 @@ export const isMollieTransaction = (transaction: TransactionWithType) => {
 export const isAdyenTransaction = (transaction: TransactionWithType) => {
   return transaction.type.includes(ADYEN_PAYMENT_PREFIX);
 };
+
+export const isDummyTransaction = (transaction: TransactionWithType) => {
+  return transaction.type.includes(DUMMY_PAYMENT_TYPE);
+};
+
 // Some payment methods expect the amount to be in cents (integers)
 // Saleor provides and expects the amount to be in dollars (decimal format / floats)
 export const getIntegerAmountFromSaleor = (dollars: number) =>

--- a/apps/saleor-app-checkout/backend/utils.ts
+++ b/apps/saleor-app-checkout/backend/utils.ts
@@ -55,7 +55,9 @@ export const getBaseUrl = (req: { headers: Record<string, string | string[] | un
     return debugEnvVars.appUrl;
   }
 
-  const { host = "", "x-forwarded-proto": protocol = "http" } = req.headers;
+  const { host = "", "x-forwarded-proto": forwardedProtocol = "http" } = req.headers;
+
+  const protocol = forwardedProtocol.includes(",") ? "http" : forwardedProtocol; // proxy can have value http,https
 
   invariant(typeof host === "string", "host is not a string");
   invariant(typeof protocol === "string", "protocol is not a string");
@@ -69,6 +71,6 @@ export const getSaleorDomain = (): Promise<string> => {
       return reject(`Missing ${envVarsNames.apiUrl} environment variable`);
     }
     const url = new URL(envVars.apiUrl);
-    return resolve(url.hostname);
+    return resolve(url.host);
   });
 };

--- a/apps/saleor-app-checkout/pages/api/dummy-pay.ts
+++ b/apps/saleor-app-checkout/pages/api/dummy-pay.ts
@@ -5,6 +5,7 @@ import { allowCors } from "@/saleor-app-checkout/backend/utils";
 import { TransactionCreateMutationVariables } from "@/saleor-app-checkout/graphql";
 import { createParseAndValidateBody } from "@/saleor-app-checkout/utils";
 import * as yup from "yup";
+import { DUMMY_PAYMENT_TYPE } from "@/saleor-app-checkout/backend/payments/providers/dummy/refunds";
 
 const dummyPayBodySchema = yup.object({
   orderId: yup.string().required(),
@@ -30,9 +31,13 @@ const handler: NextApiHandler = async (req, res) => {
   const transactionData: TransactionCreateMutationVariables = {
     id: orderId,
     transaction: {
-      type: "dummy-payment",
+      type: DUMMY_PAYMENT_TYPE,
       status: "complete",
       amountCharged,
+    },
+    transactionEvent: {
+      status: "SUCCESS",
+      name: "Charged",
     },
   };
 

--- a/apps/saleor-app-checkout/pages/api/dummy-pay.ts
+++ b/apps/saleor-app-checkout/pages/api/dummy-pay.ts
@@ -34,6 +34,7 @@ const handler: NextApiHandler = async (req, res) => {
       type: DUMMY_PAYMENT_TYPE,
       status: "complete",
       amountCharged,
+      availableActions: ["REFUND"],
     },
     transactionEvent: {
       status: "SUCCESS",

--- a/apps/saleor-app-checkout/pages/api/manifest.ts
+++ b/apps/saleor-app-checkout/pages/api/manifest.ts
@@ -12,7 +12,7 @@ import { TransactionActionRequestSubscriptionDocument } from "@/saleor-app-check
 import invariant from "ts-invariant";
 
 const handler: Handler = (request) => {
-  const { baseURL } = request.context;
+  const baseURL = getBaseUrl(request);
   invariant(typeof baseURL === "string", `baseURL is not a string`);
 
   const webhookUrl = urlJoin(getBaseUrl(request), SALEOR_WEBHOOK_TRANSACTION_ENDPOINT);

--- a/apps/saleor-app-checkout/pages/api/webhooks/saleor/transaction-action-request.ts
+++ b/apps/saleor-app-checkout/pages/api/webhooks/saleor/transaction-action-request.ts
@@ -30,11 +30,11 @@ const handler: Handler<TransactionActionPayloadFragment> = async (req) => {
   const { transaction, action } = req.params;
   console.log("Start processing Saleor transaction action", action, transaction);
 
-  if (!transaction?.type || !action.amount) {
+  if (!transaction?.type || !action?.amount) {
     console.warn(
       "Received webhook call without transaction data",
       transaction?.type,
-      action.amount
+      action?.amount
     );
     return Response.BadRequest({ success: false, message: "Missing transaction data" });
   }

--- a/apps/saleor-app-checkout/pages/api/webhooks/saleor/transaction-action-request.ts
+++ b/apps/saleor-app-checkout/pages/api/webhooks/saleor/transaction-action-request.ts
@@ -13,8 +13,10 @@ import { getTransactionProcessedEvents } from "@/saleor-app-checkout/backend/pay
 import { updateTransactionProcessedEvents } from "@/saleor-app-checkout/backend/payments/updateTransactionProcessedEvents";
 import {
   isAdyenTransaction,
+  isDummyTransaction,
   isMollieTransaction,
 } from "@/saleor-app-checkout/backend/payments/utils";
+import { handleDummyRefund } from "@/saleor-app-checkout/backend/payments/providers/dummy/refunds";
 
 export const SALEOR_WEBHOOK_TRANSACTION_ENDPOINT = "api/webhooks/saleor/transaction-action-request";
 
@@ -28,8 +30,12 @@ const handler: Handler<TransactionActionPayloadFragment> = async (req) => {
   const { transaction, action } = req.params;
   console.log("Start processing Saleor transaction action", action, transaction);
 
-  if (!transaction?.type || !transaction.reference || !action.amount) {
-    console.warn("Received webhook call without transaction data", req.params);
+  if (!transaction?.type || !action.amount) {
+    console.warn(
+      "Received webhook call without transaction data",
+      transaction?.type,
+      action.amount
+    );
     return Response.BadRequest({ success: false, message: "Missing transaction data" });
   }
 
@@ -61,6 +67,15 @@ const handler: Handler<TransactionActionPayloadFragment> = async (req) => {
       }
       if (isAdyenTransaction(transaction)) {
         await handleAdyenRefund(transactionReversal, transaction);
+      }
+      if (isDummyTransaction(transaction)) {
+        await handleDummyRefund(
+          {
+            ...transactionReversal,
+            id: transaction.id,
+          },
+          transaction
+        );
       }
     }
 


### PR DESCRIPTION
Fixes #557

Handle refunds issued for transactions made by dummy payment provider

Fix manifest URLs when app is installed locally
