### PR TITLE
fix: duplicated key in country area Select

### DIFF
--- a/packages/ui-kit/src/components/Select/Select.tsx
+++ b/packages/ui-kit/src/components/Select/Select.tsx
@@ -54,8 +54,8 @@ const SelectComponent = <TData extends string = string>(
             {placeholder}
           </option>
         )}
-        {options.map(({ label, value, disabled = false }, index) => (
-          <option value={value} disabled={disabled} key={index}>
+        {options.map(({ label, value, disabled = false }) => (
+          <option value={value} disabled={disabled} key={label + "_" + value}>
             {label}
           </option>
         ))}

--- a/packages/ui-kit/src/components/Select/Select.tsx
+++ b/packages/ui-kit/src/components/Select/Select.tsx
@@ -54,8 +54,8 @@ const SelectComponent = <TData extends string = string>(
             {placeholder}
           </option>
         )}
-        {options.map(({ label, value, disabled = false }) => (
-          <option value={value} disabled={disabled} key={value}>
+        {options.map(({ label, value, disabled = false }, index) => (
+          <option value={value} disabled={disabled} key={index}>
             {label}
           </option>
         ))}


### PR DESCRIPTION
We shouldn't assume `value` as key in the `Select` component, an example is the Japan area.

The GraphQL query:

```graphql
{
  addressValidationRules(countryCode: JP) {
    countryAreaChoices {
      raw
      verbose
    }
  }
}
```

The response:

```
{
  "data": {
    "addressValidationRules": {
      "countryAreaChoices": [
        {
          "raw": "北海道",
          "verbose": "Hokkaido"
        },
        {
          "raw": "北海道",
          "verbose": "北海道"
        },
...
```

The `raw` value is not unique so that it can't be used as the key.

In almost all cases, the options list are always fully updated, so I guess the fix will not introduce real performance issue.