### PR TITLE
Remove e2e schedule

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,9 +13,6 @@ on:
           - https://demo.saleor.io/
           - https://react-storefront-e2e.vercel.app/
 
-  schedule:
-    - cron: "00 2 * * 1-5"
-
   repository_dispatch:
     types: [automation-tests-event]
 


### PR DESCRIPTION
I want to merge this change as we want to decrease Cypress test runs. 