### PR TITLE
Fix default url in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
       environment:
         required: true
         description: "Environment to run tests against"
-        default: "https://staging-demo.saleor.io"
+        default: "https://staging-demo.saleor.io/"
         type: choice
         options:
           - https://staging-demo.saleor.io/
@@ -32,7 +32,7 @@ jobs:
       - name: Get env
         id: get-env-uri
         env:
-          DEFAULT_ENV_URI: "https://staging-demo.saleor.io"
+          DEFAULT_ENV_URI: "https://staging-demo.saleor.io/"
         run: |
           echo "ENV_URI=${{ github.event.inputs.environment || env.DEFAULT_ENV_URI }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Missing `/` at default url causing cypress tests to fail 

```
cy.request() failed trying to load:
https://staging-demo.saleor.iographql/
We attempted to make an http request to this URL but the request failed without a response.
```