### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in react-storefront please disclose it via [our huntr page](https://huntr.dev/repos/saleor/react-storefront/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of react-storefront.


### PR DESCRIPTION
As requested through the platform by @nyankiyoshi, this will point your security policy to [huntr.dev](https://huntr.dev/repos/saleor/react-storefront})