### PR TITLE
fix ImageExpand component in storefront app to show XIcon button so that user can return back to the product page by clicking the button

### DIFF
--- a/apps/storefront/components/product/ImageExpand.tsx
+++ b/apps/storefront/components/product/ImageExpand.tsx
@@ -14,21 +14,21 @@ export function ImageExpand({ image, onRemoveExpand }: ImageExpandProps) {
   }
 
   return (
-    <div className="min-h-screen absolute overflow-hidden grid grid-cols-1 mx-auto px-8 md:h-full w-full bg-gray-100">
-      <div
-        role="button"
-        tabIndex={0}
-        className="absolute grid h-6 justify-end w-full z-40 p-8 lg:px-8 mx-auto"
-        onClick={() => onRemoveExpand()}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            onRemoveExpand();
-          }
-        }}
-      >
-        <XIcon className="w-6 h-6" />
-      </div>
-      <div className="w-full h-full absolute md:mt-10">
+    <div className="absolute grid w-full min-h-screen grid-cols-1 px-8 mx-auto overflow-hidden bg-gray-100 md:h-full">
+      <div className="absolute w-full h-full md:mt-10">
+        <div
+          role="button"
+          tabIndex={0}
+          className="absolute z-10 grid justify-end w-full h-6 p-8 mx-auto mt-14 lg:px-8 md:mt-4"
+          onClick={() => onRemoveExpand()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              onRemoveExpand();
+            }
+          }}
+        >
+          <XIcon className="w-6 h-6" />
+        </div>
         <Image src={image.url} alt={image.alt} layout="fill" objectFit="scale-down" />
       </div>
     </div>


### PR DESCRIPTION
I issued a problem related to this pull request([#612](https://github.com/saleor/react-storefront/issues/612)).
But I couldn't find any commits to resolve it recently.
So I tried to fix it myself and now I make a pull request.