### PR TITLE
Fix env file - missing `NEXT_PUBLIC_SALEOR_API_URL`

### DIFF
--- a/apps/saleor-app-checkout/.env
+++ b/apps/saleor-app-checkout/.env
@@ -1,6 +1,9 @@
 # Default values for tests
 # They will work only when replaying requests with Polly.js
 # To record new requests, use real credentials in .env.local
+NEXT_PUBLIC_SALEOR_API_URL=$SALEOR_API_URL
+NEXT_PUBLIC_CHECKOUT_APP_URL=$CHECKOUT_APP_URL
+
 TEST_MOLLIE_KEY=mollie_test_key
 TEST_MOLLIE_PROFILE_ID=mollie_profile_id
 


### PR DESCRIPTION
It adds back missing env in `saleor-app-checkout` that's used in https://github.com/saleor/react-storefront/blob/canary/apps/saleor-app-checkout/frontend/misc/client.ts
