### PR TITLE
Various small fixes

### DIFF
--- a/apps/storefront/lib/auth/SaleorAuthClient.ts
+++ b/apps/storefront/lib/auth/SaleorAuthClient.ts
@@ -81,6 +81,7 @@ export class SaleorAuthClient {
       const res: TokenRefreshResponse = await response.clone().json();
 
       const {
+        errors: graphqlErrors,
         data: {
           tokenRefresh: { errors, token },
         },
@@ -88,8 +89,9 @@ export class SaleorAuthClient {
 
       this.onAuthRefresh?.(false);
 
-      if (errors.length || !token) {
-        this.storageHandler?.setAuthState("signedOut");
+      if (errors.length || graphqlErrors?.length || !token) {
+        this.tokenRefreshPromise = null;
+        this.storageHandler?.clearAuthStorage();
         return fetch(input, init);
       }
 

--- a/apps/storefront/lib/auth/types.ts
+++ b/apps/storefront/lib/auth/types.ts
@@ -20,6 +20,7 @@ export interface TokenRefreshVariables {
 }
 
 export interface TokenRefreshResponse {
+  errors?: any[];
   data: {
     tokenRefresh: {
       token: string | undefined;

--- a/packages/checkout-storefront/src/hooks/useCheckoutFormValidationTrigger.ts
+++ b/packages/checkout-storefront/src/hooks/useCheckoutFormValidationTrigger.ts
@@ -25,13 +25,9 @@ export const useCheckoutFormValidationTrigger = <TData extends FormDataBase>({
 
   const { values, validateForm, setTouched } = form;
 
-  console.log({ validating });
-
   const handleGlobalValidationTrigger = useCallback(async () => {
-    console.log(`handleGlobalValidationTrigger`, validating);
     if (validating) {
       const formErrors = await validateForm(values);
-      console.log({ formErrors });
       if (!hasErrors(formErrors)) {
         setValidationState(scope, "valid");
         return;
@@ -55,7 +51,6 @@ export const useCheckoutFormValidationTrigger = <TData extends FormDataBase>({
   ]);
 
   useEffect(() => {
-    console.log({ skip });
     if (!skip) {
       void handleGlobalValidationTrigger();
     }

--- a/packages/checkout-storefront/src/hooks/useForm/useForm.ts
+++ b/packages/checkout-storefront/src/hooks/useForm/useForm.ts
@@ -1,28 +1,51 @@
-import { FormDataBase, FormProps, UseFormReturn } from "@/checkout-storefront/hooks/useForm/types";
+import {
+  ChangeHandler,
+  FormDataBase,
+  FormProps,
+  UseFormReturn,
+} from "@/checkout-storefront/hooks/useForm/types";
 import { useFormik, useFormikContext } from "formik";
-import { useCallback } from "react";
+import { isEqual } from "lodash-es";
+import { useCallback, useState } from "react";
 
 export const useForm = <TData extends FormDataBase>({
-  initialDirty,
+  initialDirty = false,
   ...formProps
 }: FormProps<TData>): UseFormReturn<TData> => {
   const form = useFormik<TData>(formProps);
+  // we do this because in some cases it's not updated properly
+  // https://github.com/jaredpalmer/formik/issues/3165
+  const [dirty, setDirty] = useState(initialDirty);
+  const [values, setValues] = useState(formProps.initialValues);
 
-  const { dirty, handleSubmit: handleFormikSubmit } = form;
+  const { handleSubmit: handleFormikSubmit, handleChange: formikHandleChange } = form;
 
   const handleSubmit = useCallback(
     (event?: React.FormEvent<HTMLFormElement>) => {
       event?.preventDefault();
 
       // we do it here because formik doesn't pass props like dirty to onSubmit
-      if (initialDirty || dirty) {
+      if (dirty) {
         handleFormikSubmit(event);
       }
     },
-    [dirty, handleFormikSubmit, initialDirty]
+    [dirty, handleFormikSubmit]
   );
 
-  return { ...form, handleSubmit };
+  const handleChange: ChangeHandler = useCallback(
+    (event) => {
+      const { name, value } = event.target;
+
+      const updatedValues = { ...values, [name]: value };
+
+      setDirty(!isEqual(values, updatedValues));
+      setValues(updatedValues);
+      formikHandleChange(event);
+    },
+    [formikHandleChange, values]
+  );
+
+  return { ...form, handleSubmit, handleChange, values, dirty };
 };
 
 export const useFormContext = useFormikContext;

--- a/packages/checkout-storefront/src/hooks/useForm/useForm.ts
+++ b/packages/checkout-storefront/src/hooks/useForm/useForm.ts
@@ -51,6 +51,10 @@ export const useForm = <TData extends FormDataBase>({
   );
 
   const setFieldValue = async (field: FormDataField<TData>, value: TData[FormDataField<TData>]) => {
+    if (values[field] === value) {
+      return;
+    }
+
     await setFormikFieldValue(field, value);
     setValues({ ...values, [field]: value });
   };

--- a/packages/checkout-storefront/src/hooks/useForm/useForm.ts
+++ b/packages/checkout-storefront/src/hooks/useForm/useForm.ts
@@ -1,6 +1,7 @@
 import {
   ChangeHandler,
   FormDataBase,
+  FormDataField,
   FormProps,
   UseFormReturn,
 } from "@/checkout-storefront/hooks/useForm/types";
@@ -18,7 +19,11 @@ export const useForm = <TData extends FormDataBase>({
   const [dirty, setDirty] = useState(initialDirty);
   const [values, setValues] = useState(formProps.initialValues);
 
-  const { handleSubmit: handleFormikSubmit, handleChange: formikHandleChange } = form;
+  const {
+    handleSubmit: handleFormikSubmit,
+    handleChange: formikHandleChange,
+    setFieldValue: setFormikFieldValue,
+  } = form;
 
   const handleSubmit = useCallback(
     (event?: React.FormEvent<HTMLFormElement>) => {
@@ -45,7 +50,12 @@ export const useForm = <TData extends FormDataBase>({
     [formikHandleChange, values]
   );
 
-  return { ...form, handleSubmit, handleChange, values, dirty };
+  const setFieldValue = async (field: FormDataField<TData>, value: TData[FormDataField<TData>]) => {
+    await setFormikFieldValue(field, value);
+    setValues({ ...values, [field]: value });
+  };
+
+  return { ...form, handleSubmit, handleChange, values, dirty, setFieldValue };
 };
 
 export const useFormContext = useFormikContext;

--- a/packages/checkout-storefront/src/lib/auth/SaleorAuthClient.ts
+++ b/packages/checkout-storefront/src/lib/auth/SaleorAuthClient.ts
@@ -81,6 +81,7 @@ export class SaleorAuthClient {
       const res: TokenRefreshResponse = await response.clone().json();
 
       const {
+        errors: graphqlErrors,
         data: {
           tokenRefresh: { errors, token },
         },
@@ -88,8 +89,9 @@ export class SaleorAuthClient {
 
       this.onAuthRefresh?.(false);
 
-      if (errors.length || !token) {
-        this.storageHandler?.setAuthState("signedOut");
+      if (errors.length || graphqlErrors?.length || !token) {
+        this.tokenRefreshPromise = null;
+        this.storageHandler?.clearAuthStorage();
         return fetch(input, init);
       }
 

--- a/packages/checkout-storefront/src/lib/auth/types.ts
+++ b/packages/checkout-storefront/src/lib/auth/types.ts
@@ -20,6 +20,7 @@ export interface TokenRefreshVariables {
 }
 
 export interface TokenRefreshResponse {
+  errors?: any[];
   data: {
     tokenRefresh: {
       token: string | undefined;

--- a/packages/checkout-storefront/src/sections/AddressList/useAddressListForm.ts
+++ b/packages/checkout-storefront/src/sections/AddressList/useAddressListForm.ts
@@ -105,10 +105,13 @@ export const useAddressListForm = ({
       return;
     }
 
+    const matchingDefaultAddressInAddresses = addressList.find(
+      getByMatchingAddress(defaultAddress)
+    );
     // if not, prefer user default address
-    if (defaultAddress) {
+    if (defaultAddress && matchingDefaultAddressInAddresses) {
       previousCheckoutAddress.current = defaultAddress;
-      void setFieldValue("selectedAddressId", defaultAddress.id);
+      void setFieldValue("selectedAddressId", matchingDefaultAddressInAddresses.id);
       return;
     }
 

--- a/packages/checkout-storefront/src/sections/CheckoutForm/useCheckoutSubmit.ts
+++ b/packages/checkout-storefront/src/sections/CheckoutForm/useCheckoutSubmit.ts
@@ -14,7 +14,6 @@ export const useCheckoutSubmit = () => {
   const { user } = useUser();
   const { validateAllForms } = useCheckoutValidationActions();
   const { validating, validationState } = useCheckoutValidationState();
-  console.log({ validationState });
   const { updateState, loadingCheckout, submitInProgress } = useCheckoutUpdateState();
   const { setShouldRegisterUser, setSubmitInProgress } = useCheckoutUpdateStateActions();
   const { checkoutFinalize, finalizing } = useCheckoutFinalize();

--- a/packages/checkout-storefront/src/sections/DeliveryMethods/DeliveryMethods.tsx
+++ b/packages/checkout-storefront/src/sections/DeliveryMethods/DeliveryMethods.tsx
@@ -11,12 +11,17 @@ import { CommonSectionProps } from "@/checkout-storefront/lib/globalTypes";
 import { deliveryMethodsLabels, deliveryMethodsMessages } from "./messages";
 import { useDeliveryMethodsForm } from "@/checkout-storefront/sections/DeliveryMethods/useDeliveryMethodsForm";
 import { FormProvider } from "@/checkout-storefront/providers/FormProvider";
+import { useCheckoutUpdateState } from "@/checkout-storefront/state/updateStateStore";
+import { DeliveryMethodsSkeleton } from "@/checkout-storefront/sections/DeliveryMethods/DeliveryMethodsSkeleton";
+import { useUser } from "@/checkout-storefront/hooks/useUser";
 
 export const DeliveryMethods: React.FC<CommonSectionProps> = ({ collapsed }) => {
   const formatMessage = useFormattedMessages();
   const { checkout } = useCheckout();
+  const { authenticated } = useUser();
   const { shippingMethods, shippingAddress } = checkout;
   const form = useDeliveryMethodsForm();
+  const { updateState } = useCheckoutUpdateState();
 
   const getSubtitle = ({ min, max }: { min?: number | null; max?: number | null }) => {
     if (!min || !max) {
@@ -38,26 +43,30 @@ export const DeliveryMethods: React.FC<CommonSectionProps> = ({ collapsed }) => 
       <Divider />
       <div className="section" data-testid="deliveryMethods">
         <Title className="mb-2">{formatMessage(deliveryMethodsMessages.deliveryMethods)}</Title>
-        {!shippingAddress && (
+        {!authenticated && !shippingAddress && (
           <Text>{formatMessage(deliveryMethodsMessages.noShippingAddressMessage)}</Text>
         )}
-        <SelectBoxGroup label={formatMessage(deliveryMethodsLabels.deliveryMethods)}>
-          {shippingMethods?.map(
-            ({ id, name, price, minimumDeliveryDays: min, maximumDeliveryDays: max }) => (
-              <SelectBox key={id} name="selectedMethodId" value={id}>
-                <div className="min-h-12 grow flex flex-col justify-center pointer-events-none">
-                  <div className="flex flex-row justify-between self-stretch items-center">
-                    <Text>{name}</Text>
-                    <Text>{getFormattedMoney(price)}</Text>
+        {authenticated && !shippingAddress && updateState.checkoutShippingUpdate ? (
+          <DeliveryMethodsSkeleton />
+        ) : (
+          <SelectBoxGroup label={formatMessage(deliveryMethodsLabels.deliveryMethods)}>
+            {shippingMethods?.map(
+              ({ id, name, price, minimumDeliveryDays: min, maximumDeliveryDays: max }) => (
+                <SelectBox key={id} name="selectedMethodId" value={id}>
+                  <div className="min-h-12 grow flex flex-col justify-center pointer-events-none">
+                    <div className="flex flex-row justify-between self-stretch items-center">
+                      <Text>{name}</Text>
+                      <Text>{getFormattedMoney(price)}</Text>
+                    </div>
+                    <Text size="xs" color="secondary">
+                      {getSubtitle({ min, max })}
+                    </Text>
                   </div>
-                  <Text size="xs" color="secondary">
-                    {getSubtitle({ min, max })}
-                  </Text>
-                </div>
-              </SelectBox>
-            )
-          )}
-        </SelectBoxGroup>
+                </SelectBox>
+              )
+            )}
+          </SelectBoxGroup>
+        )}
       </div>
     </FormProvider>
   );

--- a/packages/checkout-storefront/src/sections/DeliveryMethods/useDeliveryMethodsForm.ts
+++ b/packages/checkout-storefront/src/sections/DeliveryMethods/useDeliveryMethodsForm.ts
@@ -72,7 +72,7 @@ export const useDeliveryMethodsForm = (): UseFormReturn<DeliveryMethodsFormData>
   });
 
   const {
-    setValues,
+    setFieldValue,
     values: { selectedMethodId },
     handleSubmit,
     handleChange,
@@ -93,12 +93,19 @@ export const useDeliveryMethodsForm = (): UseFormReturn<DeliveryMethodsFormData>
       return;
     }
 
-    void setValues({ selectedMethodId: getAutoSetMethod()?.id });
+    void setFieldValue("selectedMethodId", getAutoSetMethod()?.id);
 
     if (hasShippingCountryChanged) {
       previousShippingCountry.current = shippingAddress?.country?.code as CountryCode;
     }
-  }, [shippingAddress, shippingMethods, getAutoSetMethod, selectedMethodId, setValues]);
+  }, [
+    shippingAddress,
+    shippingMethods,
+    getAutoSetMethod,
+    selectedMethodId,
+    setFieldValue,
+    form.values.selectedMethodId,
+  ]);
 
   const onChange: ChangeHandler = (event) => {
     setCheckoutUpdateState("loading");

--- a/packages/checkout-storefront/src/sections/GuestBillingAddressSection/useBillingSameAsShippingForm.ts
+++ b/packages/checkout-storefront/src/sections/GuestBillingAddressSection/useBillingSameAsShippingForm.ts
@@ -72,6 +72,7 @@ export const useBillingSameAsShippingForm = (
   const form = useForm<BillingSameAsShippingFormData>({
     onSubmit,
     initialValues,
+    initialDirty: true,
   });
 
   const {
@@ -131,7 +132,10 @@ export const useBillingSameAsShippingForm = (
 
   // once billing address in api and form don't match, submit
   useEffect(() => {
-    if (!isMatchingAddress(billingAddress, form.values.billingAddress)) {
+    if (
+      form.values.billingAddress &&
+      !isMatchingAddress(billingAddress, form.values.billingAddress)
+    ) {
       handleSubmit();
     }
   }, [billingAddress, form.values.billingAddress, handleSubmit]);

--- a/packages/checkout-storefront/src/sections/PaymentSection/AdyenDropIn/AdyenDropIn.tsx
+++ b/packages/checkout-storefront/src/sections/PaymentSection/AdyenDropIn/AdyenDropIn.tsx
@@ -45,8 +45,6 @@ export const AdyenDropIn = memo<AdyenDropInProps>(() => {
   const { validating } = useCheckoutValidationState();
   const { allFormsValid, validateAllForms } = useCheckoutSubmit();
 
-  console.log({ validating });
-
   const { showCustomErrors } = useAlerts("checkoutPay");
 
   const [, fetchCreateDropInAdyenPayment] = useFetch(createDropInAdyenPayment, {
@@ -69,9 +67,7 @@ export const AdyenDropIn = memo<AdyenDropInProps>(() => {
   });
 
   const afterSubmit = useCallback(async () => {
-    console.log(1, { validating, allFormsValid });
     if (!validating && !allFormsValid && adyenCheckoutSubmitParams) {
-      console.log(2);
       // validated, failed, let's reset the state
       adyenCheckoutSubmitParams.component.setStatus("ready");
       setAdyenCheckoutSubmitParams(null);
@@ -79,7 +75,6 @@ export const AdyenDropIn = memo<AdyenDropInProps>(() => {
     }
 
     if (!allFormsValid || !adyenCheckoutSubmitParams || validating) {
-      console.log(3);
       // not validated yet, or still validating, or not all forms valid
       return;
     }
@@ -95,10 +90,7 @@ export const AdyenDropIn = memo<AdyenDropInProps>(() => {
       adyenStateData: adyenCheckoutSubmitParams.state.data,
     });
 
-    console.log(4);
-
     if (!result || "message" in result) {
-      console.log(5);
       console.error(result);
       showCustomErrors([{ message: result?.message || "Something went wrong…" }]);
       adyenCheckoutSubmitParams.component.setStatus("ready");
@@ -106,14 +98,12 @@ export const AdyenDropIn = memo<AdyenDropInProps>(() => {
     }
 
     if (result.payment.action) {
-      console.log(6);
       adyenCheckoutSubmitParams.component.handleAction(
         // discrepancy between adyen-api and adyen-web types 🤦‍♂️
         result.payment.action as unknown as Exclude<AdyenWebPaymentResponse["action"], undefined>
       );
       return;
     } else {
-      console.log(7);
       return handlePaymentResult(saleorApiUrl, result, adyenCheckoutSubmitParams.component);
     }
   }, [

--- a/packages/checkout-storefront/src/sections/Summary/useSummaryHeightCalc.ts
+++ b/packages/checkout-storefront/src/sections/Summary/useSummaryHeightCalc.ts
@@ -39,7 +39,8 @@ export const useSummaryHeightCalc = ({ linesCount, onBreakpointChange }: UseSumm
     };
 
     window.addEventListener("resize", handleWindowResize, { passive: true });
-    return handleWindowResize;
+
+    return () => window.removeEventListener("resize", handleWindowResize);
   }, [linesCount, onBreakpointChange]);
 
   const allItemsHeight = useMemo(() => linesCount * ITEM_HEIGHT, [linesCount]);

--- a/packages/checkout-storefront/src/sections/Summary/useSummaryHeightCalc.ts
+++ b/packages/checkout-storefront/src/sections/Summary/useSummaryHeightCalc.ts
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 // once we add custom heights etc. we'll need to calculate
 // this from rendered elements
@@ -15,14 +15,18 @@ interface UseSummaryHeightCalc {
 
 export const useSummaryHeightCalc = ({ linesCount, onBreakpointChange }: UseSummaryHeightCalc) => {
   const [maxSummaryHeight, setMaxSummaryHeight] = useState<number>(0);
+  const previousWidth = useRef(window.innerWidth);
 
   useEffect(() => {
     const handleWindowResize = () => {
       const isLg = window.innerWidth > LG_BREAKPOINT;
 
-      debounce(() => {
-        onBreakpointChange(isLg ? "lg" : "md");
-      }, 500)();
+      if (previousWidth.current !== window.innerWidth) {
+        debounce(() => {
+          previousWidth.current = window.innerWidth;
+          onBreakpointChange(isLg ? "lg" : "md");
+        }, 500)();
+      }
 
       const maxHeight = isLg
         ? // function based on on the best result visually
@@ -35,9 +39,7 @@ export const useSummaryHeightCalc = ({ linesCount, onBreakpointChange }: UseSumm
     };
 
     window.addEventListener("resize", handleWindowResize, { passive: true });
-    handleWindowResize();
-
-    return () => window.removeEventListener("resize", handleWindowResize);
+    return handleWindowResize;
   }, [linesCount, onBreakpointChange]);
 
   const allItemsHeight = useMemo(() => linesCount * ITEM_HEIGHT, [linesCount]);

--- a/packages/checkout-storefront/src/state/updateStateStore.ts
+++ b/packages/checkout-storefront/src/state/updateStateStore.ts
@@ -8,7 +8,7 @@ export type CheckoutUpdateStateStatus = "success" | "loading" | "error";
 
 export type CheckoutUpdateStateScope = Exclude<CheckoutScope, "checkoutPay" | "checkoutFinalize">;
 
-interface CheckoutUpdateStateStore {
+export interface CheckoutUpdateStateStore {
   shouldRegisterUser: boolean;
   submitInProgress: boolean;
   loadingCheckout: boolean;


### PR DESCRIPTION
Fixes: 
- saleor auth client falling in loop when refresh token is expired
- "billing address not set" error being thrown within payment in some cases
- summary closing unexpectedly after opening on mobile view
- remove some leftover console.logs

Also added a skeleton for delivery methods. Currently when logged in user has no shipping address set but the auto selection is in progress, the section says "please fill in the shipping address first" - while that makes sense for the guest user, for signed in one it's already happening so it makes more sense to replace the bit with skeleton that'll actually indicate loading to user instead of requirement for action.