### PR TITLE
Run codeql workflow only for saleor/react-storefront

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository == 'saleor/react-storefront'
     name: Analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This PR makes codeql-analysis workflow to run only on `saleor/react-storefront`.

Codeql needs to be enabled and by default the cloned repository will throw errors.

https://github.com/saleor/saleor-cli/issues/476